### PR TITLE
docs(env): add env docs + canonical .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Minimal .env.example for SmartSell (safe for dev/CI, do not use in production)
+ENVIRONMENT=local
+TESTING=False
+SECRET_KEY=dev-secret-key
+DATABASE_URL=postgresql+psycopg://postgres:postgres@127.0.0.1:5432/smartsell
+TEST_DATABASE_URL=postgresql+psycopg://postgres:postgres@127.0.0.1:5432/smartsell_test
+TEST_ASYNC_DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/smartsell_test
+REDIS_URL=redis://127.0.0.1:6379
+CORS_ORIGINS=http://localhost:3000
+RATE_LIMIT_ENABLED=1
+RATE_LIMIT_PER_MINUTE=100
+
+# --- Optional external providers (set real values only in .env.local or CI secrets) ---
+MOBIZON_API_URL=https://api.mobizon.kz
+MOBIZON_API_KEY=your-mobizon-api-key
+TIPTOP_API_URL=https://api.tippy.kz
+TIPTOP_API_KEY=your-tiptop-api-key
+TIPTOP_API_SECRET=your-tiptop-api-secret
+TIPTOP_PAY_PUBLIC_KEY=your-tiptop-pay-public-key
+TIPTOP_PAY_SECRET_KEY=your-tiptop-pay-secret-key
+KASPI_API_URL=https://api.kaspi.kz
+KASPI_API_KEY=your-kaspi-api-key
+KASPI_MERCHANT_ID=your-kaspi-merchant-id
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=your-email@gmail.com
+CLOUDINARY_URL=cloudinary://your-api-key:your-api-secret@your-cloud-name

--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -72,7 +72,7 @@
 - Added: provider listing endpoint with filters + pagination (service layer + admin API).
 - Added: events listing endpoint with filters (domain/provider/actor) + pagination; ordered results.
 - Tests: extended tests/test_admin_integrations.py for listing + events filtering; pytest green (warnings only).
-- Notes: existing warnings remain (Pydantic v1 @validator deprecations, SQLAlchemy Query.get legacy, Trio deprecations).
+- Notes: существующие предупреждения остаются (Pydantic v1 @validator deprecations, SQLAlchemy Query.get legacy, Trio deprecations).
 
 ## [2025-12-26] OTP / Integrations
 - added: runtime OTP provider resolution (OtpProviderResolver) with caching and safe fallback when registry/redis unavailable
@@ -90,3 +90,19 @@
 - commits: `feat(db): provider config storage`; `feat(integrations): provider config management and healthcheck`
 - added: `integration_provider_configs` table with encrypted payloads + key metadata; service-layer set/get/redaction/healthcheck; admin API endpoints for config read/write/healthcheck with idempotency and events; healthcheck resilient to redis failure; migration test added
 - tests: config redaction/no secret leakage, healthcheck survives redis down, provider switch still works with resolver after config writes; alembic upgrade head smoke test
+
+## [2025-12-31] Docs/env
+
+### Added
+- Документация по переменным окружения: `docs/env.md` (локальный запуск, примеры, безопасность).
+- Пример env-файла: `.env.example` (безопасные значения, все ключевые переменные для dev/CI).
+
+### Changed
+- Полностью переписаны `docs/env.md` и `.env.example`:
+  - Минимальный и безопасный .env.example (только реально используемые переменные, без дублирования и unsafe значений).
+  - Документация по переменным и запуску приведена к актуальному состоянию репозитория.
+  - Все внешние ключи только как OPTIONAL с плейсхолдерами.
+
+### Notes
+- Упрощён старт проекта и настройка окружения для новых разработчиков и CI.
+- Все примеры безопасны для публикации, реальные секреты не коммитятся.

--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -3,6 +3,22 @@
 - CD gated to main with Docker push/login only when secrets exist; build still runs without secrets
 - security workflow skips Code Scanning when disabled and guards uploads; release CI/CD merges finalized for v0.1.0
 
+## [2025-12-31] CI/CD
+
+### Added
+- Новый job `alembic-smoke` в CI: быстрый smoke-тест миграций (`alembic upgrade head`, `alembic current`, `alembic heads`) на чистой Postgres 15 (GitHub Actions).
+- Добавлен `.gitattributes` с правилами: `*.yml text eol=lf`, `*.yaml text eol=lf` (устранение CRLF-churn на Windows).
+
+### Changed
+- CD workflow (`cd.yml`):
+  - Убраны все job-level if/выражения с `secrets.*` (валидно для GitHub Actions).
+  - Секреты DockerHub теперь пробрасываются через job-level env.
+  - Docker login и push выполняются только если оба секрета заданы; если нет — выполняется build-only (без push), чтобы CD не падал.
+
+### Notes
+- CI теперь гарантирует применимость всех миграций на чистую базу Postgres (smoke-проверка alembic).
+- CD больше не ломается при отсутствии DockerHub secrets: всегда выполняется build, push — только если секреты заданы.
+
 ## [2025-12-31] Deps
 - ensure passlib ships with argon2 backend in CI (add argon2-cffi and passlib[argon2])
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,0 +1,71 @@
+# SmartSell: Окружение и переменные
+
+## Быстрый старт (Windows/WSL)
+
+1. Клонируйте репозиторий и перейдите в папку проекта.
+2. Скопируйте `.env.example` → `.env.local` и заполните своими значениями (секреты не коммитить!).
+3. Установите зависимости:
+   ```powershell
+   pip install -r requirements.txt
+   ```
+4. Запустите Postgres и Redis (например, через Docker):
+   ```powershell
+   docker run --rm -e POSTGRES_PASSWORD=postgres -e POSTGRES_USER=postgres -e POSTGRES_DB=smartsell -p 5432:5432 postgres:15
+   docker run --rm -p 6379:6379 redis:7-alpine
+   ```
+5. Примените миграции:
+   ```powershell
+   alembic upgrade head
+   ```
+6. Запустите тесты:
+   ```powershell
+   pytest -q
+   ```
+7. Запустите приложение:
+   ```powershell
+   uvicorn app.main:app --reload
+   ```
+
+## Обязательные переменные окружения
+
+| Переменная                | Пример значения                                                    |
+|---------------------------|--------------------------------------------------------------------|
+| ENVIRONMENT               | local / development / production / testing                         |
+| TESTING                   | True / False                                                       |
+| DEBUG                     | True / False                                                       |
+| SECRET_KEY                | dev-secret-key (замените в production)                             |
+| DATABASE_URL              | postgresql+psycopg://postgres:postgres@127.0.0.1:5432/smartsell     |
+| TEST_DATABASE_URL         | postgresql+psycopg://postgres:postgres@127.0.0.1:5432/smartsell_test|
+| TEST_ASYNC_DATABASE_URL   | postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/smartsell_test|
+| REDIS_URL                 | redis://127.0.0.1:6379                                             |
+| CORS_ORIGINS              | http://localhost:3000                                              |
+
+## Опциональные переменные (пример)
+
+| Переменная         | Назначение / Пример значения                |
+|--------------------|---------------------------------------------|
+| MOBIZON_API_URL    | https://api.mobizon.kz                      |
+| MOBIZON_API_KEY    | your-mobizon-api-key                        |
+| TIPTOP_API_URL     | https://api.tippy.kz                        |
+| TIPTOP_API_KEY     | your-tiptop-api-key                         |
+| KASPI_API_URL      | https://api.kaspi.kz                        |
+| KASPI_API_KEY      | your-kaspi-api-key                          |
+| KASPI_MERCHANT_ID  | your-kaspi-merchant-id                      |
+| SMTP_HOST          | smtp.gmail.com                              |
+| SMTP_PORT          | 587                                         |
+| SMTP_USER          | your-email@gmail.com                        |
+
+> **Используйте только те переменные, которые реально требуются вашему окружению и коду.**
+
+## Проверка чтения переменных
+- Для диагностики можно временно добавить в main.py:
+  ```python
+  import os; print('ENV:', {k: os.environ.get(k) for k in ['ENVIRONMENT','DATABASE_URL','REDIS_URL']})
+  ```
+- Для тестов и CI все переменные задаются через `.env.local` или secrets.
+
+## Безопасность
+- **Никогда не коммитьте реальные секреты или .env.local!**
+- Для CI/CD используйте secrets в настройках GitHub Actions.
+- `.env.example` содержит только безопасные плейсхолдеры.
+- Для production — используйте отдельные секреты и переменные окружения.


### PR DESCRIPTION
Adds docs/env.md and canonical .env.example (safe placeholders). Normalizes docs/env.md to LF to avoid CRLF churn on Windows.