### PR TITLE
test: interrupt-safe teardown + dispose engines before downgrade

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -318,3 +318,25 @@ Commits (per git show):
 - `app/storage/payments_sql.py`
 - `tests/app/api/test_no_sync_db_calls.py`
 - `tests/conftest.py`
+## [2026-01-04] Tests teardown: interrupt-safe + engine dispose first
+
+### changed
+- Усилен teardown тестов: добавлен session-level guard на KeyboardInterrupt и общий disposer, чтобы sync/async engines закрывались первыми.
+- При `PYTEST_KEEP_DB`/`KEEP_DB` и при прерывании тестов teardown пропускает alembic downgrade/drop и не роняет сессию; обычный прогон — best-effort cleanup.
+
+### fixed
+- Убраны нестабильные падения в конце прогона при `Ctrl+C`/долгом downgrade на Windows event loop.
+
+### lint
+- Приведён в порядок импорт-блок в миграциях:
+  - `migrations/versions/20251228_subs_deleted_at.py`
+  - `migrations/versions/20260102_wallet_and_payments.py`
+
+### tests
+- `python -m ruff check .`
+- `python -m pytest -q` → **163 passed, 5 skipped**
+
+### files
+- `tests/conftest.py`
+- `migrations/versions/20251228_subs_deleted_at.py`
+- `migrations/versions/20260102_wallet_and_payments.py`

--- a/migrations/versions/20251228_subs_deleted_at.py
+++ b/migrations/versions/20251228_subs_deleted_at.py
@@ -6,8 +6,8 @@ Create Date: 2025-12-28
 """
 from __future__ import annotations
 
+import sqlalchemy as sa  # noqa: F401 — kept for alembic context / consistency
 from alembic import op
-import sqlalchemy as sa  # kept for alembic context / consistency
 
 # revision identifiers, used by Alembic.
 revision = "20251228_subs_deleted_at"
@@ -18,7 +18,9 @@ depends_on = None
 
 def upgrade() -> None:
     # Offline-safe: no inspect; additive DDL with IF NOT EXISTS
-    op.execute('ALTER TABLE IF EXISTS "subscriptions" ADD COLUMN IF NOT EXISTS "deleted_at" TIMESTAMP WITHOUT TIME ZONE')
+    op.execute(
+        'ALTER TABLE IF EXISTS "subscriptions" ADD COLUMN IF NOT EXISTS "deleted_at" TIMESTAMP WITHOUT TIME ZONE'
+    )
     op.execute('ALTER TABLE IF EXISTS "subscriptions" ADD COLUMN IF NOT EXISTS "ended_at" TIMESTAMP WITH TIME ZONE')
     op.execute('CREATE INDEX IF NOT EXISTS "ix_subscriptions_deleted_at" ON "subscriptions" ("deleted_at")')
 

--- a/migrations/versions/20260102_wallet_and_payments.py
+++ b/migrations/versions/20260102_wallet_and_payments.py
@@ -7,7 +7,6 @@ Create Date: 2026-01-02 13:25:00.000000
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy import inspect
 
 try:
     from migrations.utils.pghelpers import safe_inspect
@@ -49,7 +48,9 @@ def upgrade():
         op.create_table(
             "wallet_ledger",
             sa.Column("id", sa.Integer(), primary_key=True),
-            sa.Column("account_id", sa.Integer(), sa.ForeignKey("wallet_accounts.id", ondelete="CASCADE"), nullable=False),
+            sa.Column(
+                "account_id", sa.Integer(), sa.ForeignKey("wallet_accounts.id", ondelete="CASCADE"), nullable=False
+            ),
             sa.Column("entry_type", sa.String(length=20), nullable=False),
             sa.Column("amount", sa.Numeric(18, _DECIMAL_PLACES), nullable=False),
             sa.Column("currency", sa.String(length=10), nullable=False),
@@ -116,4 +117,3 @@ def downgrade():
             except Exception:
                 pass
         op.drop_table("wallet_accounts")
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ Pytest configuration and fixtures for async database testing.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from typing import Any
@@ -368,6 +369,43 @@ TEST_DATABASE_URL, SYNC_TEST_DATABASE_URL = _ensure_test_urls()
 test_engine: AsyncEngine | None = None
 TestingSessionLocal: async_sessionmaker[AsyncSession] | None = None
 sync_engine: Engine | None = None
+logger = logging.getLogger(__name__)
+_TEST_RUN_INTERRUPTED = False
+
+
+def pytest_keyboard_interrupt(excinfo):
+    """Mark test session as interrupted to skip heavy teardown on Ctrl+C."""
+    global _TEST_RUN_INTERRUPTED
+    _TEST_RUN_INTERRUPTED = True
+
+
+def _dispose_test_engines() -> None:
+    """Best-effort disposal of async/sync engines; never raises."""
+    global test_engine, sync_engine, TestingSessionLocal
+
+    try:
+        if test_engine is not None:
+            try:
+                await_future = test_engine.dispose()
+                if hasattr(await_future, "__await__"):
+                    asyncio.run(await_future)
+            except Exception as e:  # noqa: PERF203 — log for diagnosis
+                logger.warning("Failed to dispose async test engine: %s", e)
+            test_engine = None
+    except Exception as e:  # noqa: PERF203 — log for diagnosis
+        logger.warning("Async engine cleanup error: %s", e)
+
+    try:
+        if sync_engine is not None:
+            try:
+                sync_engine.dispose()
+            except Exception as e:  # noqa: PERF203 — log for diagnosis
+                logger.warning("Failed to dispose sync test engine: %s", e)
+            sync_engine = None
+    except Exception as e:  # noqa: PERF203 — log for diagnosis
+        logger.warning("Sync engine cleanup error: %s", e)
+
+    TestingSessionLocal = None
 
 
 # ======================================================================================
@@ -582,18 +620,7 @@ def test_db() -> Iterator[None]:
         raise RuntimeError(f"Refusing to use non-test async database URL: {async_url}")
 
     # Dispose all existing engines before schema reset (if any were created)
-    if test_engine is not None:
-        try:
-            await_future = test_engine.dispose()
-            if hasattr(await_future, "__await__"):
-                asyncio.run(await_future)
-        except Exception:
-            pass
-    if sync_engine is not None:
-        try:
-            sync_engine.dispose()
-        except Exception:
-            pass
+    _dispose_test_engines()
 
     # Reset public schema to avoid duplicates across runs
     eng = sa.create_engine(sync_url, future=True)
@@ -706,11 +733,30 @@ def test_db() -> Iterator[None]:
     try:
         yield
     finally:
-        try:
-            command.downgrade(cfg, "base")
-        except Exception:
-            # Если даунгрейд не удался, не роняем всю сессию тестов
-            pass
+        # Always release engines/sessions first; teardown must be idempotent
+        _dispose_test_engines()
+
+        keep_db = any(
+            str(os.getenv(key, "")).strip().lower() in {"1", "true", "yes", "on"}
+            for key in ("PYTEST_KEEP_DB", "KEEP_DB")
+        )
+
+        skip_downgrade = False
+        reason = None
+        if keep_db:
+            skip_downgrade = True
+            reason = "KEEP_DB flag is set"
+        elif _TEST_RUN_INTERRUPTED:
+            skip_downgrade = True
+            reason = "test run was interrupted"
+
+        if skip_downgrade:
+            logger.warning("Skipping alembic downgrade: %s", reason)
+        else:
+            try:
+                command.downgrade(cfg, "base")
+            except Exception as e:  # noqa: PERF203 — best-effort cleanup
+                logger.warning("Alebic downgrade failed: %s", e)
 
 
 # ======================================================================================


### PR DESCRIPTION
Fix root cause of flaky teardown on Windows/Ctrl+C: always dispose engines first; skip downgrade when KEEP_DB/PYTEST_KEEP_DB or interrupted. Also ruff import-order fixes in two migrations.