### PR TITLE
security(tenant): enforce company_id from token claims

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -1,3 +1,16 @@
+## [2026-01-04] Tenant company scoping helper + query guardrails
+
+### Added
+- Shared tenant company resolver in pp/core/security.py to enforce company_id from auth claims and centralize platform-admin override rules.
+- Regression tests covering company_id query behavior for wallet/payments (same-tenant allowed, cross-tenant forbidden) in 	ests/app/api/test_wallet_payments_tenant.py.
+
+### Changed
+- Wallet, payments, subscriptions, invoices, kaspi, and analytics endpoints now resolve company scope via the helper and reject mismatched query/body company_id values instead of trusting request parameters.
+
+### Verified
+- uff check app/core/security.py app/api/v1/payments.py app/api/v1/wallet.py app/api/v1/subscriptions.py app/api/v1/invoices.py app/api/v1/kaspi.py app/api/v1/analytics.py tests/app/api/test_wallet_payments_tenant.py
+- pytest tests/app/api/test_wallet_payments_tenant.py -q
+- pytest -q
 ## [2026-01-03] Tenant isolation: billing + wallet/payments; storage alignment
 
 ### Added
@@ -347,3 +360,4 @@ Commits (per git show):
 
 ### notes
 - Локальные проверки: `ruff check` и `pytest -q` — зелёные (167 passed, 5 skipped).
+

--- a/app/api/v1/analytics.py
+++ b/app/api/v1/analytics.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.db import get_async_db
 from app.core.deps import api_rate_limit_dep, ensure_idempotency
 from app.core.errors import bad_request, server_error
-from app.core.security import get_current_user
+from app.core.security import get_current_user, resolve_tenant_company_id
 from app.models import Order, OrderItem, Product, User
 from app.schemas import (
     AnalyticsFilter,
@@ -46,10 +46,7 @@ async def require_analyst(user: User = Depends(_auth_user)) -> User:
 
 
 def _resolve_company_id(current_user: User) -> int:
-    company_id = getattr(current_user, "company_id", None)
-    if company_id is None:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
-    return int(company_id)
+    return resolve_tenant_company_id(current_user)
 
 
 def _parse_dt_or_default(value: str | None, default: datetime) -> datetime:

--- a/app/api/v1/invoices.py
+++ b/app/api/v1/invoices.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_async_db
-from app.core.security import decode_and_validate, is_token_revoked
+from app.core.security import decode_and_validate, is_token_revoked, resolve_tenant_company_id
 from app.models.billing import Invoice
 from app.models.company import Company
 from app.models.user import User
@@ -82,9 +82,7 @@ async def create_invoice(
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):
-    company_id = getattr(user, "company_id", None)
-    if not company_id:
-        raise HTTPException(status_code=403, detail="Company not set")
+    company_id = resolve_tenant_company_id(user, getattr(payload, "company_id", None), not_found_detail="Company not set")
 
     await _ensure_company(db, company_id)
 
@@ -125,12 +123,7 @@ async def list_invoices(
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):
-    current_company = getattr(user, "company_id", None)
-    if company_id is not None and company_id != current_company:
-        raise HTTPException(status_code=403, detail="forbidden")
-    resolved_company = company_id or current_company
-    if not resolved_company:
-        raise HTTPException(status_code=403, detail="Company not set")
+    resolved_company = resolve_tenant_company_id(user, company_id, not_found_detail="Company not set")
 
     stmt = select(Invoice).where(Invoice.company_id == resolved_company)
     stmt = stmt.where(Invoice.deleted_at.is_(None)) if hasattr(Invoice, "deleted_at") else stmt
@@ -157,12 +150,7 @@ async def get_invoice(
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):
-    current_company = getattr(user, "company_id", None)
-    if company_id is not None and company_id != current_company:
-        raise HTTPException(status_code=403, detail="forbidden")
-    resolved_company = company_id or current_company
-    if not resolved_company:
-        raise HTTPException(status_code=403, detail="Company not set")
+    resolved_company = resolve_tenant_company_id(user, company_id, not_found_detail="Company not set")
 
     stmt = select(Invoice).where(Invoice.id == invoice_id, Invoice.company_id == resolved_company)
     stmt = stmt.where(Invoice.deleted_at.is_(None)) if hasattr(Invoice, "deleted_at") else stmt

--- a/app/api/v1/invoices.py
+++ b/app/api/v1/invoices.py
@@ -82,7 +82,9 @@ async def create_invoice(
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):
-    company_id = resolve_tenant_company_id(user, getattr(payload, "company_id", None), not_found_detail="Company not set")
+    company_id = resolve_tenant_company_id(
+        user, getattr(payload, "company_id", None), not_found_detail="Company not set"
+    )
 
     await _ensure_company(db, company_id)
 

--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -36,7 +36,7 @@ from sqlalchemy import bindparam, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_async_db  # noqa — для совместимости импорт-алиас
-from app.core.security import get_current_user
+from app.core.security import get_current_user, resolve_tenant_company_id
 
 # Доменные зависимости/схемы:
 from app.integrations.kaspi_adapter import KaspiAdapter, KaspiAdapterError
@@ -71,12 +71,7 @@ async def _auth_user(current_user: User = Depends(get_current_user)) -> User:
 
 
 def _resolve_company_id(current_user: User, company_id: int | None) -> int:
-    resolved = getattr(current_user, "company_id", None)
-    if company_id is not None and company_id != resolved:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden: cross-tenant access")
-    if resolved is None:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden: cross-tenant access")
-    return resolved
+    return resolve_tenant_company_id(current_user, company_id, not_found_detail="Forbidden: cross-tenant access")
 
 
 # ------------------------------- Локальные схемы -----------------------------

--- a/app/api/v1/payments.py
+++ b/app/api/v1/payments.py
@@ -11,7 +11,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_async_db
-from app.core.security import get_current_user, require_manager
+from app.core.security import (
+    get_current_user,
+    is_platform_admin,
+    require_manager,
+    resolve_tenant_company_id,
+)
 from app.models.user import User
 from app.storage.payments_sql import PaymentsStorageSQL
 from app.storage.wallet_sql import WalletStorageSQL
@@ -58,13 +63,6 @@ def _pick_http_status(exc: Exception) -> int:
     return status.HTTP_400_BAD_REQUEST
 
 
-def _is_platform_admin(user: User | None) -> bool:
-    try:
-        return str(getattr(user, "role", "")).lower() == "platform_admin"
-    except Exception:
-        return False
-
-
 async def _ensure_user_in_company(
     target_user_id: int,
     current_user: User,
@@ -75,7 +73,7 @@ async def _ensure_user_in_company(
     user = await db.get(User, target_user_id)
     if not user:
         raise HTTPException(status_code=404, detail=not_found_detail)
-    if _is_platform_admin(current_user):
+    if is_platform_admin(current_user):
         return user
     if getattr(user, "company_id", None) != getattr(current_user, "company_id", None):
         raise HTTPException(status_code=404, detail=not_found_detail)
@@ -177,6 +175,7 @@ async def create_and_capture(
     db: AsyncSession = Depends(get_async_db),
 ):
     try:
+        resolved_company_id = resolve_tenant_company_id(current_user)
         await _ensure_user_in_company(req.user_id, current_user, db, not_found_detail="user not found")
         acc = await _ensure_account_access(req.wallet_account_id, current_user, db)
         if int(acc.get("user_id", 0)) != req.user_id:
@@ -188,7 +187,7 @@ async def create_and_capture(
             req.amount,
             req.currency,
             req.reference,
-            company_id=getattr(current_user, "company_id", None),
+            company_id=resolved_company_id,
         )
         await db.commit()
         return Payment(**p)
@@ -210,9 +209,10 @@ async def refund(
     db: AsyncSession = Depends(get_async_db),
 ):
     try:
+        resolved_company_id = resolve_tenant_company_id(current_user)
         storage = await _get_payment_storage(db)
         payment = await _ensure_payment_visible(
-            await storage.get(payment_id, company_id=getattr(current_user, "company_id", None)),
+            await storage.get(payment_id, company_id=resolved_company_id),
             current_user,
             db,
         )
@@ -221,7 +221,7 @@ async def refund(
             payment_id,
             req.amount,
             req.reference,
-            company_id=getattr(current_user, "company_id", None),
+            company_id=resolved_company_id,
         )
         await db.commit()
         return Payment(**p)
@@ -243,9 +243,10 @@ async def cancel(
     db: AsyncSession = Depends(get_async_db),
 ):
     try:
+        resolved_company_id = resolve_tenant_company_id(current_user)
         storage = await _get_payment_storage(db)
         payment = await _ensure_payment_visible(
-            await storage.get(payment_id, company_id=getattr(current_user, "company_id", None)),
+            await storage.get(payment_id, company_id=resolved_company_id),
             current_user,
             db,
         )
@@ -253,7 +254,7 @@ async def cancel(
         p = await storage.cancel(
             payment_id,
             req.reason if req else None,
-            company_id=getattr(current_user, "company_id", None),
+            company_id=resolved_company_id,
         )
         await db.commit()
         return Payment(**p)
@@ -271,8 +272,9 @@ async def get_payment(
     db: AsyncSession = Depends(get_async_db),
 ):
     storage = await _get_payment_storage(db)
+    resolved_company_id = resolve_tenant_company_id(current_user)
     p = await _ensure_payment_visible(
-        await storage.get(payment_id, company_id=getattr(current_user, "company_id", None)),
+        await storage.get(payment_id, company_id=resolved_company_id),
         current_user,
         db,
     )
@@ -289,13 +291,12 @@ async def list_payments(
     current_user: User = Depends(_auth_user),
     db: AsyncSession = Depends(get_async_db),
 ):
+    resolved_company_id = resolve_tenant_company_id(current_user, company_id)
     allowed_ids: list[int] | None = None
-    if company_id is not None and company_id != getattr(current_user, "company_id", None):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
     if user_id is not None:
         await _ensure_user_in_company(user_id, current_user, db, not_found_detail="payment not found")
-    if not _is_platform_admin(current_user):
-        stmt = select(User.id).where(User.company_id == getattr(current_user, "company_id", None))
+    if not is_platform_admin(current_user):
+        stmt = select(User.id).where(User.company_id == resolved_company_id)
         result = (await db.execute(stmt)).all()
         allowed_ids = [int(r[0]) for r in result]
         if user_id is not None:
@@ -308,11 +309,11 @@ async def list_payments(
         page,
         size,
         user_ids=allowed_ids,
-        company_id=getattr(current_user, "company_id", None),
+        company_id=resolved_company_id,
     )
     items = [Payment(**i) for i in out["items"]]
-    if not _is_platform_admin(current_user):
-        current_company = getattr(current_user, "company_id", None)
+    if not is_platform_admin(current_user):
+        current_company = resolved_company_id
         filtered: list[Payment] = []
         if current_company is not None:
             for p in items:

--- a/app/api/v1/subscriptions.py
+++ b/app/api/v1/subscriptions.py
@@ -15,7 +15,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 # --- проектные зависимости (пути проверьте по вашему проекту) ---
 from app.core.db import get_async_db
-from app.core.security import decode_and_validate, is_token_revoked
+from app.core.security import (
+    decode_and_validate,
+    is_platform_admin,
+    is_token_revoked,
+    resolve_tenant_company_id,
+)
 from app.models.billing import BillingPayment, Subscription
 from app.models.company import Company
 from app.models.user import User
@@ -118,24 +123,6 @@ def ensure_company_access(user, company: Company) -> None:
     raise HTTPException(status_code=404, detail="Company not found")
 
 
-def _is_platform_admin(user: User | None) -> bool:
-    try:
-        return getattr(user, "role", None) in {"platform_admin", "superadmin"}
-    except Exception:
-        return False
-
-
-def _resolve_company_id(user: User, company_id: int | None, *, not_found_detail: str = "Company not found") -> int:
-    current_company = getattr(user, "company_id", None)
-    if company_id is not None and not _is_platform_admin(user):
-        if current_company != company_id:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
-    resolved = company_id or current_company
-    if resolved is None:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=not_found_detail)
-    return resolved
-
-
 async def _get_subscription_scoped(
     db: AsyncSession,
     user: User,
@@ -144,7 +131,7 @@ async def _get_subscription_scoped(
     allow_deleted: bool = False,
 ) -> Subscription:
     stmt = select(Subscription).where(Subscription.id == subscription_id)
-    if not _is_platform_admin(user):
+    if not is_platform_admin(user):
         stmt = stmt.where(Subscription.company_id == getattr(user, "company_id", None))
     sub = (await db.execute(stmt)).scalar_one_or_none()
     if not sub:
@@ -229,7 +216,12 @@ async def list_subscriptions(
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):
-    resolved_company_id = _resolve_company_id(user, company_id)
+    resolved_company_id = resolve_tenant_company_id(
+        user,
+        company_id,
+        allow_platform_override=True,
+        not_found_detail="Company not found",
+    )
     _company = await ensure_company(db, resolved_company_id)
     ensure_company_access(user, _company)
 
@@ -266,7 +258,12 @@ async def get_current_subscription(
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):
-    resolved_company_id = _resolve_company_id(user, company_id)
+    resolved_company_id = resolve_tenant_company_id(
+        user,
+        company_id,
+        allow_platform_override=True,
+        not_found_detail="Company not found",
+    )
     _company = await ensure_company(db, resolved_company_id)
     ensure_company_access(user, _company)
 
@@ -302,7 +299,12 @@ async def create_subscription(
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):
-    resolved_company_id = _resolve_company_id(user, payload.company_id)
+    resolved_company_id = resolve_tenant_company_id(
+        user,
+        payload.company_id,
+        allow_platform_override=True,
+        not_found_detail="Company not found",
+    )
     _company = await ensure_company(db, resolved_company_id)
     ensure_company_access(user, _company)
 
@@ -465,7 +467,7 @@ async def archive_subscription(
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):
-    if not _is_platform_admin(user):
+    if not is_platform_admin(user):
         raise HTTPException(status_code=403, detail="Admin only")
 
     sub = await _get_subscription_scoped(db, user, subscription_id, allow_deleted=True)
@@ -486,7 +488,7 @@ async def restore_subscription(
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):
-    if not _is_platform_admin(user):
+    if not is_platform_admin(user):
         raise HTTPException(status_code=403, detail="Admin only")
 
     sub = await _get_subscription_scoped(db, user, subscription_id, allow_deleted=True)

--- a/app/api/v1/wallet.py
+++ b/app/api/v1/wallet.py
@@ -12,7 +12,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_async_db
-from app.core.security import get_current_user, require_company_admin, require_manager
+from app.core.security import (
+    get_current_user,
+    is_platform_admin,
+    require_company_admin,
+    require_manager,
+    resolve_tenant_company_id,
+)
 from app.models.user import User
 from app.storage.wallet_sql import WalletStorageSQL
 
@@ -71,13 +77,6 @@ def _safe_bool(v: Any, default: bool = False) -> bool:
         return default
 
 
-def _is_platform_admin(user: User | None) -> bool:
-    try:
-        return str(getattr(user, "role", "")).lower() == "platform_admin"
-    except Exception:
-        return False
-
-
 async def _ensure_user_in_company(
     target_user_id: int,
     current_user: User,
@@ -88,7 +87,7 @@ async def _ensure_user_in_company(
     user = await db.get(User, target_user_id)
     if not user:
         raise HTTPException(status_code=404, detail=not_found_detail)
-    if _is_platform_admin(current_user):
+    if is_platform_admin(current_user):
         return user
     if getattr(user, "company_id", None) != getattr(current_user, "company_id", None):
         raise HTTPException(status_code=404, detail=not_found_detail)
@@ -125,7 +124,7 @@ async def _ensure_account_access(
 async def _filter_accounts_for_user(
     items: list[dict[str, Any]], current_user: User, db: AsyncSession
 ) -> list[dict[str, Any]]:
-    if _is_platform_admin(current_user):
+    if is_platform_admin(current_user):
         return items
     current_company = getattr(current_user, "company_id", None)
     if current_company is None:
@@ -368,15 +367,14 @@ async def list_accounts(
     db: AsyncSession = Depends(get_async_db),
 ) -> WalletAccountsPage:
     try:
-        if company_id is not None and company_id != getattr(current_user, "company_id", None):
-            raise HTTPException(status_code=403, detail="forbidden")
+        resolved_company_id = resolve_tenant_company_id(current_user, company_id)
         ccy = _norm_ccy(currency) if currency else None
         if user_id is not None:
             await _ensure_user_in_company(user_id, current_user, db)
 
         allowed_ids: list[int] | None = None
-        if not _is_platform_admin(current_user):
-            stmt = select(User.id).where(User.company_id == getattr(current_user, "company_id", None))
+        if not is_platform_admin(current_user):
+            stmt = select(User.id).where(User.company_id == resolved_company_id)
             rows = (await db.execute(stmt)).all()
             allowed_ids = [int(r[0]) for r in rows]
             if user_id is not None:
@@ -394,13 +392,13 @@ async def list_accounts(
                 page=page,
                 size=size,
                 user_ids=allowed_ids,
-                company_id=getattr(current_user, "company_id", None),
+                company_id=resolved_company_id,
             )
         else:
             rows = await storage.list_accounts(
                 user_id=user_id,
                 user_ids=allowed_ids,
-                company_id=getattr(current_user, "company_id", None),
+                company_id=resolved_company_id,
             )
             items = rows["items"] if isinstance(rows, dict) and "items" in rows else rows
             if not isinstance(items, list):
@@ -612,7 +610,7 @@ async def transfer(
     try:
         src_acc = await _ensure_account_access(req.source_account_id, current_user, db)
         dst_acc = await _ensure_account_access(req.destination_account_id, current_user, db)
-        if not _is_platform_admin(current_user):
+        if not is_platform_admin(current_user):
             src_company = getattr(
                 await _ensure_user_in_company(int(src_acc.get("user_id", 0)), current_user, db), "company_id", None
             )

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -861,6 +861,48 @@ if _HAS_FASTAPI:
         except Exception:
             return ""
 
+    def is_platform_admin(user: User | None) -> bool:
+        try:
+            return str(getattr(user, "role", "") or "").lower() == "platform_admin"
+        except Exception:
+            return False
+
+    def resolve_tenant_company_id(
+        current_user: User,
+        requested_company_id: int | None = None,
+        *,
+        allow_platform_override: bool = False,
+        not_found_detail: str = "forbidden",
+    ) -> int:
+        """Resolve company scope from token claims and enforce tenant isolation.
+
+        - For tenant users, a provided company_id must match the token/user company_id;
+          otherwise a 403 is raised.
+        - If allow_platform_override is True and the caller is platform_admin, we honor
+          the requested company_id for cross-tenant operations.
+        - Falls back to the token claim first, then the user record.
+        """
+
+        token_claims = getattr(current_user, "_token_claims", {}) or {}
+        token_company = token_claims.get("company_id")
+        user_company = getattr(current_user, "company_id", None)
+        resolved = token_company if token_company is not None else user_company
+
+        if requested_company_id is not None:
+            if resolved is not None and requested_company_id != resolved and not (
+                allow_platform_override and is_platform_admin(current_user)
+            ):
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
+            if allow_platform_override and is_platform_admin(current_user):
+                resolved = requested_company_id
+            elif resolved is None:
+                resolved = requested_company_id
+
+        if resolved is None:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=not_found_detail)
+
+        return int(resolved)
+
     def _enforce_roles(user: User, allowed: set[str]) -> User:
         role = _user_role(user)
         if role == "platform_admin":

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -889,8 +889,10 @@ if _HAS_FASTAPI:
         resolved = token_company if token_company is not None else user_company
 
         if requested_company_id is not None:
-            if resolved is not None and requested_company_id != resolved and not (
-                allow_platform_override and is_platform_admin(current_user)
+            if (
+                resolved is not None
+                and requested_company_id != resolved
+                and not (allow_platform_override and is_platform_admin(current_user))
             ):
                 raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
             if allow_platform_override and is_platform_admin(current_user):

--- a/tests/app/api/test_wallet_payments_tenant.py
+++ b/tests/app/api/test_wallet_payments_tenant.py
@@ -303,9 +303,7 @@ async def test_wallet_list_company_param_same_company_ok(client, db_session, com
     assert created.status_code == 201, created.text
     account_id = created.json()["id"]
 
-    resp = await client.get(
-        f"/api/v1/wallet/accounts?company_id={company_a_id}", headers=company_a_admin_headers
-    )
+    resp = await client.get(f"/api/v1/wallet/accounts?company_id={company_a_id}", headers=company_a_admin_headers)
     assert resp.status_code == 200, resp.text
     items = resp.json().get("items") or resp.json().get("data") or []
     assert any(it.get("id") == account_id for it in items)

--- a/tests/app/api/test_wallet_payments_tenant.py
+++ b/tests/app/api/test_wallet_payments_tenant.py
@@ -247,6 +247,39 @@ async def test_payments_list_company_param_forbidden(
 
 
 @pytest.mark.anyio
+async def test_payments_list_company_param_same_company_ok(client, db_session, company_a_admin_headers):
+    user_a = _get_user_by_phone(db_session, "+70000010001")
+    company_a_id = user_a.company_id
+
+    acc = await client.post(
+        "/api/v1/wallet/accounts",
+        json={"user_id": user_a.id, "currency": "KZT"},
+        headers=company_a_admin_headers,
+    )
+    assert acc.status_code == 201, acc.text
+    account_id = acc.json()["id"]
+
+    pay = await client.post(
+        "/api/v1/payments/",
+        json={
+            "user_id": user_a.id,
+            "wallet_account_id": account_id,
+            "amount": "5.00",
+            "currency": "KZT",
+            "reference": "same-company",
+        },
+        headers=company_a_admin_headers,
+    )
+    assert pay.status_code == 201, pay.text
+    payment_id = pay.json()["id"]
+
+    resp = await client.get(f"/api/v1/payments/?company_id={company_a_id}", headers=company_a_admin_headers)
+    assert resp.status_code == 200, resp.text
+    items = resp.json().get("items") or resp.json().get("data") or []
+    assert any(it.get("id") == payment_id for it in items)
+
+
+@pytest.mark.anyio
 async def test_wallet_list_company_param_forbidden(
     client, db_session, company_a_admin_headers, company_b_admin_headers
 ):
@@ -255,3 +288,24 @@ async def test_wallet_list_company_param_forbidden(
 
     resp = await client.get(f"/api/v1/wallet/accounts?company_id={company_a_id}", headers=company_b_admin_headers)
     assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_wallet_list_company_param_same_company_ok(client, db_session, company_a_admin_headers):
+    user_a = _get_user_by_phone(db_session, "+70000010001")
+    company_a_id = user_a.company_id
+
+    created = await client.post(
+        "/api/v1/wallet/accounts",
+        json={"user_id": user_a.id, "currency": "KZT"},
+        headers=company_a_admin_headers,
+    )
+    assert created.status_code == 201, created.text
+    account_id = created.json()["id"]
+
+    resp = await client.get(
+        f"/api/v1/wallet/accounts?company_id={company_a_id}", headers=company_a_admin_headers
+    )
+    assert resp.status_code == 200, resp.text
+    items = resp.json().get("items") or resp.json().get("data") or []
+    assert any(it.get("id") == account_id for it in items)


### PR DESCRIPTION
Centralizes company scope resolution via resolve_tenant_company_id; rejects mismatched company_id in query/body; updates wallet/payments regression tests; journal updated.