### PR TITLE
security(tenant): remove platform override for company_id scoping

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -1,3 +1,16 @@
+## [2026-01-04] Tenant scoping: remove platform override for company_id
+
+### Added
+- Regression tests to block platform_admin from scoping wallet accounts and payments lists via foreign company_id while keeping tenant admins allowed.
+
+### Changed
+- Subscriptions list/current/create endpoints now ignore platform overrides and enforce company_id consistency with token scope.
+
+### Verified
+- python -m ruff format app tests tools
+- python -m ruff check app tests tools
+- pytest -q
+
 ## [2026-01-04] Tenant company scoping helper + query guardrails
 
 ### Added
@@ -8,7 +21,8 @@
 - Wallet, payments, subscriptions, invoices, kaspi, and analytics endpoints now resolve company scope via the helper and reject mismatched query/body company_id values instead of trusting request parameters.
 
 ### Verified
-- uff check app/core/security.py app/api/v1/payments.py app/api/v1/wallet.py app/api/v1/subscriptions.py app/api/v1/invoices.py app/api/v1/kaspi.py app/api/v1/analytics.py tests/app/api/test_wallet_payments_tenant.py
+- 
+uff check app/core/security.py app/api/v1/payments.py app/api/v1/wallet.py app/api/v1/subscriptions.py app/api/v1/invoices.py app/api/v1/kaspi.py app/api/v1/analytics.py tests/app/api/test_wallet_payments_tenant.py
 - pytest tests/app/api/test_wallet_payments_tenant.py -q
 - pytest -q
 ## [2026-01-03] Tenant isolation: billing + wallet/payments; storage alignment

--- a/app/api/v1/subscriptions.py
+++ b/app/api/v1/subscriptions.py
@@ -219,9 +219,10 @@ async def list_subscriptions(
     resolved_company_id = resolve_tenant_company_id(
         user,
         company_id,
-        allow_platform_override=True,
         not_found_detail="Company not found",
     )
+    if company_id is not None and company_id != resolved_company_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
     _company = await ensure_company(db, resolved_company_id)
     ensure_company_access(user, _company)
 
@@ -261,9 +262,10 @@ async def get_current_subscription(
     resolved_company_id = resolve_tenant_company_id(
         user,
         company_id,
-        allow_platform_override=True,
         not_found_detail="Company not found",
     )
+    if company_id is not None and company_id != resolved_company_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
     _company = await ensure_company(db, resolved_company_id)
     ensure_company_access(user, _company)
 
@@ -302,9 +304,10 @@ async def create_subscription(
     resolved_company_id = resolve_tenant_company_id(
         user,
         payload.company_id,
-        allow_platform_override=True,
         not_found_detail="Company not found",
     )
+    if payload.company_id != resolved_company_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
     _company = await ensure_company(db, resolved_company_id)
     ensure_company_access(user, _company)
 

--- a/tests/app/api/test_subscriptions_api.py
+++ b/tests/app/api/test_subscriptions_api.py
@@ -4,109 +4,111 @@ BASE = "/api/v1/subscriptions"
 
 
 @pytest.mark.anyio
-async def test_create_subscription_trial_ok(client, auth_headers):
+async def test_create_subscription_trial_ok(client, company_a_admin_headers):
     r = await client.post(
         BASE,
         json={
-            "company_id": 1,
+            "company_id": 1001,
             "plan": "Pro",
             "billing_cycle": "monthly",
             "price": "24900.00",
             "currency": "KZT",
             "trial_days": 7,
         },
-        headers=auth_headers,
+        headers=company_a_admin_headers,
     )
     assert r.status_code == 201, r.text
     data = r.json()
-    assert data["company_id"] == 1
+    assert data["company_id"] == 1001
     assert data["plan"] == "Pro"
     assert data["status"] in ("trial", "active")
     assert data["next_billing_date"]
 
 
 @pytest.mark.anyio
-async def test_forbid_second_active_subscription(client, auth_headers):
+async def test_forbid_second_active_subscription(client, company_a_admin_headers):
     # первая активная
     r1 = await client.post(
         BASE,
         json={
-            "company_id": 2,
+            "company_id": 1001,
             "plan": "Start",
             "billing_cycle": "monthly",
             "price": "1000.00",
             "currency": "KZT",
             "trial_days": 0,
         },
-        headers=auth_headers,
+        headers=company_a_admin_headers,
     )
     assert r1.status_code == 201, r1.text
     # вторая активная → 409
     r2 = await client.post(
         BASE,
         json={
-            "company_id": 2,
+            "company_id": 1001,
             "plan": "Pro",
             "billing_cycle": "monthly",
             "price": "2000.00",
             "currency": "KZT",
             "trial_days": 0,
         },
-        headers=auth_headers,
+        headers=company_a_admin_headers,
     )
     assert r2.status_code == 409
 
 
 @pytest.mark.anyio
-async def test_update_cancel_resume_renew_flow(client, auth_headers):
+async def test_update_cancel_resume_renew_flow(client, company_a_admin_headers):
     r = await client.post(
         BASE,
         json={
-            "company_id": 3,
+            "company_id": 1001,
             "plan": "Start",
             "billing_cycle": "yearly",
             "price": "12000.00",
             "currency": "KZT",
             "trial_days": 0,
         },
-        headers=auth_headers,
+        headers=company_a_admin_headers,
     )
     sub = r.json()
     sid = sub["id"]
 
-    upd = await client.patch(f"{BASE}/{sid}", json={"plan": "Business", "price": "33900.00"}, headers=auth_headers)
+    upd = await client.patch(
+        f"{BASE}/{sid}", json={"plan": "Business", "price": "33900.00"}, headers=company_a_admin_headers
+    )
     assert upd.status_code == 200 and upd.json()["plan"] == "Business"
 
-    c1 = await client.post(f"{BASE}/{sid}/cancel", headers=auth_headers)
+    c1 = await client.post(f"{BASE}/{sid}/cancel", headers=company_a_admin_headers)
     assert c1.status_code == 200
-    c2 = await client.post(f"{BASE}/{sid}/cancel", headers=auth_headers)  # идемпотентность
+    c2 = await client.post(f"{BASE}/{sid}/cancel", headers=company_a_admin_headers)  # идемпотентность
     assert c2.status_code == 200
 
-    rs = await client.post(f"{BASE}/{sid}/resume", headers=auth_headers)
+    rs = await client.post(f"{BASE}/{sid}/resume", headers=company_a_admin_headers)
     assert rs.status_code == 200 and rs.json()["status"] == "active"
 
     before = rs.json()["next_billing_date"]
-    rn = await client.post(f"{BASE}/{sid}/renew", headers=auth_headers)
+    rn = await client.post(f"{BASE}/{sid}/renew", headers=company_a_admin_headers)
     assert rn.status_code == 200 and rn.json()["next_billing_date"] != before
 
 
 @pytest.mark.anyio
-async def test_current_and_filters(client, auth_headers):
+async def test_current_and_filters(client, company_a_admin_headers):
     await client.post(
         BASE,
         json={
-            "company_id": 4,
+            "company_id": 1001,
             "plan": "Pro",
             "billing_cycle": "monthly",
             "price": "5000.00",
             "currency": "KZT",
             "trial_days": 0,
         },
-        headers=auth_headers,
+        headers=company_a_admin_headers,
     )
 
-    cur = await client.get(f"{BASE}/current", params={"company_id": 4}, headers=auth_headers)
+    cur = await client.get(f"{BASE}/current", params={"company_id": 1001}, headers=company_a_admin_headers)
     assert cur.status_code == 200 and cur.json() is not None
 
-    lst = await client.get(BASE, params={"company_id": 4, "plan": "Pro"}, headers=auth_headers)
+    lst = await client.get(BASE, params={"company_id": 1001, "plan": "Pro"}, headers=company_a_admin_headers)
     assert lst.status_code == 200 and isinstance(lst.json(), list)

--- a/tests/app/api/test_wallet_payments_tenant.py
+++ b/tests/app/api/test_wallet_payments_tenant.py
@@ -280,6 +280,44 @@ async def test_payments_list_company_param_same_company_ok(client, db_session, c
 
 
 @pytest.mark.anyio
+async def test_payments_list_company_param_platform_admin_forbidden(
+    client, db_session, company_a_admin_headers, auth_headers
+):
+    user_a = _get_user_by_phone(db_session, "+70000010001")
+    company_a_id = user_a.company_id
+
+    acc = await client.post(
+        "/api/v1/wallet/accounts",
+        json={"user_id": user_a.id, "currency": "KZT"},
+        headers=company_a_admin_headers,
+    )
+    assert acc.status_code == 201, acc.text
+    account_id = acc.json()["id"]
+
+    pay = await client.post(
+        "/api/v1/payments/",
+        json={
+            "user_id": user_a.id,
+            "wallet_account_id": account_id,
+            "amount": "5.00",
+            "currency": "KZT",
+            "reference": "platform-forbidden",
+        },
+        headers=company_a_admin_headers,
+    )
+    assert pay.status_code == 201, pay.text
+    payment_id = pay.json()["id"]
+
+    allowed = await client.get(f"/api/v1/payments/?company_id={company_a_id}", headers=company_a_admin_headers)
+    assert allowed.status_code == 200, allowed.text
+    allowed_items = allowed.json().get("items") or allowed.json().get("data") or []
+    assert any(it.get("id") == payment_id for it in allowed_items)
+
+    forbidden = await client.get(f"/api/v1/payments/?company_id={company_a_id}", headers=auth_headers)
+    assert forbidden.status_code == 403
+
+
+@pytest.mark.anyio
 async def test_wallet_list_company_param_forbidden(
     client, db_session, company_a_admin_headers, company_b_admin_headers
 ):
@@ -307,3 +345,27 @@ async def test_wallet_list_company_param_same_company_ok(client, db_session, com
     assert resp.status_code == 200, resp.text
     items = resp.json().get("items") or resp.json().get("data") or []
     assert any(it.get("id") == account_id for it in items)
+
+
+@pytest.mark.anyio
+async def test_wallet_list_company_param_platform_admin_forbidden(
+    client, db_session, company_a_admin_headers, auth_headers
+):
+    user_a = _get_user_by_phone(db_session, "+70000010001")
+    company_a_id = user_a.company_id
+
+    created = await client.post(
+        "/api/v1/wallet/accounts",
+        json={"user_id": user_a.id, "currency": "KZT"},
+        headers=company_a_admin_headers,
+    )
+    assert created.status_code == 201, created.text
+    account_id = created.json()["id"]
+
+    allowed = await client.get(f"/api/v1/wallet/accounts?company_id={company_a_id}", headers=company_a_admin_headers)
+    assert allowed.status_code == 200, allowed.text
+    allowed_items = allowed.json().get("items") or allowed.json().get("data") or []
+    assert any(it.get("id") == account_id for it in allowed_items)
+
+    forbidden = await client.get(f"/api/v1/wallet/accounts?company_id={company_a_id}", headers=auth_headers)
+    assert forbidden.status_code == 403


### PR DESCRIPTION
Tenant scoping is absolute: platform_admin cannot override company_id via request params. Adds regression tests; ruff+pytest green; journal updated.