### PR TITLE
security(tenant): enforce tenant scope across api v1

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -1,3 +1,16 @@
+## [2026-01-04] Enforce tenant scoping across v1
+
+### Added
+- Regression coverage for invoice listing to ensure tenant admins are allowed only for their company and platform admins cannot override company_id.
+
+### Changed
+- Applied resolve_tenant_company_id scoping in analytics and products endpoints to remove implicit platform overrides.
+
+### Verified
+- python -m ruff format app tests tools
+- python -m ruff check app tests tools
+- pytest -q
+
 ## [2026-01-04] Tenant scoping: remove platform override for company_id
 
 ### Added

--- a/app/api/v1/analytics.py
+++ b/app/api/v1/analytics.py
@@ -513,9 +513,7 @@ async def get_sales_data(
     else:  # month
         date_trunc = func.date_trunc("month", Order.created_at)
 
-    resolved_company_id = getattr(current_user, "company_id", None)
-    if resolved_company_id is None:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
+    resolved_company_id = resolve_tenant_company_id(current_user)
 
     res = await db.execute(
         select(

--- a/app/api/v1/products.py
+++ b/app/api/v1/products.py
@@ -30,6 +30,7 @@ from app.core.dependencies import (
 )
 from app.core.exceptions import AuthorizationError, ConflictError, NotFoundError, SmartSellValidationError
 from app.core.logging import audit_logger
+from app.core.security import resolve_tenant_company_id
 from app.models.product import Category, Product
 from app.models.user import User
 from app.schemas.base import PaginatedResponse, SuccessResponse
@@ -186,9 +187,8 @@ def _ensure_role(user: User, allowed: set[str]) -> None:
 
 
 def _filter_company(stmt, user: User):
-    cid = getattr(user, "company_id", None)
-    if cid is not None:
-        stmt = stmt.where(Product.company_id == cid)
+    cid = resolve_tenant_company_id(user)
+    stmt = stmt.where(Product.company_id == cid)
     return stmt
 
 
@@ -255,10 +255,11 @@ async def create_product(
             if not category:
                 raise NotFoundError("Category not found", "CATEGORY_NOT_FOUND")
 
+        resolved_company_id = resolve_tenant_company_id(current_user)
         payload = product_data.model_dump()
         if payload.get("sku"):
             payload["sku"] = payload["sku"].strip().upper()
-        payload["company_id"] = getattr(current_user, "company_id", None)
+        payload["company_id"] = resolved_company_id
         product = Product(**payload)
         db.add(product)
         await db.flush()

--- a/tests/app/api/test_invoices_tenant.py
+++ b/tests/app/api/test_invoices_tenant.py
@@ -1,0 +1,59 @@
+import pytest
+
+from app.models.user import User
+
+
+def _get_user_by_phone(db_session, phone: str) -> User:
+    return db_session.query(User).filter(User.phone == phone).one()
+
+
+@pytest.mark.anyio
+async def test_invoices_list_same_company_allowed(client, db_session, company_a_admin_headers):
+    user_a = _get_user_by_phone(db_session, "+70000010001")
+    company_a_id = user_a.company_id
+
+    created = await client.post(
+        "/api/v1/invoices",
+        json={"amount": "100.00", "currency": "KZT", "status": "draft"},
+        headers=company_a_admin_headers,
+    )
+    assert created.status_code == 201, created.text
+
+    listed = await client.get(f"/api/v1/invoices?company_id={company_a_id}", headers=company_a_admin_headers)
+    assert listed.status_code == 200, listed.text
+    items = listed.json()
+    assert any(inv.get("company_id") == company_a_id for inv in items)
+
+
+@pytest.mark.anyio
+async def test_invoices_list_other_company_forbidden(
+    client, db_session, company_a_admin_headers, company_b_admin_headers
+):
+    user_a = _get_user_by_phone(db_session, "+70000010001")
+    company_a_id = user_a.company_id
+
+    created = await client.post(
+        "/api/v1/invoices",
+        json={"amount": "150.00", "currency": "KZT", "status": "draft"},
+        headers=company_a_admin_headers,
+    )
+    assert created.status_code == 201, created.text
+
+    forbidden = await client.get(f"/api/v1/invoices?company_id={company_a_id}", headers=company_b_admin_headers)
+    assert forbidden.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_invoices_list_platform_admin_forbidden(client, db_session, company_a_admin_headers, auth_headers):
+    user_a = _get_user_by_phone(db_session, "+70000010001")
+    company_a_id = user_a.company_id
+
+    created = await client.post(
+        "/api/v1/invoices",
+        json={"amount": "200.00", "currency": "KZT", "status": "draft"},
+        headers=company_a_admin_headers,
+    )
+    assert created.status_code == 201, created.text
+
+    forbidden = await client.get(f"/api/v1/invoices?company_id={company_a_id}", headers=auth_headers)
+    assert forbidden.status_code == 403


### PR DESCRIPTION
Enforces resolve_tenant_company_id scoping across api v1 (analytics/products + invoice tenant regressions). Adds tests; ruff+pytest green; journal updated.