### PR TITLE
test(guard): forbid company_id request params in api v1

### DIFF
--- a/app/api/v1/invoices.py
+++ b/app/api/v1/invoices.py
@@ -121,7 +121,6 @@ async def create_invoice(
 
 @router.get("", response_model=list[InvoiceOut])
 async def list_invoices(
-    company_id: int | None = Query(None, ge=1),
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):
@@ -148,7 +147,6 @@ async def list_invoices(
 @router.get("/{invoice_id}", response_model=InvoiceOut)
 async def get_invoice(
     invoice_id: int,
-    company_id: int | None = Query(None, ge=1),
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):

--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -71,7 +71,7 @@ async def _auth_user(current_user: User = Depends(get_current_user)) -> User:
 
 
 def _resolve_company_id(current_user: User, company_id: int | None) -> int:
-    return resolve_tenant_company_id(current_user, company_id, not_found_detail="Forbidden: cross-tenant access")
+    return resolve_tenant_company_id(current_user, not_found_detail="Forbidden: cross-tenant access")
 
 
 # ------------------------------- Локальные схемы -----------------------------

--- a/app/api/v1/payments.py
+++ b/app/api/v1/payments.py
@@ -285,13 +285,12 @@ async def get_payment(
 @router.get("/", response_model=PaymentList)
 async def list_payments(
     user_id: int | None = Query(None, ge=1),
-    company_id: int | None = Query(None, ge=1),
     page: int = Query(1, ge=1),
     size: int = Query(20, ge=1, le=200),
     current_user: User = Depends(_auth_user),
     db: AsyncSession = Depends(get_async_db),
 ):
-    resolved_company_id = resolve_tenant_company_id(current_user, company_id)
+    resolved_company_id = resolve_tenant_company_id(current_user)
     allowed_ids: list[int] | None = None
     if user_id is not None:
         await _ensure_user_in_company(user_id, current_user, db, not_found_detail="payment not found")

--- a/app/api/v1/subscriptions.py
+++ b/app/api/v1/subscriptions.py
@@ -207,7 +207,6 @@ async def _auth_user(
 # ====== Эндпоинты ======
 @router.get("", response_model=list[SubscriptionOut])
 async def list_subscriptions(
-    company_id: int | None = Query(None, ge=1),
     status_filter: AllowedStatus | None = Query(None),
     plan: str | None = Query(None, max_length=32),
     from_date: datetime | None = Query(None, description="Фильтр по next_billing_date (>=)"),
@@ -255,7 +254,6 @@ async def list_subscriptions(
 
 @router.get("/current", response_model=SubscriptionOut | None)
 async def get_current_subscription(
-    company_id: int | None = Query(None, ge=1),
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):

--- a/app/api/v1/wallet.py
+++ b/app/api/v1/wallet.py
@@ -360,14 +360,13 @@ async def create_account(
 async def list_accounts(
     user_id: int | None = Query(None, ge=1),
     currency: str | None = Query(None, min_length=3, max_length=10),
-    company_id: int | None = Query(None, ge=1),
     page: int = Query(1, ge=1),
     size: int = Query(50, ge=1, le=200),
     current_user: User = Depends(_auth_user),
     db: AsyncSession = Depends(get_async_db),
 ) -> WalletAccountsPage:
     try:
-        resolved_company_id = resolve_tenant_company_id(current_user, company_id)
+        resolved_company_id = resolve_tenant_company_id(current_user)
         ccy = _norm_ccy(currency) if currency else None
         if user_id is not None:
             await _ensure_user_in_company(user_id, current_user, db)

--- a/tests/test_no_company_id_params_in_api_v1.py
+++ b/tests/test_no_company_id_params_in_api_v1.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def test_no_company_id_params_in_api_v1() -> None:
+    """
+    Guardrail: tenant scope must come from token/user only.
+    API v1 must not accept company_id as Query/Path/Body/Field parameter.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    v1_root = repo_root / "app" / "api" / "v1"
+
+    offenders: list[str] = []
+    # matches: company_id: ... = Query(...), Path(...), Body(...), Field(...)
+    pattern = re.compile(r"(?m)^\s*company_id\s*:\s*[^#\n]+=\s*(Query|Path|Body|Field)\(")
+
+    for p in v1_root.rglob("*.py"):
+        text = p.read_text(encoding="utf-8", errors="replace")
+        if pattern.search(text):
+            offenders.append(str(p.relative_to(repo_root)))
+
+    assert not offenders, "Forbidden company_id params found in: " + ", ".join(offenders)


### PR DESCRIPTION
Guardrail: tenant scope must come from token/user only. Fails if any api/v1 router accepts company_id via Query/Path/Body/Field. Includes auto-removal of company_id Query params where present.