### PR TITLE
fix(kaspi v1): orders sync without body; safe logging

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -402,3 +402,19 @@ Commits (per git show):
 ### notes
 - Локальные проверки: `ruff check` и `pytest -q` — зелёные (167 passed, 5 skipped).
 
+## [2026-01-04] Kaspi v1: orders sync without body + safe logging
+
+### Changed
+- `POST /api/v1/kaspi/orders/sync` no longer requires a request body (endpoint works with token-scoped tenant only).
+- Removed the empty `OrdersSyncIn` model.
+- Hardened error logging to avoid referencing undefined locals and to avoid logging request body; logs now use resolved company id.
+
+### Added
+- `tests/app/api/test_kaspi_endpoints.py`:
+  - `/api/v1/kaspi/orders/sync` accepts empty requests and stays token-scoped.
+  - `/api/v1/kaspi/feed` is token-scoped and ignores any company_id hints.
+
+### Verified
+- python -m ruff format --check app tests tools
+- python -m ruff check app tests tools
+- pytest -q

--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -70,7 +70,7 @@ async def _auth_user(current_user: User = Depends(get_current_user)) -> User:
     return current_user
 
 
-def _resolve_company_id(current_user: User, company_id: int | None) -> int:
+def _resolve_company_id(current_user: User) -> int:
     return resolve_tenant_company_id(current_user, not_found_detail="Forbidden: cross-tenant access")
 
 
@@ -99,10 +99,6 @@ class ConnectStoreOut(BaseModel):
     saved: bool
     message: str | None = None
     adapter_health: Any | None = None
-
-
-class OrdersSyncIn(BaseModel):
-    pass
 
 
 class AvailabilitySyncIn(BaseModel):
@@ -349,10 +345,10 @@ async def kaspi_import_status(req: ImportStatusQuery):
     summary="Синхронизировать последние заказы Kaspi в локальную БД",
 )
 async def kaspi_orders_sync(
-    payload: OrdersSyncIn,
     current_user: User = Depends(_auth_user),
     session: AsyncSession = Depends(get_async_db),
 ):
+    resolved_company_id: int | None = None
     try:
         svc = KaspiService()
         resolved_company_id = _resolve_company_id(current_user)
@@ -361,7 +357,7 @@ async def kaspi_orders_sync(
     except RuntimeError as e:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e))
     except Exception as e:
-        logger.error("Kaspi orders sync failed: payload=%s err=%s", payload.model_dump(), e)
+        logger.error("Kaspi orders sync failed: company_id=%s err=%s", resolved_company_id, e)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 
 
@@ -374,6 +370,7 @@ async def kaspi_generate_feed(
     current_user: User = Depends(_auth_user),
     session: AsyncSession = Depends(get_async_db),
 ):
+    resolved_company_id: int | None = None
     try:
         resolved_company_id = _resolve_company_id(current_user)
         svc = KaspiService()

--- a/tests/app/api/test_kaspi_endpoints.py
+++ b/tests/app/api/test_kaspi_endpoints.py
@@ -1,0 +1,52 @@
+import pytest
+
+from app.api.v1 import kaspi as kaspi_module
+
+
+@pytest.mark.anyio
+async def test_kaspi_orders_sync_allows_empty_body(monkeypatch, async_client, company_a_admin_headers):
+    called = {"count": 0, "company_id": None}
+
+    class _FakeKaspiService:
+        async def sync_orders(self, company_id: int, db):  # noqa: ANN001
+            called["count"] += 1
+            called["company_id"] = company_id
+            return {"synced_for": company_id}
+
+    monkeypatch.setattr(kaspi_module, "KaspiService", _FakeKaspiService)
+
+    resp = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["synced_for"] == 1001
+
+    resp_empty = await async_client.post(
+        "/api/v1/kaspi/orders/sync",
+        headers=company_a_admin_headers,
+        json={},
+    )
+    assert resp_empty.status_code == 200, resp_empty.text
+    assert resp_empty.json()["synced_for"] == 1001
+
+    assert called["count"] == 2
+    assert called["company_id"] == 1001
+
+
+@pytest.mark.anyio
+async def test_kaspi_feed_ignores_company_param(monkeypatch, async_client, company_a_admin_headers):
+    captured = {"company_id": None}
+
+    class _FakeKaspiService:
+        async def generate_product_feed(self, company_id: int, db):  # noqa: ANN001
+            captured["company_id"] = company_id
+            return "<feed/>"
+
+    monkeypatch.setattr(kaspi_module, "KaspiService", _FakeKaspiService)
+
+    resp = await async_client.get(
+        "/api/v1/kaspi/feed",
+        headers=company_a_admin_headers,
+        params={"company_id": 999},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.text == "<feed/>"
+    assert captured["company_id"] == 1001


### PR DESCRIPTION
Kaspi v1: /orders/sync no longer requires request body (token-scoped only). Removed empty OrdersSyncIn. Safe logging (no body, no undefined locals). Added tests (test_kaspi_endpoints.py). Ruff+pytest green.