### PR TITLE
feat(kaspi): incremental idempotent orders sync (watermark + lock + upsert)

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -458,3 +458,9 @@ Commits (per git show):
 - added: password injection when missing (DB_PASSWORD -> PGPASSWORD -> borrow from DATABASE_URL/DB_URL), without logging secrets
 - updated: async engine init now uses async resolver and logs safe debug-only diagnostics
 - tests: test_db_async_url_resolution.py + kept pgpass/password fallback coverage
+## [2026-01-06] Kaspi: orders sync MVP (incremental + idempotent)
+- added: incremental sync using kaspi_order_sync_state watermark with 2-minute overlap for safety
+- added: idempotent upsert for orders via unique (company_id, external_id)
+- added: per-company concurrency guard via pg_try_advisory_xact_lock
+- api: /api/v1/kaspi/orders/sync returns 409 when sync is already running
+- tests: standardized async test marks to pytest.mark.asyncio; conftest cleanup and fixture compatibility

--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -452,3 +452,9 @@ Commits (per git show):
 
 ### Verified
 - ruff format/check (app/tests/tools)
+## [2026-01-06] DB: deterministic async DB URL resolution (fix InvalidPasswordError in runtime)
+- fixed: async engine could select a different URL than migrations/psql and lose password, causing InvalidPasswordError
+- added: resolve_async_database_url() with strict priority (TEST_ASYNC_DATABASE_URL > TEST_DATABASE_URL > fallback) + scheme normalization to postgresql+asyncpg
+- added: password injection when missing (DB_PASSWORD -> PGPASSWORD -> borrow from DATABASE_URL/DB_URL), without logging secrets
+- updated: async engine init now uses async resolver and logs safe debug-only diagnostics
+- tests: test_db_async_url_resolution.py + kept pgpass/password fallback coverage

--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -50,7 +50,7 @@ from app.schemas.kaspi import (
     KaspiTokenOut,
     OrdersQuery,
 )
-from app.services.kaspi_service import KaspiService
+from app.services.kaspi_service import KaspiService, KaspiSyncAlreadyRunning
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/kaspi", tags=["kaspi"])
@@ -352,8 +352,10 @@ async def kaspi_orders_sync(
     try:
         svc = KaspiService()
         resolved_company_id = _resolve_company_id(current_user)
-        result = await svc.sync_orders(company_id=resolved_company_id, db=session)
+        result = await svc.sync_orders(db=session, company_id=resolved_company_id)
         return result
+    except KaspiSyncAlreadyRunning:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="kaspi sync already running")
     except RuntimeError as e:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e))
     except Exception as e:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -98,6 +98,72 @@ def _is_local_env(env_value: str, debug: bool) -> bool:
     return debug or env_norm in {"local", "development", "dev"}
 
 
+def _mask_db_fp(url: str) -> str:
+    return db_connection_fingerprint(url, include_password=False)
+
+
+def _inject_password_if_missing(url: str) -> str:
+    """Inject password for local/dev/pytest Postgres URLs when missing.
+
+    Priority: DB_PASSWORD -> PGPASSWORD -> password from DATABASE_URL/DB_URL.
+    No-ops for non-Postgres URLs, URLs with password, or non-local/non-pytest envs.
+    """
+
+    try:
+        if not url:
+            return url
+
+        env = os.environ
+        env_name = env.get("ENVIRONMENT", "")
+        debug_flag = env.get("DEBUG", "0").lower() in {"1", "true", "yes", "on"}
+        if not (_is_local_env(env_name, debug_flag) or _under_pytest()):
+            return url
+
+        parsed = urlparse(url)
+        if not parsed.scheme.startswith("postgres"):
+            return url
+        if parsed.password or not parsed.username:
+            return url
+
+        password = env.get("DB_PASSWORD") or env.get("PGPASSWORD")
+        if not password:
+            base_env_url = env.get("DATABASE_URL") or env.get("DB_URL")
+            try:
+                if base_env_url and base_env_url != url:
+                    base_parsed = urlparse(base_env_url)
+                    if base_parsed.password and (base_parsed.scheme or "").startswith("postgres"):
+                        password = base_parsed.password
+            except Exception:
+                password = None
+
+        if not password:
+            return url
+
+        host = parsed.hostname or ""
+        port = f":{parsed.port}" if parsed.port else ""
+        netloc = f"{quote(parsed.username)}:{quote(password)}@{host}{port}"
+        return urlunparse((parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment))
+    except Exception:
+        return url
+
+
+def _to_asyncpg_url(url: str) -> str:
+    try:
+        if url.startswith("postgresql+asyncpg://"):
+            return url
+        if url.startswith("postgresql+psycopg2://"):
+            return url.replace("postgresql+psycopg2://", "postgresql+asyncpg://", 1)
+        if url.startswith("postgresql+psycopg://"):
+            return url.replace("postgresql+psycopg://", "postgresql+asyncpg://", 1)
+        if url.startswith("postgresql://"):
+            return url.replace("postgresql://", "postgresql+asyncpg://", 1)
+        if url.startswith("postgres://"):
+            return url.replace("postgres://", "postgresql+asyncpg://", 1)
+    except Exception:
+        return url
+    return url
+
+
 def resolve_database_url(settings: Settings | None = None) -> tuple[str, str, str]:
     """
     Single source of truth for DB URL resolution.
@@ -145,8 +211,36 @@ def resolve_database_url(settings: Settings | None = None) -> tuple[str, str, st
         else:
             raise ValueError("DATABASE_URL/TEST_DATABASE_URL is required in non-local environments")
 
+    # Local/dev/pytest: if URL lacks password but PGPASSWORD is set, inject it for async connections
+    resolved_url = _inject_password_if_missing(resolved_url)
+
     fingerprint = db_url_fingerprint(resolved_url)
     return resolved_url, source, fingerprint
+
+
+def resolve_async_database_url(settings: Settings) -> tuple[str, str, str]:
+    env = os.environ
+
+    url: str | None = None
+    source = ""
+
+    if env.get("TEST_ASYNC_DATABASE_URL"):
+        url = env.get("TEST_ASYNC_DATABASE_URL")
+        source = "TEST_ASYNC_DATABASE_URL"
+    elif env.get("TEST_DATABASE_URL"):
+        url = env.get("TEST_DATABASE_URL")
+        source = "TEST_DATABASE_URL"
+    else:
+        url_base, src_base, _ = resolve_database_url(settings)
+        url = url_base
+        source = src_base
+
+    url = url or ""
+    url = _to_asyncpg_url(url)
+    url = _inject_password_if_missing(url)
+
+    fp = _mask_db_fp(url)
+    return url, f"{source}->async", fp
 
 
 def _parse_list_like(v: Any) -> Any:

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -53,6 +53,7 @@ try:
         _under_pytest,
         db_url_fingerprint,
         get_settings,
+        resolve_async_database_url,
         resolve_database_url,
     )
 
@@ -384,7 +385,26 @@ def _get_async_engine() -> AsyncEngine:
     if _ASYNC_ENGINE is not None:
         return _ASYNC_ENGINE
 
-    url = _resolve_async_url()
+    url, source, fp = resolve_async_database_url(settings)
+
+    if logger.isEnabledFor(logging.DEBUG) or os.getenv("PYTEST_DEBUG_ERRORS"):
+        try:
+            parsed = make_url(url)
+            logger.debug(
+                "db_url_async_resolved",
+                extra={
+                    "source": source,
+                    "fp_no_pw": fp,
+                    "user": parsed.username or "",
+                    "host": parsed.host or "",
+                    "port": parsed.port or "",
+                    "db": parsed.database or "",
+                    "has_password": bool(parsed.password),
+                },
+            )
+        except Exception:
+            pass
+
     _log_effective_url(url, mode="async")
     _ASYNC_ENGINE = create_async_engine(url, **_engine_options(async_engine=True))
     _ASYNC_SESSION_MAKER = async_sessionmaker(

--- a/app/services/kaspi_service.py
+++ b/app/services/kaspi_service.py
@@ -14,18 +14,26 @@ Kaspi.kz integration: product feed generation, orders sync, and availability syn
 """
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from typing import Any, Optional
 
 import httpx
-from sqlalchemy import and_, select
+from sqlalchemy import and_, literal_column, select, text
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.models import Order, OrderItem, Product
+from app.models.kaspi_order_sync_state import KaspiOrderSyncState
+from app.models.order import OrderSource
 
 logger = get_logger(__name__)
+
+
+class KaspiSyncAlreadyRunning(RuntimeError):
+    pass
 
 
 # ---------------------- small utils ---------------------- #
@@ -119,8 +127,8 @@ class KaspiService:
 
     def __init__(self, api_key: Optional[str] = None, base_url: Optional[str] = None):
         # Читаем из settings, но допускаем явную прокидку при создании сервиса
-        self.api_key = api_key or settings.KASPI_API_TOKEN or ""
-        self.base_url = (base_url or settings.KASPI_API_URL or "").rstrip("/")
+        self.api_key = api_key or getattr(settings, "KASPI_API_TOKEN", "") or ""
+        self.base_url = (base_url or getattr(settings, "KASPI_API_URL", "") or "").rstrip("/")
         self.headers = {
             "Authorization": f"Bearer {self.api_key}" if self.api_key else "",
             "Content-Type": "application/json",
@@ -239,56 +247,153 @@ class KaspiService:
 
     # ---------------------- Orders sync (DB) ---------------------- #
 
-    async def sync_orders(self, company_id: int, db: AsyncSession) -> dict[str, Any]:
-        """
-        Загружает свежие заказы из Kaspi и создаёт/обновляет их в локальной БД.
-        """
-        created = 0
+    async def sync_orders(
+        self,
+        *,
+        db: AsyncSession,
+        company_id: int,
+        date_from: datetime | None = None,
+        date_to: datetime | None = None,
+        statuses: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Инкрементальная и идемпотентная синхронизация заказов Kaspi."""
+        now = _utcnow()
+        effective_to = date_to or now
+        overlap = timedelta(minutes=2)
+        fetched = 0
+        inserted = 0
         updated = 0
-        errors: list[str] = []
 
         try:
-            kaspi_orders = await self.get_orders()
-        except Exception as e:
-            logger.error("Kaspi orders sync failed to fetch: %s", e)
-            raise RuntimeError(f"Kaspi orders sync failed: {e}") from e
+            await db.rollback()
+            async with db.begin():
+                await db.execute(text("SET LOCAL lock_timeout = '2s'"))
+                await db.execute(text("SET LOCAL statement_timeout = '10s'"))
 
-        for ko in kaspi_orders:
-            try:
-                ext_id = _as_str(ko.get("id"))
-                # Ищем существующий
-                q = await db.execute(
-                    select(Order).where(and_(Order.company_id == company_id, Order.external_id == ext_id))
-                )
-                existing: Order | None = q.scalar_one_or_none()
+                await self._acquire_company_lock(db, company_id)
 
-                mapped_status = self._map_kaspi_status(_as_str(ko.get("status")))
-                if existing:
-                    if existing.status != mapped_status:
-                        existing.status = mapped_status
-                        updated += 1
-                else:
-                    order = await self._create_order_from_kaspi(ko, company_id, db)
-                    if order:
-                        created += 1
-            except Exception as e:
-                logger.error("Error processing Kaspi order %s: %s", ko.get("id"), e)
-                errors.append(str(e))
+                state = await self._load_or_create_state(db, company_id)
 
-        try:
-            await db.commit()
-        except Exception as e:
-            logger.error("DB commit error during Kaspi orders sync: %s", e)
-            errors.append(f"commit: {e}")
+                base_from = date_from or state.last_synced_at or (effective_to - timedelta(days=1))
+                effective_from = base_from - overlap
 
-        result = {
-            "total_processed": len(kaspi_orders),
-            "created": created,
+                watermark = effective_from
+                last_ext = state.last_external_order_id
+
+                for status in statuses or [None]:
+                    page = 1
+                    while True:
+                        batch = await self.get_orders(
+                            date_from=effective_from,
+                            date_to=effective_to,
+                            status=status,
+                            page=page,
+                            page_size=100,
+                        )
+                        if not batch:
+                            break
+
+                        fetched += len(batch)
+                        for payload in batch:
+                            ext_id = _as_str(payload.get("id")).strip()
+                            if not ext_id:
+                                continue
+
+                            mapped_status = self._map_kaspi_status(_as_str(payload.get("status")))
+                            order_number = self._order_number_from_payload(company_id, ext_id, payload)
+                            customer = payload.get("customer") or {}
+                            currency = _as_str(payload.get("currency")) or "KZT"
+                            total_amount = self._decimal_or_zero(
+                                payload.get("totalPrice") or payload.get("total_amount") or payload.get("total") or 0
+                            )
+                            updated_ts = self._extract_order_timestamp(payload) or effective_to
+
+                            stmt = (
+                                insert(Order)
+                                .values(
+                                    company_id=company_id,
+                                    order_number=order_number,
+                                    external_id=ext_id,
+                                    source=OrderSource.KASPI,
+                                    status=mapped_status,
+                                    customer_phone=customer.get("phone") or None,
+                                    customer_name=customer.get("name") or None,
+                                    customer_address=payload.get("deliveryAddress")
+                                    or payload.get("delivery_address")
+                                    or None,
+                                    delivery_method=payload.get("deliveryMode") or payload.get("delivery_mode") or None,
+                                    total_amount=total_amount,
+                                    currency=currency,
+                                    updated_at=now,
+                                )
+                                .on_conflict_do_update(
+                                    index_elements=[Order.company_id, Order.external_id],
+                                    set_={
+                                        "status": mapped_status,
+                                        "source": OrderSource.KASPI,
+                                        "order_number": order_number,
+                                        "customer_phone": customer.get("phone") or None,
+                                        "customer_name": customer.get("name") or None,
+                                        "customer_address": payload.get("deliveryAddress")
+                                        or payload.get("delivery_address")
+                                        or None,
+                                        "delivery_method": payload.get("deliveryMode")
+                                        or payload.get("delivery_mode")
+                                        or None,
+                                        "total_amount": total_amount,
+                                        "currency": currency,
+                                        "updated_at": now,
+                                    },
+                                )
+                                .returning(literal_column("xmax = 0").label("inserted"))
+                            )
+
+                            async with db.begin_nested():
+                                res = await db.execute(stmt)
+
+                            inserted_flag: bool = bool(res.scalar_one())
+                            if inserted_flag:
+                                inserted += 1
+                            else:
+                                updated += 1
+
+                            if updated_ts > watermark or (
+                                updated_ts == watermark and ext_id and ext_id > (last_ext or "")
+                            ):
+                                watermark = updated_ts
+                                last_ext = ext_id
+
+                        if len(batch) < 100:
+                            break
+                        page += 1
+
+                state.last_synced_at = watermark
+                state.last_external_order_id = last_ext
+                state.updated_at = now
+        except KaspiSyncAlreadyRunning:
+            raise
+        except Exception:
+            logger.exception("Kaspi orders sync internal error: company_id=%s", company_id)
+            raise
+
+        summary = {
+            "company_id": company_id,
+            "fetched": fetched,
+            "inserted": inserted,
             "updated": updated,
-            "errors": errors,
+            "from": effective_from.isoformat(),
+            "to": effective_to.isoformat(),
+            "watermark": watermark.isoformat(),
         }
-        logger.info("Kaspi orders sync completed: %s", result)
-        return result
+
+        logger.info(
+            "Kaspi orders sync: company_id=%s fetched=%s inserted=%s updated=%s",
+            company_id,
+            fetched,
+            inserted,
+            updated,
+        )
+        return summary
 
     async def _create_order_from_kaspi(
         self, kaspi_order: dict[str, Any], company_id: int, db: AsyncSession
@@ -372,6 +477,67 @@ class KaspiService:
             "RETURNED": "refunded",
         }
         return mapping.get(kaspi_status.upper(), "pending")
+
+    async def _acquire_company_lock(self, db: AsyncSession, company_id: int) -> None:
+        lock_key = company_id * 97311
+        res = await db.execute(text("SELECT pg_try_advisory_xact_lock(:lock_key)").bindparams(lock_key=lock_key))
+        ok = res.scalar_one_or_none()
+        if not ok:
+            raise KaspiSyncAlreadyRunning("kaspi sync already running")
+
+    async def _load_or_create_state(self, db: AsyncSession, company_id: int) -> KaspiOrderSyncState:
+        q = await db.execute(
+            select(KaspiOrderSyncState).where(KaspiOrderSyncState.company_id == company_id).with_for_update()
+        )
+        state = q.scalar_one_or_none()
+        if not state:
+            state = KaspiOrderSyncState(company_id=company_id)
+            db.add(state)
+            await db.flush()
+        return state
+
+    def _order_number_from_payload(self, company_id: int, external_id: str, payload: dict[str, Any]) -> str:
+        candidate = _as_str(payload.get("orderNumber") or payload.get("code") or "").strip()
+        if candidate:
+            return candidate
+        return f"KASPI-{company_id}-{external_id}"
+
+    def _extract_order_timestamp(self, payload: dict[str, Any]) -> datetime | None:
+        candidates = [
+            payload.get("updated_at"),
+            payload.get("updatedAt"),
+            payload.get("updated"),
+            payload.get("modificationDate"),
+            payload.get("modified_at"),
+            payload.get("changedAt"),
+            payload.get("created_at"),
+            payload.get("createdAt"),
+        ]
+        for candidate in candidates:
+            ts = self._parse_dt(candidate)
+            if ts:
+                return ts
+        return None
+
+    @staticmethod
+    def _parse_dt(value: Any) -> datetime | None:
+        if isinstance(value, datetime):
+            return value.astimezone(UTC).replace(tzinfo=None) if value.tzinfo else value
+        if isinstance(value, str):
+            try:
+                cleaned = value.replace("Z", "+00:00")
+                dt = datetime.fromisoformat(cleaned)
+                return dt.astimezone(UTC).replace(tzinfo=None) if dt.tzinfo else dt
+            except Exception:
+                return None
+        return None
+
+    @staticmethod
+    def _decimal_or_zero(value: Any):
+        try:
+            return Decimal(str(value or 0))
+        except Exception:
+            return Decimal("0")
 
     # ---------------------- Product feed ---------------------- #
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 # Removed deprecated `env` block to avoid PytestConfigWarning.
 # Configure test database URLs via environment or .env.test instead.
+addopts = -p no:anyio -p pytest_asyncio
+asyncio_mode = auto
 filterwarnings =
 	ignore:Accessing argon2.__version__ is deprecated and will be removed.*:DeprecationWarning:passlib\.handlers\.argon2

--- a/tests/app/api/test_invoices_tenant.py
+++ b/tests/app/api/test_invoices_tenant.py
@@ -7,7 +7,7 @@ def _get_user_by_phone(db_session, phone: str) -> User:
     return db_session.query(User).filter(User.phone == phone).one()
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_invoices_list_same_company_allowed(client, db_session, company_a_admin_headers):
     user_a = _get_user_by_phone(db_session, "+70000010001")
     company_a_id = user_a.company_id
@@ -25,7 +25,7 @@ async def test_invoices_list_same_company_allowed(client, db_session, company_a_
     assert any(inv.get("company_id") == company_a_id for inv in items)
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_invoices_list_other_company_forbidden(
     client, db_session, company_a_admin_headers, company_b_admin_headers
 ):
@@ -45,7 +45,7 @@ async def test_invoices_list_other_company_forbidden(
     assert all(inv.get("company_id") != company_a_id for inv in items)
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_invoices_list_platform_admin_forbidden(client, db_session, company_a_admin_headers, auth_headers):
     user_a = _get_user_by_phone(db_session, "+70000010001")
     company_a_id = user_a.company_id

--- a/tests/app/api/test_kaspi_endpoints.py
+++ b/tests/app/api/test_kaspi_endpoints.py
@@ -3,7 +3,7 @@ import pytest
 from app.api.v1 import kaspi as kaspi_module
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_kaspi_orders_sync_allows_empty_body(monkeypatch, async_client, company_a_admin_headers):
     called = {"count": 0, "company_id": None}
 
@@ -31,7 +31,7 @@ async def test_kaspi_orders_sync_allows_empty_body(monkeypatch, async_client, co
     assert called["company_id"] == 1001
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_kaspi_feed_ignores_company_param(monkeypatch, async_client, company_a_admin_headers):
     captured = {"company_id": None}
 
@@ -52,7 +52,7 @@ async def test_kaspi_feed_ignores_company_param(monkeypatch, async_client, compa
     assert captured["company_id"] == 1001
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_kaspi_feed_propagates_errors(monkeypatch, async_client, company_a_admin_headers):
     class _FailingKaspiService:
         async def generate_product_feed(self, company_id: int, db):  # noqa: ANN001

--- a/tests/app/api/test_kaspi_orders_sync.py
+++ b/tests/app/api/test_kaspi_orders_sync.py
@@ -1,0 +1,126 @@
+import asyncio
+
+import pytest
+import sqlalchemy as sa
+
+from app.models import Order
+from app.models.kaspi_order_sync_state import KaspiOrderSyncState
+from app.services.kaspi_service import KaspiService, KaspiSyncAlreadyRunning
+
+
+def _orders_payload(total: int = 1100, status: str = "NEW") -> list[dict]:
+    return [
+        {
+            "id": "ext-1",
+            "status": status,
+            "totalPrice": total,
+            "customer": {"phone": "+7700", "name": "John"},
+        },
+        {
+            "id": "ext-2",
+            "status": status,
+            "totalPrice": total + 50,
+            "customer": {"phone": "+7701", "name": "Jane"},
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_first_sync_creates_orders(monkeypatch, async_client, async_db_session, company_a_admin_headers):
+    async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return _orders_payload() if page == 1 else []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders)
+
+    resp = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["inserted"] == 2
+    assert data["updated"] == 0
+
+    res = await async_db_session.execute(sa.select(Order).where(Order.company_id == 1001))
+    orders = res.scalars().all()
+    assert len(orders) == 2
+
+    state_res = await async_db_session.execute(
+        sa.select(KaspiOrderSyncState).where(KaspiOrderSyncState.company_id == 1001)
+    )
+    state = state_res.scalar_one()
+    assert state.last_synced_at is not None
+
+
+@pytest.mark.asyncio
+async def test_second_sync_is_idempotent(monkeypatch, async_client, async_db_session, company_a_admin_headers):
+    async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return _orders_payload() if page == 1 else []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders)
+
+    first = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert first.status_code == 200, first.text
+
+    second = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert second.status_code == 200, second.text
+    data = second.json()
+    assert data["inserted"] == 0
+    assert data["updated"] >= 0
+
+    res = await async_db_session.execute(sa.select(Order).where(Order.company_id == 1001))
+    orders = res.scalars().all()
+    assert len(orders) == 2
+
+
+@pytest.mark.asyncio
+async def test_status_and_total_are_updated(monkeypatch, async_client, async_db_session, company_a_admin_headers):
+    async def fake_get_orders_initial(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return _orders_payload(status="NEW") if page == 1 else []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders_initial)
+    first = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert first.status_code == 200, first.text
+
+    async def fake_get_orders_updated(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        if page > 1:
+            return []
+        payload = _orders_payload(total=1500, status="CONFIRMED")
+        payload[0]["totalPrice"] = 1700
+        payload[0]["status"] = "SHIPPED"
+        return payload
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders_updated)
+    second = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert second.status_code == 200, second.text
+    data = second.json()
+    assert data["inserted"] == 0
+    assert data["updated"] >= 1
+
+    res = await async_db_session.execute(sa.select(Order).where(Order.company_id == 1001, Order.external_id == "ext-1"))
+    order = res.scalar_one()
+    assert str(order.total_amount) in {"1700", "1700.00"}
+    status_value = order.status.value if hasattr(order.status, "value") else order.status
+    assert status_value == "shipped"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_sync_returns_409(monkeypatch, async_client, company_a_admin_headers):
+    async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return _orders_payload() if page == 1 else []
+
+    lock_calls = {"n": 0}
+
+    async def fake_lock(self, db, company_id):  # noqa: ARG002
+        lock_calls["n"] += 1
+        if lock_calls["n"] == 1:
+            await asyncio.sleep(0.05)
+            return
+        raise KaspiSyncAlreadyRunning("kaspi sync already running")
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders)
+    monkeypatch.setattr(KaspiService, "_acquire_company_lock", fake_lock)
+
+    first = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert first.status_code == 200, first.text
+
+    second = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert second.status_code == 409
+    assert "sync" in (second.json().get("detail", ""))

--- a/tests/app/api/test_rbac_v2.py
+++ b/tests/app/api/test_rbac_v2.py
@@ -1,13 +1,13 @@
 import pytest
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_wallet_requires_token(async_client):
     resp = await async_client.get("/api/v1/wallet/accounts")
     assert resp.status_code == 401
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_wallet_forbids_insufficient_role(async_client, company_a_storekeeper_headers):
     # Storekeeper role cannot create wallet accounts (admin/manager only)
     payload = {"user_id": 1, "currency": "KZT"}
@@ -20,7 +20,7 @@ async def test_wallet_forbids_insufficient_role(async_client, company_a_storekee
     assert resp.status_code == 403
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_wallet_forbids_cross_company_query(async_client, company_a_admin_headers):
     resp = await async_client.get(
         "/api/v1/wallet/accounts",
@@ -31,7 +31,7 @@ async def test_wallet_forbids_cross_company_query(async_client, company_a_admin_
     assert resp.json()["meta"]["total"] == 0
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_wallet_allows_company_admin(async_client, company_a_admin_headers):
     resp = await async_client.get("/api/v1/wallet/accounts", headers=company_a_admin_headers)
     assert resp.status_code == 200

--- a/tests/app/api/test_subscriptions_api.py
+++ b/tests/app/api/test_subscriptions_api.py
@@ -3,7 +3,7 @@ import pytest
 BASE = "/api/v1/subscriptions"
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_create_subscription_trial_ok(client, company_a_admin_headers):
     r = await client.post(
         BASE,
@@ -24,7 +24,7 @@ async def test_create_subscription_trial_ok(client, company_a_admin_headers):
     assert data["next_billing_date"]
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_forbid_second_active_subscription(client, company_a_admin_headers):
     # первая активная
     r1 = await client.post(
@@ -54,7 +54,7 @@ async def test_forbid_second_active_subscription(client, company_a_admin_headers
     assert r2.status_code == 409
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_update_cancel_resume_renew_flow(client, company_a_admin_headers):
     r = await client.post(
         BASE,
@@ -88,7 +88,7 @@ async def test_update_cancel_resume_renew_flow(client, company_a_admin_headers):
     assert rn.status_code == 200 and rn.json()["next_billing_date"] != before
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_current_and_filters(client, company_a_admin_headers):
     await client.post(
         BASE,

--- a/tests/app/api/test_wallet_payments_tenant.py
+++ b/tests/app/api/test_wallet_payments_tenant.py
@@ -7,7 +7,7 @@ def _get_user_by_phone(db_session, phone: str) -> User:
     return db_session.query(User).filter(User.phone == phone).one()
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_wallet_accounts_hidden_across_companies(
     client,
     db_session,
@@ -34,7 +34,7 @@ async def test_wallet_accounts_hidden_across_companies(
     assert all(it.get("id") != account_id for it in items)
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_payments_hidden_across_companies(
     client,
     db_session,
@@ -75,7 +75,7 @@ async def test_payments_hidden_across_companies(
     assert all(it.get("id") != payment_id for it in items)
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_wallet_account_visible_same_company(client, db_session, company_a_admin_headers):
     """Ensure newly created wallet account is immediately readable by the same tenant."""
     user_a = _get_user_by_phone(db_session, "+70000010001")
@@ -92,7 +92,7 @@ async def test_wallet_account_visible_same_company(client, db_session, company_a
     assert got.status_code == 200, got.text
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_wallet_ledger_hidden_across_companies(
     client, db_session, company_a_admin_headers, company_b_admin_headers
 ):
@@ -110,7 +110,7 @@ async def test_wallet_ledger_hidden_across_companies(
     assert ledger.status_code == 404
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_deposit_cross_tenant_forbidden(client, db_session, company_a_admin_headers, company_b_admin_headers):
     user_a = _get_user_by_phone(db_session, "+70000010001")
     created = await client.post(
@@ -129,7 +129,7 @@ async def test_deposit_cross_tenant_forbidden(client, db_session, company_a_admi
     assert resp.status_code == 404
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_withdraw_cross_tenant_forbidden(client, db_session, company_a_admin_headers, company_b_admin_headers):
     user_a = _get_user_by_phone(db_session, "+70000010001")
     created = await client.post(
@@ -156,7 +156,7 @@ async def test_withdraw_cross_tenant_forbidden(client, db_session, company_a_adm
     assert resp.status_code == 404
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_transfer_cross_tenant_destination_forbidden(
     client,
     db_session,
@@ -203,7 +203,7 @@ async def test_transfer_cross_tenant_destination_forbidden(
     assert transfer.status_code == 404
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_payment_create_cross_tenant_forbidden(
     client,
     db_session,
@@ -235,7 +235,7 @@ async def test_payment_create_cross_tenant_forbidden(
     assert pay.status_code == 404
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_payments_list_scoped_by_token(
     client, db_session, company_a_admin_headers, company_b_admin_headers, auth_headers
 ):
@@ -279,7 +279,7 @@ async def test_payments_list_scoped_by_token(
     assert all(it.get("id") != payment_id for it in platform_items)
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_wallet_list_scoped_by_token(
     client, db_session, company_a_admin_headers, company_b_admin_headers, auth_headers
 ):

--- a/tests/app/test_auth.py
+++ b/tests/app/test_auth.py
@@ -11,7 +11,7 @@ from app.models import Company, OtpAttempt, User
 from app.utils.otp import hash_otp_code
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 class TestAuth:
     """Test authentication endpoints"""
 

--- a/tests/app/test_tenant_isolation.py
+++ b/tests/app/test_tenant_isolation.py
@@ -1,6 +1,6 @@
 import pytest
 
-pytestmark = pytest.mark.anyio
+pytestmark = pytest.mark.asyncio
 
 
 async def _get_items(resp_json):

--- a/tests/app/test_tenant_isolation_billing.py
+++ b/tests/app/test_tenant_isolation_billing.py
@@ -7,7 +7,7 @@ def _get_user_by_phone(db_session, phone: str) -> User:
     return db_session.query(User).filter(User.phone == phone).one()
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_wallet_isolation_between_companies(
     client,
     db_session,
@@ -44,7 +44,7 @@ async def test_wallet_isolation_between_companies(
     assert listed.json()["meta"]["total"] == 0
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_payments_isolation_between_companies(
     client,
     db_session,
@@ -82,7 +82,7 @@ async def test_payments_isolation_between_companies(
     assert listed.json()["meta"]["total"] == 0
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_subscriptions_isolation_between_companies(
     client,
     db_session,
@@ -114,7 +114,7 @@ async def test_subscriptions_isolation_between_companies(
     assert foreign_current.json() is None
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_subscriptions_get_by_id_cross_company_forbidden(
     client,
     db_session,
@@ -143,7 +143,7 @@ async def test_subscriptions_get_by_id_cross_company_forbidden(
     assert foreign_get.status_code == 404
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_subscriptions_payments_cross_company_forbidden(
     client,
     db_session,
@@ -171,7 +171,7 @@ async def test_subscriptions_payments_cross_company_forbidden(
     assert payments.status_code == 404
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_subscriptions_company_param_bypass_forbidden(
     client,
     db_session,
@@ -189,7 +189,7 @@ async def test_subscriptions_company_param_bypass_forbidden(
     assert resp.json() == []
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_invoices_company_param_bypass_forbidden(
     client,
     db_session,
@@ -206,7 +206,7 @@ async def test_invoices_company_param_bypass_forbidden(
     assert resp.json() == []
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_invoices_cross_tenant_get_by_id_forbidden(
     client,
     db_session,
@@ -231,7 +231,7 @@ async def test_invoices_cross_tenant_get_by_id_forbidden(
     assert resp.status_code == 403 or resp.status_code == 404
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_rbac_roles_restricted_actions(
     client,
     db_session,

--- a/tests/app/test_tenant_isolation_campaigns.py
+++ b/tests/app/test_tenant_isolation_campaigns.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_campaigns_isolation_between_companies(
     client,
     company_a_admin_headers,
@@ -44,7 +44,7 @@ async def test_campaigns_isolation_between_companies(
     assert messages.status_code == 404
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_campaign_messages_not_mutable_cross_company(
     client,
     company_a_admin_headers,

--- a/tests/app/test_tenant_isolation_invoices.py
+++ b/tests/app/test_tenant_isolation_invoices.py
@@ -18,7 +18,9 @@ async def test_invoices_list_isolated_between_companies(async_client, company_a_
 
 
 @pytest.mark.asyncio
-async def test_invoice_get_by_id_hidden_from_other_company(async_client, company_a_admin_headers, company_b_admin_headers):
+async def test_invoice_get_by_id_hidden_from_other_company(
+    async_client, company_a_admin_headers, company_b_admin_headers
+):
     payload = {"amount": "42.50", "currency": "KZT", "status": "draft", "description": "secret"}
     created = await async_client.post(BASE, json=payload, headers=company_a_admin_headers)
     assert created.status_code == 201, created.text

--- a/tests/app/test_tenant_isolation_invoices.py
+++ b/tests/app/test_tenant_isolation_invoices.py
@@ -3,7 +3,7 @@ import pytest
 BASE = "/api/v1/invoices"
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_invoices_list_isolated_between_companies(async_client, company_a_admin_headers, company_b_admin_headers):
     payload = {"amount": "15.00", "currency": "KZT", "status": "draft", "description": "tenant A invoice"}
     created = await async_client.post(BASE, json=payload, headers=company_a_admin_headers)
@@ -17,10 +17,8 @@ async def test_invoices_list_isolated_between_companies(async_client, company_a_
     assert all(it.get("id") != invoice_id for it in items)
 
 
-@pytest.mark.anyio
-async def test_invoice_get_by_id_hidden_from_other_company(
-    async_client, company_a_admin_headers, company_b_admin_headers
-):
+@pytest.mark.asyncio
+async def test_invoice_get_by_id_hidden_from_other_company(async_client, company_a_admin_headers, company_b_admin_headers):
     payload = {"amount": "42.50", "currency": "KZT", "status": "draft", "description": "secret"}
     created = await async_client.post(BASE, json=payload, headers=company_a_admin_headers)
     assert created.status_code == 201, created.text

--- a/tests/app/test_tenant_isolation_subscriptions.py
+++ b/tests/app/test_tenant_isolation_subscriptions.py
@@ -3,7 +3,7 @@ import pytest
 BASE = "/api/v1/subscriptions"
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_subscriptions_list_isolated_between_companies(
     async_client, company_a_admin_headers, company_b_admin_headers
 ):
@@ -21,7 +21,7 @@ async def test_subscriptions_list_isolated_between_companies(
     assert forbidden.json() == []
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_subscription_payments_hidden_from_other_company(
     async_client, company_a_admin_headers, company_b_admin_headers
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,6 @@ from urllib.parse import quote
 
 import pytest
 import pytest_asyncio
-
-# SQLAlchemy
 import sqlalchemy as sa
 from alembic import command
 from alembic.config import Config
@@ -42,22 +40,10 @@ from sqlalchemy import MetaData, Table, text
 from sqlalchemy import exc as sa_exc  # РѕР±СЂР°Р±РѕС‚РєР° OperationalError/В«already existsВ»
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.engine.url import make_url
-from sqlalchemy.ext.asyncio import (
-    AsyncEngine,
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
 from sqlalchemy.sql.type_api import TypeEngine  # С‚РёРїС‹ РґР»СЏ С„РёР»СЊС‚СЂР° unsupported
-
-
-@pytest.fixture
-def anyio_backend():
-    """Force asyncio backend; asyncpg does not run under trio without extra shims."""
-    return "asyncio"
-
 
 # Compatibility shim: newer trio may not expose MultiError; avoid touching deprecated attribute when present.
 try:
@@ -366,7 +352,7 @@ TEST_DATABASE_URL, SYNC_TEST_DATABASE_URL = _ensure_test_urls()
 
 # Module-level engine/sessionmaker variables initialized to None
 # Created AFTER alembic upgrade in test_db fixture
-test_engine: AsyncEngine | None = None
+_async_test_engine: AsyncEngine | None = None
 TestingSessionLocal: async_sessionmaker[AsyncSession] | None = None
 sync_engine: Engine | None = None
 logger = logging.getLogger(__name__)
@@ -381,17 +367,17 @@ def pytest_keyboard_interrupt(excinfo):
 
 def _dispose_test_engines() -> None:
     """Best-effort disposal of async/sync engines; never raises."""
-    global test_engine, sync_engine, TestingSessionLocal
+    global _async_test_engine, sync_engine, TestingSessionLocal
 
     try:
-        if test_engine is not None:
+        if _async_test_engine is not None:
             try:
-                await_future = test_engine.dispose()
+                await_future = _async_test_engine.dispose()
                 if hasattr(await_future, "__await__"):
                     asyncio.run(await_future)
             except Exception as e:  # noqa: PERF203 — log for diagnosis
                 logger.warning("Failed to dispose async test engine: %s", e)
-            test_engine = None
+            _async_test_engine = None
     except Exception as e:  # noqa: PERF203 — log for diagnosis
         logger.warning("Async engine cleanup error: %s", e)
 
@@ -607,7 +593,7 @@ def _ensure_patch_create_all_for_postgres() -> None:
 @pytest.fixture(scope="session")
 def test_db() -> Iterator[None]:
     """Разворачиваем схему через Alembic upgrade head и откатываемся после тестов."""
-    global test_engine, sync_engine, TestingSessionLocal
+    global _async_test_engine, sync_engine, TestingSessionLocal
 
     sync_url = SYNC_TEST_DATABASE_URL
     async_url = TEST_DATABASE_URL
@@ -699,7 +685,7 @@ def test_db() -> Iterator[None]:
         temp_engine.dispose()
 
     # Re-create engines post-upgrade
-    test_engine = create_async_engine(
+    _async_test_engine = create_async_engine(
         async_url,
         echo=False,
         pool_pre_ping=True,
@@ -707,7 +693,7 @@ def test_db() -> Iterator[None]:
         future=True,
     )
     TestingSessionLocal = async_sessionmaker(
-        bind=test_engine,
+        bind=_async_test_engine,
         class_=AsyncSession,
         expire_on_commit=False,
     )
@@ -760,21 +746,7 @@ def test_db() -> Iterator[None]:
 
 
 # ======================================================================================
-# 5) Event loop РґР»СЏ pytest-asyncio (strict mode СЃРѕРІРјРµСЃС‚РёРј)
-# ======================================================================================
-
-
-@pytest.fixture(scope="session")
-def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    loop = asyncio.new_event_loop()
-    try:
-        yield loop
-    finally:
-        loop.close()
-
-
-# ======================================================================================
-# 6) FastAPI РєР»РёРµРЅС‚С‹ (async/sync) СЃ Р»РµРЅРёРІС‹РјРё РёРјРїРѕСЂС‚Р°РјРё app Рё get_db
+# 5) FastAPI РєР»РёРµРЅС‚С‹ (async/sync) СЃ Р»РµРЅРёРІС‹РјРё РёРјРїРѕСЂС‚Р°РјРё app Рё get_db
 # ======================================================================================
 
 
@@ -837,6 +809,15 @@ async def async_db_session(test_db: None) -> AsyncIterator[AsyncSession]:
         yield session
     finally:
         await session.close()
+
+
+@pytest.fixture
+def test_engine() -> AsyncEngine:
+    """Compatibility alias for tests expecting `test_engine` fixture name."""
+    global _async_test_engine
+    if _async_test_engine is None:
+        raise RuntimeError("test_engine not initialized; test_db fixture must run first")
+    return _async_test_engine
 
 
 # Backward-compat alias used by some tests
@@ -1082,8 +1063,8 @@ def db_session(test_db: None):
         connection.close()
 
 
-@pytest_asyncio.fixture
-async def auth_headers(async_client: AsyncClient):
+@pytest.fixture
+def auth_headers(test_db: None):
     """Seed a platform admin user and return its bearer token."""
     from app.core.security import create_access_token, get_password_hash  # type: ignore
     from app.models.company import Company  # type: ignore

--- a/tests/test_db_async_url_resolution.py
+++ b/tests/test_db_async_url_resolution.py
@@ -1,0 +1,59 @@
+from urllib.parse import urlparse
+
+from app.core.config import Settings, resolve_async_database_url
+
+
+def _clear_db_env(monkeypatch):
+    for key in (
+        "TEST_ASYNC_DATABASE_URL",
+        "TEST_DATABASE_URL",
+        "TEST_ASYNC_DATABASE_URL",
+        "DATABASE_URL",
+        "DB_URL",
+        "DB_PASSWORD",
+        "PGPASSWORD",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_async_url_prefers_test_async(monkeypatch):
+    _clear_db_env(monkeypatch)
+    monkeypatch.setenv(
+        "TEST_ASYNC_DATABASE_URL",
+        "postgresql+asyncpg://postgres:admin123@127.0.0.1:5432/smartsell_test",
+    )
+
+    url, source, _ = resolve_async_database_url(Settings())
+    parsed = urlparse(url)
+
+    assert source.startswith("TEST_ASYNC_DATABASE_URL")
+    assert parsed.scheme.startswith("postgresql+asyncpg")
+    assert parsed.password == "admin123"
+
+
+def test_async_from_test_database_url_psycopg(monkeypatch):
+    _clear_db_env(monkeypatch)
+    monkeypatch.setenv(
+        "TEST_DATABASE_URL",
+        "postgresql+psycopg2://postgres:admin123@127.0.0.1:5432/smartsell_test",
+    )
+
+    url, source, _ = resolve_async_database_url(Settings())
+    parsed = urlparse(url)
+
+    assert source.startswith("TEST_DATABASE_URL")
+    assert parsed.scheme.startswith("postgresql+asyncpg")
+    assert parsed.password == "admin123"
+
+
+def test_async_password_injected_from_pgpassword(monkeypatch):
+    _clear_db_env(monkeypatch)
+    monkeypatch.setenv("TEST_DATABASE_URL", "postgresql+asyncpg://postgres@127.0.0.1:5432/smartsell_test")
+    monkeypatch.setenv("PGPASSWORD", "admin123")
+
+    url, source, _ = resolve_async_database_url(Settings())
+    parsed = urlparse(url)
+
+    assert source.startswith("TEST_DATABASE_URL")
+    assert parsed.scheme.startswith("postgresql+asyncpg")
+    assert parsed.password == "admin123"

--- a/tests/test_db_password_pgpass.py
+++ b/tests/test_db_password_pgpass.py
@@ -1,0 +1,54 @@
+from urllib.parse import urlparse
+
+from app.core.config import Settings, resolve_database_url
+
+
+def _clear_db_env(monkeypatch):
+    for key in (
+        "TEST_DATABASE_URL",
+        "TEST_ASYNC_DATABASE_URL",
+        "DATABASE_TEST_URL",
+        "DATABASE_URL",
+        "DB_URL",
+        "DB_PASSWORD",
+        "PGPASSWORD",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_pgpassword_injected_when_url_missing_password(monkeypatch):
+    # Simulate local/pytest context with PGPASSWORD provided and URL lacking password
+    monkeypatch.setenv("ENVIRONMENT", "local")
+    _clear_db_env(monkeypatch)
+
+    url_without_password = "postgresql+asyncpg://postgres@localhost:5432/smartsell_test"
+    # testing flag keeps resolution predictable; provide test URL without password
+    monkeypatch.setenv("TEST_DATABASE_URL", url_without_password)
+    monkeypatch.setenv("PGPASSWORD", "secret_pw")
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "config::pgpass")
+
+    url, source, _ = resolve_database_url(Settings())
+    parsed = urlparse(url)
+
+    assert parsed.scheme.startswith("postgres")
+    assert parsed.password == "secret_pw"
+    assert source == "TEST_DATABASE_URL"
+
+
+def test_password_borrowed_from_database_url(monkeypatch):
+    # If test URL lacks password and DATABASE_URL has one, borrow it
+    monkeypatch.setenv("ENVIRONMENT", "local")
+    _clear_db_env(monkeypatch)
+
+    test_url = "postgresql+asyncpg://postgres@localhost:5432/smartsell_test"
+    base_url = "postgresql+asyncpg://postgres:from_base@localhost:5432/smartsell_test"
+
+    monkeypatch.setenv("TEST_DATABASE_URL", test_url)
+    monkeypatch.setenv("DATABASE_URL", base_url)
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "config::pgpass2")
+
+    url, source, _ = resolve_database_url(Settings())
+    parsed = urlparse(url)
+
+    assert parsed.password == "from_base"
+    assert source == "TEST_DATABASE_URL"

--- a/tests/test_e2e_platform.py
+++ b/tests/test_e2e_platform.py
@@ -137,7 +137,7 @@ def test_e2e_models_happy_path(db_session, company, admin_user, product, warehou
 
 
 # ---------- HTTP SMOKE (если есть FastAPI-приложение) ----------
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_http_smoke_if_app_exists(async_client):
     try:
         from app.main import create_app

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_feature_flags_crud(client):
     r1 = await client.get("/feature-flags")
     assert r1.status_code == 200

--- a/tests/test_health_and_ready.py
+++ b/tests/test_health_and_ready.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_health_ok(client):
     r = await client.get("/health")
     assert r.status_code == 200
@@ -9,7 +9,7 @@ async def test_health_ok(client):
     assert "checks" in j and "version" in j
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_ready_relaxed_200(client, monkeypatch):
     monkeypatch.setenv("READINESS_STRICT", "0")
     r = await client.get("/ready")
@@ -17,7 +17,7 @@ async def test_ready_relaxed_200(client, monkeypatch):
     assert "ready" in r.json()
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_metrics_available(client):
     r = await client.get("/metrics")
     assert r.status_code == 200

--- a/tests/test_platform_admin_tenant_access_policy.py
+++ b/tests/test_platform_admin_tenant_access_policy.py
@@ -62,7 +62,7 @@ async def _call_endpoint(async_client, path: str, method: str, headers: dict[str
     return await requester(path, headers=headers)
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 @pytest.mark.parametrize("path,method", TENANT_ENDPOINTS)
 async def test_platform_admin_without_company_forbidden(
     async_client, platform_admin_no_company_headers, monkeypatch, path, method
@@ -71,7 +71,7 @@ async def test_platform_admin_without_company_forbidden(
     assert resp.status_code == 403
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 @pytest.mark.parametrize("path,method", TENANT_ENDPOINTS)
 async def test_tenant_admin_allowed(async_client, company_a_admin_headers, monkeypatch, path, method):
     resp = await _call_endpoint(async_client, path, method, company_a_admin_headers, monkeypatch)

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_security_headers_present(client):
     r = await client.get("/ping")
     h = r.headers


### PR DESCRIPTION
Implements incremental+idempotent Kaspi orders sync using kaspi_order_sync_state watermark and per-company advisory lock. Uses ON CONFLICT upsert by (company_id, external_id). Adds tests + conftest cleanup. Journal entry included.