### PR TITLE
fix(kaspi): prevent watermark rollback when no orders fetched

### DIFF
--- a/app/services/kaspi_service.py
+++ b/app/services/kaspi_service.py
@@ -274,11 +274,16 @@ class KaspiService:
 
                 state = await self._load_or_create_state(db, company_id)
 
-                base_from = date_from or state.last_synced_at or (effective_to - timedelta(days=1))
+                prev_last_synced = state.last_synced_at
+                prev_last_ext = state.last_external_order_id
+                is_new_state = prev_last_synced is None and prev_last_ext is None
+
+                base_from = date_from or prev_last_synced or (effective_to - timedelta(days=1))
                 effective_from = base_from - overlap
 
-                watermark = effective_from
-                last_ext = state.last_external_order_id
+                watermark = prev_last_synced or base_from
+                last_ext = prev_last_ext
+                made_progress = False
 
                 for status in statuses or [None]:
                     page = 1
@@ -362,13 +367,21 @@ class KaspiService:
                             ):
                                 watermark = updated_ts
                                 last_ext = ext_id
+                            made_progress = True
 
                         if len(batch) < 100:
                             break
                         page += 1
 
-                state.last_synced_at = watermark
-                state.last_external_order_id = last_ext
+                if made_progress or is_new_state:
+                    final_wm = watermark if prev_last_synced is None else max(prev_last_synced, watermark)
+                    state.last_synced_at = final_wm
+                    state.last_external_order_id = last_ext
+                else:
+                    final_wm = prev_last_synced or watermark
+                    state.last_synced_at = prev_last_synced
+                    state.last_external_order_id = prev_last_ext
+
                 state.updated_at = now
         except KaspiSyncAlreadyRunning:
             raise
@@ -383,7 +396,7 @@ class KaspiService:
             "updated": updated,
             "from": effective_from.isoformat(),
             "to": effective_to.isoformat(),
-            "watermark": watermark.isoformat(),
+            "watermark": (state.last_synced_at or final_wm).isoformat() if (state.last_synced_at or final_wm) else None,
         }
 
         logger.info(

--- a/tests/app/api/test_kaspi_orders_sync.py
+++ b/tests/app/api/test_kaspi_orders_sync.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import sqlalchemy as sa
@@ -41,6 +42,53 @@ async def test_first_sync_creates_orders(monkeypatch, async_client, async_db_ses
     res = await async_db_session.execute(sa.select(Order).where(Order.company_id == 1001))
     orders = res.scalars().all()
     assert len(orders) == 2
+
+
+@pytest.mark.asyncio
+async def test_watermark_not_moved_backwards_on_empty_batch(
+    monkeypatch, async_client, async_db_session, company_a_admin_headers
+):
+    async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders)
+
+    existing_ts = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc).replace(tzinfo=None)
+    state = KaspiOrderSyncState(company_id=1001, last_synced_at=existing_ts, last_external_order_id="prev")
+    async_db_session.add(state)
+    await async_db_session.commit()
+
+    resp = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    await async_db_session.refresh(state)
+    assert state.last_synced_at == existing_ts
+    assert state.last_external_order_id == "prev"
+    assert data["watermark"].startswith(existing_ts.isoformat())
+
+
+@pytest.mark.asyncio
+async def test_first_run_no_orders_sets_reasonable_watermark(monkeypatch, async_client, async_db_session, company_a_admin_headers):
+    async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders)
+
+    resp = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    res = await async_db_session.execute(
+        sa.select(KaspiOrderSyncState).where(KaspiOrderSyncState.company_id == 1001)
+    )
+    state = res.scalar_one()
+
+    now = datetime.utcnow()
+    assert state.last_synced_at is not None
+    assert state.last_synced_at <= now
+    assert state.last_synced_at >= now - timedelta(days=2)
+    assert data["watermark"].startswith(state.last_synced_at.isoformat())
 
     state_res = await async_db_session.execute(
         sa.select(KaspiOrderSyncState).where(KaspiOrderSyncState.company_id == 1001)

--- a/tests/app/api/test_kaspi_orders_sync.py
+++ b/tests/app/api/test_kaspi_orders_sync.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 import sqlalchemy as sa
@@ -53,7 +53,7 @@ async def test_watermark_not_moved_backwards_on_empty_batch(
 
     monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders)
 
-    existing_ts = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc).replace(tzinfo=None)
+    existing_ts = datetime(2025, 1, 1, 12, 0, tzinfo=UTC).replace(tzinfo=None)
     state = KaspiOrderSyncState(company_id=1001, last_synced_at=existing_ts, last_external_order_id="prev")
     async_db_session.add(state)
     await async_db_session.commit()
@@ -69,7 +69,9 @@ async def test_watermark_not_moved_backwards_on_empty_batch(
 
 
 @pytest.mark.asyncio
-async def test_first_run_no_orders_sets_reasonable_watermark(monkeypatch, async_client, async_db_session, company_a_admin_headers):
+async def test_first_run_no_orders_sets_reasonable_watermark(
+    monkeypatch, async_client, async_db_session, company_a_admin_headers
+):
     async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
         return []
 
@@ -79,9 +81,7 @@ async def test_first_run_no_orders_sets_reasonable_watermark(monkeypatch, async_
     assert resp.status_code == 200, resp.text
     data = resp.json()
 
-    res = await async_db_session.execute(
-        sa.select(KaspiOrderSyncState).where(KaspiOrderSyncState.company_id == 1001)
-    )
+    res = await async_db_session.execute(sa.select(KaspiOrderSyncState).where(KaspiOrderSyncState.company_id == 1001))
     state = res.scalar_one()
 
     now = datetime.utcnow()


### PR DESCRIPTION
Fixes Kaspi orders sync watermark handling: do not move watermark backwards when empty batches/no orders; preserve state; adds tests for empty/first-run scenarios.