### PR TITLE
feat(kaspi): idempotent order items (unique order_id+sku + upsert)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -317,3 +317,5 @@ __pycache__/
 *.py[cod]
 *.class
 
+
+_branch_protection_*.json

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -863,6 +863,7 @@ class OrderItem(Base):
             "unit_price >= 0 AND total_price >= 0 AND cost_price >= 0",
             name="ck_order_item_price_non_negative",
         ),
+        UniqueConstraint("order_id", "sku", name="uq__order_items__order_id_sku"),
         Index("ix_order_items_order_sku", "order_id", "sku"),
     )
 

--- a/app/services/kaspi_service.py
+++ b/app/services/kaspi_service.py
@@ -171,11 +171,11 @@ class KaspiService:
         if not date_to:
             date_to = _utcnow()
 
-        params: dict[str, Any] = {
-            "dateFrom": date_from.strftime("%Y-%m-%dT%H:%M:%S"),
-            "dateTo": date_to.strftime("%Y-%m-%dT%H:%M:%S"),
+        params = {
             "page": page,
             "pageSize": page_size,
+            "dateFrom": date_from.isoformat(),
+            "dateTo": date_to.isoformat(),
         }
         if status:
             params["status"] = status
@@ -185,33 +185,10 @@ class KaspiService:
                 resp = await client.get(self._url("/orders"), headers=self.headers, params=params)
                 resp.raise_for_status()
                 data = resp.json() or {}
-                # API может называть список по-разному
-                return data.get("orders") or data.get("items") or []
+                return data.get("orders") or data.get("items") or data.get("data") or []
             except httpx.HTTPError as e:
                 logger.error("Kaspi get_orders error: %s", e)
                 raise RuntimeError(f"Failed to fetch orders from Kaspi: {e}") from e
-
-    async def get_order_details(self, order_id: str) -> dict[str, Any] | None:
-        async with self._client() as client:
-            try:
-                resp = await client.get(self._url(f"/orders/{order_id}"), headers=self.headers)
-                resp.raise_for_status()
-                return resp.json()
-            except httpx.HTTPError as e:
-                logger.error("Kaspi get_order_details(%s) error: %s", order_id, e)
-                return None
-
-    async def update_order_status(self, order_id: str, status: str) -> bool:
-        payload = {"status": status}
-        async with self._client() as client:
-            try:
-                resp = await client.patch(self._url(f"/orders/{order_id}/status"), headers=self.headers, json=payload)
-                resp.raise_for_status()
-                logger.info("Kaspi: статус заказа %s обновлён на '%s'.", order_id, status)
-                return True
-            except httpx.HTTPError as e:
-                logger.error("Kaspi update_order_status(%s) error: %s", order_id, e)
-                return False
 
     # ---------------------- Products API ---------------------- #
 
@@ -350,17 +327,20 @@ class KaspiService:
                                         "updated_at": now,
                                     },
                                 )
-                                .returning(literal_column("xmax = 0").label("inserted"))
+                                .returning(Order.id, literal_column("xmax = 0").label("inserted"))
                             )
 
                             async with db.begin_nested():
                                 res = await db.execute(stmt)
 
-                            inserted_flag: bool = bool(res.scalar_one())
+                            row = res.one()
+                            inserted_flag: bool = bool(row.inserted)
                             if inserted_flag:
                                 inserted += 1
                             else:
                                 updated += 1
+
+                            order_pk = row.id
 
                             if updated_ts > watermark or (
                                 updated_ts == watermark and ext_id and ext_id > (last_ext or "")
@@ -368,6 +348,10 @@ class KaspiService:
                                 watermark = updated_ts
                                 last_ext = ext_id
                             made_progress = True
+
+                            await self._upsert_order_items(
+                                db, order_id=order_pk, company_id=company_id, payload=payload
+                            )
 
                         if len(batch) < 100:
                             break
@@ -407,6 +391,87 @@ class KaspiService:
             updated,
         )
         return summary
+
+    async def _upsert_order_items(
+        self,
+        db: AsyncSession,
+        *,
+        order_id: int,
+        company_id: int,
+        payload: dict[str, Any],
+    ) -> None:
+        items = payload.get("items") or payload.get("orderItems") or []
+        if not items:
+            return
+
+        now = _utcnow()
+
+        for item in items:
+            sku = _as_str(item.get("productSku") or item.get("sku")).strip()
+            if not sku:
+                continue
+
+            name = _as_str(item.get("productName") or item.get("title") or item.get("name") or sku).strip() or sku
+
+            qty_raw = item.get("quantity") or item.get("qty") or 1
+            try:
+                qty = max(1, int(qty_raw))
+            except Exception:
+                qty = 1
+
+            unit_price = self._decimal_or_zero(
+                item.get("basePrice") or item.get("unitPrice") or item.get("unit_price") or item.get("price") or 0
+            )
+
+            total_price_raw = item.get("totalPrice") or item.get("total_price")
+            if total_price_raw is None:
+                total_price_raw = unit_price * qty
+            total_price = self._decimal_or_zero(total_price_raw)
+
+            cost_price = self._decimal_or_zero(item.get("costPrice") or item.get("cost_price") or 0)
+
+            product_id = None
+            product_ext_id = _as_str(item.get("productId") or item.get("product_id") or "").strip()
+            if product_ext_id:
+                try:
+                    res = await db.execute(
+                        select(Product.id).where(
+                            and_(Product.company_id == company_id, Product.kaspi_product_id == product_ext_id)
+                        )
+                    )
+                    product_id = res.scalar_one_or_none()
+                except Exception:
+                    product_id = None
+
+            insert_values = {
+                "order_id": order_id,
+                "product_id": product_id,
+                "sku": sku,
+                "name": name,
+                "unit_price": unit_price,
+                "quantity": qty,
+                "total_price": total_price,
+                "cost_price": cost_price,
+            }
+
+            update_values = {
+                "product_id": product_id,
+                "name": name,
+                "unit_price": unit_price,
+                "quantity": qty,
+                "total_price": total_price,
+                "cost_price": cost_price,
+            }
+            if hasattr(OrderItem, "updated_at"):
+                update_values["updated_at"] = now
+
+            stmt = (
+                insert(OrderItem)
+                .values(**insert_values)
+                .on_conflict_do_update(index_elements=[OrderItem.order_id, OrderItem.sku], set_=update_values)
+            )
+
+            await db.execute(stmt)
 
     async def _create_order_from_kaspi(
         self, kaspi_order: dict[str, Any], company_id: int, db: AsyncSession

--- a/migrations/versions/2d43c3d56e28_kaspi_unique_order_items_order_id_sku.py
+++ b/migrations/versions/2d43c3d56e28_kaspi_unique_order_items_order_id_sku.py
@@ -1,0 +1,27 @@
+"""kaspi: unique order_items (order_id, sku)
+
+Revision ID: 2d43c3d56e28
+Revises: e3ee67c23527
+Create Date: 2026-01-06 08:52:25.942187+00:00
+
+"""
+from collections.abc import Sequence
+from typing import Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2d43c3d56e28"
+down_revision: Union[str, Sequence[str], None] = "e3ee67c23527"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_unique_constraint("uq__order_items__order_id_sku", "order_items", ["order_id", "sku"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint("uq__order_items__order_id_sku", "order_items", type_="unique")

--- a/tests/app/api/test_kaspi_orders_sync.py
+++ b/tests/app/api/test_kaspi_orders_sync.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta, timezone
 import pytest
 import sqlalchemy as sa
 
-from app.models import Order
+from app.models import Order, OrderItem
 from app.models.kaspi_order_sync_state import KaspiOrderSyncState
 from app.services.kaspi_service import KaspiService, KaspiSyncAlreadyRunning
 
@@ -23,6 +23,33 @@ def _orders_payload(total: int = 1100, status: str = "NEW") -> list[dict]:
             "totalPrice": total + 50,
             "customer": {"phone": "+7701", "name": "Jane"},
         },
+    ]
+
+
+def _orders_payload_with_items(total: int = 1100, status: str = "NEW") -> list[dict]:
+    return [
+        {
+            "id": "ext-1",
+            "status": status,
+            "totalPrice": total,
+            "customer": {"phone": "+7700", "name": "John"},
+            "items": [
+                {
+                    "productSku": "SKU-1",
+                    "productName": "Item One",
+                    "quantity": 1,
+                    "basePrice": 100,
+                    "totalPrice": 100,
+                },
+                {
+                    "productSku": "SKU-2",
+                    "productName": "Item Two",
+                    "quantity": 2,
+                    "basePrice": 150,
+                    "totalPrice": 300,
+                },
+            ],
+        }
     ]
 
 
@@ -147,6 +174,78 @@ async def test_status_and_total_are_updated(monkeypatch, async_client, async_db_
     assert str(order.total_amount) in {"1700", "1700.00"}
     status_value = order.status.value if hasattr(order.status, "value") else order.status
     assert status_value == "shipped"
+
+
+@pytest.mark.asyncio
+async def test_order_items_upsert_idempotent(monkeypatch, async_client, async_db_session, company_a_admin_headers):
+    async def fake_get_orders_initial(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return _orders_payload_with_items(status="NEW") if page == 1 else []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders_initial)
+
+    first = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert first.status_code == 200, first.text
+
+    async def fake_get_orders_second(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return _orders_payload_with_items(status="CONFIRMED") if page == 1 else []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders_second)
+    second = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert second.status_code == 200, second.text
+
+    res = await async_db_session.execute(sa.select(Order).where(Order.company_id == 1001, Order.external_id == "ext-1"))
+    order = res.scalar_one()
+
+    items_res = await async_db_session.execute(
+        sa.select(OrderItem).where(OrderItem.order_id == order.id).order_by(OrderItem.sku)
+    )
+    items = items_res.scalars().all()
+    assert len(items) == 2
+    assert {(it.sku, int(it.quantity)) for it in items} == {("SKU-1", 1), ("SKU-2", 2)}
+
+
+@pytest.mark.asyncio
+async def test_order_items_update_values(monkeypatch, async_client, async_db_session, company_a_admin_headers):
+    async def fake_get_orders_initial(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return _orders_payload_with_items(status="NEW") if page == 1 else []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders_initial)
+    first = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert first.status_code == 200, first.text
+
+    def _payload_updated():
+        payload = _orders_payload_with_items(status="SHIPPED")
+        payload[0]["items"][0]["quantity"] = 3
+        payload[0]["items"][0]["basePrice"] = 120
+        payload[0]["items"][0]["productName"] = "Item One Updated"
+        payload[0]["items"][1]["quantity"] = 1
+        payload[0]["items"][1]["basePrice"] = 200
+        payload[0]["items"][1]["totalPrice"] = 200
+        return payload
+
+    async def fake_get_orders_second(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return _payload_updated() if page == 1 else []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders_second)
+    second = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert second.status_code == 200, second.text
+
+    res = await async_db_session.execute(sa.select(Order).where(Order.company_id == 1001, Order.external_id == "ext-1"))
+    order = res.scalar_one()
+
+    items_res = await async_db_session.execute(
+        sa.select(OrderItem).where(OrderItem.order_id == order.id).order_by(OrderItem.sku)
+    )
+    items = items_res.scalars().all()
+    assert len(items) == 2
+
+    item_map = {it.sku: it for it in items}
+    assert int(item_map["SKU-1"].quantity) == 3
+    assert str(item_map["SKU-1"].unit_price) in {"120", "120.00"}
+    assert (item_map["SKU-1"].name or "").startswith("Item One Updated")
+
+    assert int(item_map["SKU-2"].quantity) == 1
+    assert str(item_map["SKU-2"].unit_price) in {"200", "200.00"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds unique constraint for order_items(order_id, sku) + migration. Kaspi orders sync upserts items to prevent duplicates; tests updated. Includes .gitignore for local branch protection JSON.