### PR TITLE
feat(kaspi): refresh order status + idempotent status history

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -473,3 +473,7 @@ Commits (per git show):
 - added: unique constraint order_items(order_id, sku) + migration 2d43c3d56e28_kaspi_unique_order_items_order_id_sku
 - changed: Kaspi orders sync now upserts OrderItem by (order_id, sku) to prevent duplicates; item fields update on conflict
 - tests: extended kaspi orders sync tests to cover item idempotency
+## [2026-01-06] Kaspi: order status refresh + idempotent status history
+- added: unique constraint for OrderStatusHistory to prevent duplicates by (order_id, status, changed_at) + migration 29a2929fc59b_kaspi_order_status_history_unique
+- changed: Kaspi orders sync refreshes Order status/updated_at from payload timestamps and records status history idempotently (ON CONFLICT DO NOTHING)
+- tests: extended kaspi orders sync tests to cover status updates + non-duplicating status history

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -959,6 +959,10 @@ class OrderStatusHistory(Base):
 
     order = relationship("Order", back_populates="status_history")
 
+    __table_args__ = (
+        UniqueConstraint("order_id", "new_status", "changed_at", name="uq__order_status_history__order_status_changed"),
+    )
+
     # -------- Снимки истории --------
     @staticmethod
     async def snapshot_for_order_async(session, order_id: int) -> list[dict[str, Any]]:

--- a/app/services/kaspi_service.py
+++ b/app/services/kaspi_service.py
@@ -22,12 +22,13 @@ import httpx
 from sqlalchemy import and_, literal_column, select, text
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.models import Order, OrderItem, Product
 from app.models.kaspi_order_sync_state import KaspiOrderSyncState
-from app.models.order import OrderSource
+from app.models.order import OrderSource, OrderStatus, OrderStatusHistory
 
 logger = get_logger(__name__)
 
@@ -288,7 +289,9 @@ class KaspiService:
                             total_amount = self._decimal_or_zero(
                                 payload.get("totalPrice") or payload.get("total_amount") or payload.get("total") or 0
                             )
-                            updated_ts = self._extract_order_timestamp(payload) or effective_to
+                            status_changed_at = self._extract_order_timestamp(payload)
+                            updated_ts = status_changed_at or effective_to
+                            effective_updated = updated_ts or now
 
                             stmt = (
                                 insert(Order)
@@ -306,7 +309,7 @@ class KaspiService:
                                     delivery_method=payload.get("deliveryMode") or payload.get("delivery_mode") or None,
                                     total_amount=total_amount,
                                     currency=currency,
-                                    updated_at=now,
+                                    updated_at=effective_updated,
                                 )
                                 .on_conflict_do_update(
                                     index_elements=[Order.company_id, Order.external_id],
@@ -324,7 +327,7 @@ class KaspiService:
                                         or None,
                                         "total_amount": total_amount,
                                         "currency": currency,
-                                        "updated_at": now,
+                                        "updated_at": effective_updated,
                                     },
                                 )
                                 .returning(Order.id, literal_column("xmax = 0").label("inserted"))
@@ -349,8 +352,18 @@ class KaspiService:
                                 last_ext = ext_id
                             made_progress = True
 
-                            await self._upsert_order_items(
+                            items_updated = await self._upsert_order_items(
                                 db, order_id=order_pk, company_id=company_id, payload=payload
+                            )
+
+                            if items_updated:
+                                await self._recalculate_order_totals(db, order_id=order_pk)
+
+                            await self._upsert_status_history(
+                                db,
+                                order_id=order_pk,
+                                new_status=mapped_status,
+                                changed_at=status_changed_at,
                             )
 
                         if len(batch) < 100:
@@ -399,12 +412,13 @@ class KaspiService:
         order_id: int,
         company_id: int,
         payload: dict[str, Any],
-    ) -> None:
+    ) -> bool:
         items = payload.get("items") or payload.get("orderItems") or []
         if not items:
-            return
+            return False
 
         now = _utcnow()
+        processed = False
 
         for item in items:
             sku = _as_str(item.get("productSku") or item.get("sku")).strip()
@@ -472,6 +486,54 @@ class KaspiService:
             )
 
             await db.execute(stmt)
+            processed = True
+
+        return processed
+
+    async def _recalculate_order_totals(self, db: AsyncSession, *, order_id: int) -> None:
+        res = await db.execute(select(Order).options(selectinload(Order.items)).where(Order.id == order_id))
+        order = res.scalar_one_or_none()
+        if not order:
+            return
+
+        try:
+            order.calculate_totals()
+        except Exception:
+            logger.exception("Kaspi: failed to recalc totals for order_id=%s", order_id)
+
+    async def _upsert_status_history(
+        self,
+        db: AsyncSession,
+        *,
+        order_id: int,
+        new_status: str | OrderStatus,
+        changed_at: datetime | None,
+    ) -> None:
+        if not changed_at:
+            return
+
+        status_enum: OrderStatus
+        if isinstance(new_status, OrderStatus):
+            status_enum = new_status
+        else:
+            try:
+                status_enum = OrderStatus(new_status)
+            except Exception:
+                status_enum = OrderStatus.PENDING
+
+        stmt = (
+            insert(OrderStatusHistory)
+            .values(order_id=order_id, old_status=status_enum, new_status=status_enum, changed_at=changed_at)
+            .on_conflict_do_nothing(
+                index_elements=[
+                    OrderStatusHistory.order_id,
+                    OrderStatusHistory.new_status,
+                    OrderStatusHistory.changed_at,
+                ]
+            )
+        )
+
+        await db.execute(stmt)
 
     async def _create_order_from_kaspi(
         self, kaspi_order: dict[str, Any], company_id: int, db: AsyncSession

--- a/migrations/versions/29a2929fc59b_kaspi_order_status_history_unique.py
+++ b/migrations/versions/29a2929fc59b_kaspi_order_status_history_unique.py
@@ -1,0 +1,31 @@
+"""kaspi: order status history unique
+
+Revision ID: 29a2929fc59b
+Revises: 2d43c3d56e28
+Create Date: 2026-01-06 09:19:55.527176+00:00
+
+"""
+from collections.abc import Sequence
+from typing import Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "29a2929fc59b"
+down_revision: Union[str, Sequence[str], None] = "2d43c3d56e28"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_unique_constraint(
+        "uq__order_status_history__order_status_changed",
+        "order_status_history",
+        ["order_id", "new_status", "changed_at"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint("uq__order_status_history__order_status_changed", "order_status_history", type_="unique")

--- a/tests/app/api/test_kaspi_orders_sync.py
+++ b/tests/app/api/test_kaspi_orders_sync.py
@@ -1,11 +1,12 @@
 import asyncio
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 import sqlalchemy as sa
 
 from app.models import Order, OrderItem
 from app.models.kaspi_order_sync_state import KaspiOrderSyncState
+from app.models.order import OrderStatusHistory
 from app.services.kaspi_service import KaspiService, KaspiSyncAlreadyRunning
 
 
@@ -48,6 +49,27 @@ def _orders_payload_with_items(total: int = 1100, status: str = "NEW") -> list[d
                     "basePrice": 150,
                     "totalPrice": 300,
                 },
+            ],
+        }
+    ]
+
+
+def _orders_payload_with_status_timestamp(status: str, ts: datetime) -> list[dict]:
+    return [
+        {
+            "id": "ext-1",
+            "status": status,
+            "updatedAt": ts.isoformat().replace("+00:00", "Z"),
+            "totalPrice": 100,
+            "customer": {"phone": "+7700", "name": "John"},
+            "items": [
+                {
+                    "productSku": "SKU-1",
+                    "productName": "Item One",
+                    "quantity": 1,
+                    "basePrice": 100,
+                    "totalPrice": 100,
+                }
             ],
         }
     ]
@@ -246,6 +268,44 @@ async def test_order_items_update_values(monkeypatch, async_client, async_db_ses
 
     assert int(item_map["SKU-2"].quantity) == 1
     assert str(item_map["SKU-2"].unit_price) in {"200", "200.00"}
+
+
+@pytest.mark.asyncio
+async def test_status_history_is_idempotent(monkeypatch, async_client, async_db_session, company_a_admin_headers):
+    ts1 = datetime(2025, 1, 1, 10, 0, tzinfo=UTC)
+    ts2 = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+
+    async def fake_get_orders_initial(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return _orders_payload_with_status_timestamp(status="NEW", ts=ts1) if page == 1 else []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders_initial)
+    first = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert first.status_code == 200, first.text
+
+    async def fake_get_orders_second(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return _orders_payload_with_status_timestamp(status="SHIPPED", ts=ts2) if page == 1 else []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders_second)
+    second = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert second.status_code == 200, second.text
+
+    third = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert third.status_code == 200, third.text
+
+    res = await async_db_session.execute(sa.select(Order).where(Order.company_id == 1001, Order.external_id == "ext-1"))
+    order = res.scalar_one()
+    status_value = order.status.value if hasattr(order.status, "value") else order.status
+    assert status_value == "shipped"
+
+    hist_res = await async_db_session.execute(
+        sa.select(OrderStatusHistory)
+        .where(OrderStatusHistory.order_id == order.id)
+        .order_by(OrderStatusHistory.changed_at)
+    )
+    history = hist_res.scalars().all()
+    assert len(history) == 2
+    statuses = [h.new_status.value if hasattr(h.new_status, "value") else h.new_status for h in history]
+    assert statuses == ["pending", "shipped"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Kaspi orders sync now refreshes Order status/updated_at from payload and records OrderStatusHistory idempotently (unique by order_id+status+changed_at, ON CONFLICT DO NOTHING). Includes focused migration 29a2929fc59b_kaspi_order_status_history_unique and tests.