### PR TITLE
feat(kaspi): harden orders sync (Retry-After + idempotency tests)

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -10,6 +10,17 @@
 
 ## [2026-01-04] Strip company_id inputs from v1
 
+## [2026-01-06] Kaspi retry-after + idempotency
+
+### Added
+- Retry-After support with jitter for Kaspi order fetch retries to reduce thundering herd.
+- Idempotency tests for Kaspi orders sync (duplicate runs, watermark progression, Retry-After handling).
+
+### Verified
+- python -m ruff check app/services/kaspi_service.py tests/app/api/test_kaspi_orders_sync.py
+- python -m pytest -q tests/app/api/test_kaspi_orders_sync.py
+
+
 ### Added
 - Guard coverage retained to detect any company_id Query/Path/Body/Field usage across v1 routes.
 

--- a/app/services/kaspi_service.py
+++ b/app/services/kaspi_service.py
@@ -14,6 +14,7 @@ Kaspi.kz integration: product feed generation, orders sync, and availability syn
 """
 
 import asyncio
+import random
 from collections.abc import AsyncIterator, Mapping
 from contextlib import nullcontext
 from datetime import UTC, datetime, timedelta
@@ -295,6 +296,7 @@ class KaspiService:
                         date_to=effective_to,
                         status=status,
                         page_size=100,
+                        company_id=company_id,
                     ):
                         fetched += len(batch)
                         for payload in batch:
@@ -560,6 +562,7 @@ class KaspiService:
         date_to: datetime,
         status: str | None,
         page_size: int,
+        company_id: int,
     ) -> AsyncIterator[list[dict[str, Any]]]:
         page = 1
 
@@ -570,6 +573,7 @@ class KaspiService:
                 status=status,
                 page=page,
                 page_size=page_size,
+                company_id=company_id,
             )
 
             items, meta = self._normalize_orders_response(batch, page, page_size)
@@ -591,6 +595,7 @@ class KaspiService:
         status: str | None,
         page: int,
         page_size: int,
+        company_id: int,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         attempts = 3
         delays = [0.2, 0.5, 1.0]
@@ -613,8 +618,35 @@ class KaspiService:
                 if not transient or is_last:
                     logger.error("Kaspi get_orders failed after retries: %s", e)
                     raise
+                retry_after_header = None
+                resp_obj = getattr(e, "response", None)
+                if isinstance(e, httpx.HTTPStatusError) and code == 429 and resp_obj is not None:
+                    try:
+                        retry_after_header = resp_obj.headers.get("Retry-After")
+                    except Exception:
+                        retry_after_header = None
                 delay = delays[attempt]
-                logger.warning("Kaspi get_orders transient %s, retrying in %ss", code or type(e).__name__, delay)
+                try:
+                    if retry_after_header is not None:
+                        delay = max(delay, float(retry_after_header))
+                except Exception:
+                    delay = delay
+                delay = delay + random.uniform(0, 0.2)
+                correlation_id = None
+                if resp_obj is not None:
+                    try:
+                        correlation_id = resp_obj.headers.get("X-Correlation-ID")
+                    except Exception:
+                        correlation_id = None
+                logger.warning(
+                    "Kaspi get_orders transient code=%s attempt=%s delay=%.2fs page=%s company_id=%s corr=%s",
+                    code or type(e).__name__,
+                    attempt + 1,
+                    delay,
+                    page,
+                    company_id,
+                    correlation_id,
+                )
                 await asyncio.sleep(delay)
 
         # Not reachable

--- a/tests/app/api/test_kaspi_orders_sync.py
+++ b/tests/app/api/test_kaspi_orders_sync.py
@@ -430,6 +430,95 @@ async def test_status_history_is_idempotent(monkeypatch, async_client, async_db_
 
 
 @pytest.mark.asyncio
+async def test_double_sync_idempotent_no_duplicates(monkeypatch, async_client, async_db_session, company_a_admin_headers):
+    payload = _orders_payload_with_items(status="NEW")
+
+    async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return payload if page == 1 else []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders)
+
+    first = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert first.status_code == 200, first.text
+
+    res_before = await async_db_session.execute(sa.select(sa.func.count()).select_from(Order))
+    items_before = await async_db_session.execute(sa.select(sa.func.count()).select_from(OrderItem))
+    hist_before = await async_db_session.execute(sa.select(sa.func.count()).select_from(OrderStatusHistory))
+
+    second = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert second.status_code == 200, second.text
+
+    res_after = await async_db_session.execute(sa.select(sa.func.count()).select_from(Order))
+    items_after = await async_db_session.execute(sa.select(sa.func.count()).select_from(OrderItem))
+    hist_after = await async_db_session.execute(sa.select(sa.func.count()).select_from(OrderStatusHistory))
+
+    assert res_before.scalar_one() == res_after.scalar_one()
+    assert items_before.scalar_one() == items_after.scalar_one()
+    assert hist_before.scalar_one() == hist_after.scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_watermark_moves_forward(monkeypatch, async_client, async_db_session, company_a_admin_headers):
+    ts1 = datetime(2025, 1, 1, 10, 0, tzinfo=UTC)
+    ts2 = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+
+    async def fake_get_orders_first(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return _orders_payload_with_status_timestamp(status="NEW", ts=ts1) if page == 1 else []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders_first)
+    first = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert first.status_code == 200, first.text
+
+    state_res = await async_db_session.execute(
+        sa.select(KaspiOrderSyncState).where(KaspiOrderSyncState.company_id == 1001)
+    )
+    state_first = state_res.scalar_one()
+
+    async def fake_get_orders_second(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return _orders_payload_with_status_timestamp(status="SHIPPED", ts=ts2) if page == 1 else []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders_second)
+    second = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert second.status_code == 200, second.text
+
+    state_res_second = await async_db_session.execute(
+        sa.select(KaspiOrderSyncState).where(KaspiOrderSyncState.company_id == 1001)
+    )
+    state_second = state_res_second.scalar_one()
+
+    assert state_second.last_synced_at is not None
+    assert state_first.last_synced_at is not None
+    assert state_second.last_synced_at >= state_first.last_synced_at
+
+
+@pytest.mark.asyncio
+async def test_retry_uses_retry_after_header(monkeypatch, async_client, async_db_session, company_a_admin_headers):
+    calls = {"n": 0, "sleep": []}
+
+    async def fake_sleep(delay):
+        calls["sleep"].append(delay)
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        calls["n"] += 1
+        if calls["n"] == 1:
+            req = httpx.Request("GET", "http://kaspi.test/orders")
+            resp = httpx.Response(429, headers={"Retry-After": "1"}, request=req)
+            raise httpx.HTTPStatusError("rate limited", request=req, response=resp)
+        return _orders_payload(status="NEW") if page == 1 else []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders)
+
+    resp = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert resp.status_code == 200, resp.text
+
+    assert calls["n"] == 2
+    assert calls["sleep"] and calls["sleep"][0] >= 1
+
+
+@pytest.mark.asyncio
 async def test_concurrent_sync_returns_409(monkeypatch, async_client, company_a_admin_headers):
     async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
         return _orders_payload() if page == 1 else []

--- a/tests/app/api/test_kaspi_orders_sync.py
+++ b/tests/app/api/test_kaspi_orders_sync.py
@@ -430,7 +430,9 @@ async def test_status_history_is_idempotent(monkeypatch, async_client, async_db_
 
 
 @pytest.mark.asyncio
-async def test_double_sync_idempotent_no_duplicates(monkeypatch, async_client, async_db_session, company_a_admin_headers):
+async def test_double_sync_idempotent_no_duplicates(
+    monkeypatch, async_client, async_db_session, company_a_admin_headers
+):
     payload = _orders_payload_with_items(status="NEW")
 
     async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001


### PR DESCRIPTION
Hardening Kaspi orders sync: respect Retry-After on 429 with jitter; add regression tests for double-sync idempotency (no duplicates) and watermark monotonicity. Verified locally: ruff + pytest (targeted + full).