### PR TITLE
feat(kaspi): sync state last_error persistence

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -1,3 +1,13 @@
+## [2026-01-06] Kaspi sync state last_error fields
+
+### Added
+- Persisted last_error_at/code/message on Kaspi sync failures with safe truncation and stable codes.
+- Cleared last_error_* on success; state endpoint now returns persisted error metadata.
+- Coverage for error persistence and clearing.
+
+### Verified
+- python -m pytest -q tests/app/api/test_kaspi_orders_sync.py
+
 ## [2026-01-06] Kaspi sync hardening: advisory lock + state endpoint
 
 ### Added

--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -51,7 +51,7 @@ from app.schemas.kaspi import (
     KaspiTokenOut,
     OrdersQuery,
 )
-from app.services.kaspi_service import KaspiService, KaspiSyncAlreadyRunning
+from app.services.kaspi_service import KaspiService, KaspiSyncAlreadyRunning, _safe_error_message, _utcnow
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/kaspi", tags=["kaspi"])
@@ -351,6 +351,7 @@ async def kaspi_orders_sync(
     session: AsyncSession = Depends(get_async_db),
 ):
     resolved_company_id: int | None = None
+    svc: KaspiService | None = None
     try:
         resolved_company_id = _resolve_company_id(current_user)
         svc = KaspiService()
@@ -362,11 +363,28 @@ async def kaspi_orders_sync(
         return result
     except KaspiSyncAlreadyRunning:
         raise HTTPException(status_code=status.HTTP_423_LOCKED, detail="kaspi sync already running")
-    except RuntimeError as e:
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e))
     except Exception as e:
+        try:
+            await session.rollback()
+        except Exception:
+            pass
+        if resolved_company_id is not None:
+            try:
+                svc = svc or KaspiService()
+                await svc.record_sync_error(
+                    session,
+                    company_id=resolved_company_id,
+                    code=svc.classify_sync_error(e),
+                    message=_safe_error_message(e),
+                    occurred_at=_utcnow(),
+                )
+                await session.commit()
+            except Exception:
+                logger.exception(
+                    "Kaspi orders sync: failed to persist error state for company_id=%s", resolved_company_id
+                )
         logger.error("Kaspi orders sync failed: company_id=%s err=%s", resolved_company_id, e)
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e))
 
 
 @router.get(
@@ -462,12 +480,15 @@ async def kaspi_orders_sync_state(
     state = res.scalar_one_or_none()
     watermark = getattr(state, "last_synced_at", None) if state else None
     last_success_at = getattr(state, "last_synced_at", None) if state else None
+    last_error_at = getattr(state, "last_error_at", None) if state else None
+    last_error_code = getattr(state, "last_error_code", None) if state else None
+    last_error_message = getattr(state, "last_error_message", None) if state else None
     return KaspiSyncStateOut(
         watermark=watermark,
         last_success_at=last_success_at,
-        last_error_at=None,
-        last_error_code=None,
-        last_error_message=None,
+        last_error_at=last_error_at,
+        last_error_code=last_error_code,
+        last_error_message=last_error_message,
     )
 
 

--- a/app/models/kaspi_order_sync_state.py
+++ b/app/models/kaspi_order_sync_state.py
@@ -15,6 +15,9 @@ class KaspiOrderSyncState(Base):
     company_id = Column(ForeignKey("companies.id", ondelete="CASCADE"), nullable=False)
     last_synced_at = Column(DateTime, nullable=True)
     last_external_order_id = Column(String(128), nullable=True)
+    last_error_at = Column(DateTime, nullable=True)
+    last_error_code = Column(String(64), nullable=True)
+    last_error_message = Column(String(500), nullable=True)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
 
     company = relationship("Company", backref="kaspi_sync_state")

--- a/app/services/kaspi_service.py
+++ b/app/services/kaspi_service.py
@@ -31,6 +31,7 @@ from sqlalchemy.orm import selectinload
 
 from app.core.config import settings
 from app.core.logging import get_logger
+from app.integrations.kaspi_adapter import KaspiAdapterError
 from app.models import Order, OrderItem, Product
 from app.models.kaspi_order_sync_state import KaspiOrderSyncState
 from app.models.order import OrderSource, OrderStatus, OrderStatusHistory
@@ -52,6 +53,11 @@ def _utcnow() -> datetime:
 
 def _as_str(v: Any) -> str:
     return "" if v is None else str(v)
+
+
+def _safe_error_message(exc: Exception, limit: int = 500) -> str:
+    msg = str(exc) or exc.__class__.__name__
+    return msg[:limit]
 
 
 def _first_present(data: Mapping[str, Any], *keys: str) -> Any | None:
@@ -405,6 +411,9 @@ class KaspiService:
                         state.last_external_order_id = prev_last_ext
 
                     state.updated_at = now
+                    state.last_error_at = None
+                    state.last_error_code = None
+                    state.last_error_message = None
         except KaspiSyncAlreadyRunning:
             logger.warning(
                 "Kaspi orders sync locked: company_id=%s request_id=%s duration_ms=%s",
@@ -830,6 +839,57 @@ class KaspiService:
                 await db.execute(text("SELECT pg_advisory_unlock(:lock_key)").bindparams(lock_key=lock_key))
             except Exception:
                 pass
+
+    def _classify_sync_error(self, exc: Exception) -> str:
+        if isinstance(exc, httpx.TimeoutException):
+            return "kaspi_timeout"
+        if isinstance(exc, httpx.HTTPStatusError):
+            try:
+                status = exc.response.status_code
+                return f"kaspi_http_{status}"
+            except Exception:
+                return "kaspi_http_error"
+        if isinstance(exc, httpx.HTTPError):
+            return "kaspi_http_error"
+        if isinstance(exc, KaspiAdapterError):
+            return "kaspi_adapter_error"
+        return "internal_error"
+
+    def classify_sync_error(self, exc: Exception) -> str:
+        return self._classify_sync_error(exc)
+
+    async def _record_sync_error(
+        self,
+        db: AsyncSession,
+        *,
+        company_id: int,
+        code: str,
+        message: str,
+        occurred_at: datetime,
+    ) -> None:
+        if db.in_transaction():
+            try:
+                await db.rollback()
+            except Exception:
+                pass
+        tx_ctx = nullcontext() if db.in_transaction() else db.begin()
+        async with tx_ctx:
+            state = await self._load_or_create_state(db, company_id)
+            state.last_error_at = occurred_at
+            state.last_error_code = code
+            state.last_error_message = message[:500] if message else None
+            state.updated_at = occurred_at
+
+    async def record_sync_error(
+        self,
+        db: AsyncSession,
+        *,
+        company_id: int,
+        code: str,
+        message: str,
+        occurred_at: datetime,
+    ) -> None:
+        await self._record_sync_error(db, company_id=company_id, code=code, message=message, occurred_at=occurred_at)
 
     async def _acquire_company_lock(self, db: AsyncSession, company_id: int) -> None:
         # Legacy helper preserved for compatibility; delegates to session-level advisory lock

--- a/migrations/versions/3a4e0c5f9c2b_kaspi_sync_state_last_error_fields.py
+++ b/migrations/versions/3a4e0c5f9c2b_kaspi_sync_state_last_error_fields.py
@@ -1,0 +1,30 @@
+"""kaspi: add last error fields to sync state
+
+Revision ID: 3a4e0c5f9c2b
+Revises: 29a2929fc59b
+Create Date: 2026-01-06 21:10:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "3a4e0c5f9c2b"
+down_revision: Union[str, Sequence[str], None] = "29a2929fc59b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("kaspi_order_sync_state", sa.Column("last_error_at", sa.DateTime(), nullable=True))
+    op.add_column("kaspi_order_sync_state", sa.Column("last_error_code", sa.String(length=64), nullable=True))
+    op.add_column("kaspi_order_sync_state", sa.Column("last_error_message", sa.String(length=500), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("kaspi_order_sync_state", "last_error_message")
+    op.drop_column("kaspi_order_sync_state", "last_error_code")
+    op.drop_column("kaspi_order_sync_state", "last_error_at")

--- a/tests/app/api/test_kaspi_orders_sync.py
+++ b/tests/app/api/test_kaspi_orders_sync.py
@@ -565,3 +565,47 @@ async def test_sync_state_endpoint_reflects_watermark(monkeypatch, async_client,
     assert data["last_error_at"] is None
     assert data["last_error_code"] is None
     assert data["last_error_message"] is None
+
+
+@pytest.mark.asyncio
+async def test_sync_state_records_last_error(monkeypatch, async_client, company_a_admin_headers):
+    async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        raise RuntimeError("kaspi boom")
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders)
+
+    resp = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert resp.status_code in {500, 502}
+
+    state_resp = await async_client.get("/api/v1/kaspi/orders/sync/state", headers=company_a_admin_headers)
+    assert state_resp.status_code == 200
+    data = state_resp.json()
+    assert data["last_error_code"] == "internal_error"
+    assert data["last_error_at"] is not None
+    assert data["last_error_message"] and "kaspi" in data["last_error_message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_sync_state_clears_last_error_after_success(monkeypatch, async_client, company_a_admin_headers):
+    calls = {"fail": True}
+
+    async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        if calls["fail"]:
+            calls["fail"] = False
+            raise RuntimeError("kaspi temporary")
+        return _orders_payload(status="NEW") if page == 1 else []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders)
+
+    first = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert first.status_code in {500, 502}
+
+    second = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert second.status_code == 200, second.text
+
+    state_resp = await async_client.get("/api/v1/kaspi/orders/sync/state", headers=company_a_admin_headers)
+    assert state_resp.status_code == 200
+    data = state_resp.json()
+    assert data["last_error_code"] is None
+    assert data["last_error_message"] is None
+    assert data["last_error_at"] is None


### PR DESCRIPTION
Persists Kaspi orders sync failure metadata (last_error_at/code/message) in KaspiOrderSyncState and exposes it via /api/v1/kaspi/orders/sync/state. Clears last_error_* on success. Adds migration + tests and updates PROJECT_JOURNAL.