### PR TITLE
feat(kaspi): proper HTTP statuses for orders sync (429/504/500) + safe errors

### DIFF
--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -27,6 +27,7 @@ app/api/v1/kaspi.py — Полный, боевой роутер интеграц
 """
 
 import logging
+from datetime import datetime
 from typing import Any
 
 import sqlalchemy as sa
@@ -36,6 +37,7 @@ from sqlalchemy import bindparam, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_async_db  # noqa — для совместимости импорт-алиас
+from app.core.errors import safe_error_message
 from app.core.security import get_current_user, resolve_tenant_company_id
 
 # Доменные зависимости/схемы:
@@ -51,7 +53,7 @@ from app.schemas.kaspi import (
     KaspiTokenOut,
     OrdersQuery,
 )
-from app.services.kaspi_service import KaspiService, KaspiSyncAlreadyRunning, _safe_error_message, _utcnow
+from app.services.kaspi_service import KaspiService, KaspiSyncAlreadyRunning
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/kaspi", tags=["kaspi"])
@@ -371,20 +373,37 @@ async def kaspi_orders_sync(
         if resolved_company_id is not None:
             try:
                 svc = svc or KaspiService()
+                error_code = svc.classify_sync_error(e)
                 await svc.record_sync_error(
                     session,
                     company_id=resolved_company_id,
-                    code=svc.classify_sync_error(e),
-                    message=_safe_error_message(e),
-                    occurred_at=_utcnow(),
+                    code=error_code,
+                    message=safe_error_message(e),
+                    occurred_at=datetime.utcnow(),
                 )
                 await session.commit()
             except Exception:
                 logger.exception(
                     "Kaspi orders sync: failed to persist error state for company_id=%s", resolved_company_id
                 )
-        logger.error("Kaspi orders sync failed: company_id=%s err=%s", resolved_company_id, e)
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e))
+        svc = svc or KaspiService()
+        error_code = svc.classify_sync_error(e)
+        retry_after = svc.get_retry_after_seconds(e)
+        logger.error("Kaspi orders sync failed: company_id=%s code=%s err=%s", resolved_company_id, error_code, e)
+
+        if error_code == "kaspi_http_429":
+            headers = {"Retry-After": str(retry_after)} if retry_after is not None else None
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="kaspi rate limited", headers=headers
+            )
+
+        if error_code == "kaspi_timeout":
+            raise HTTPException(status_code=status.HTTP_504_GATEWAY_TIMEOUT, detail="kaspi timeout")
+
+        if error_code.startswith("kaspi_http_") or error_code == "kaspi_adapter_error":
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi upstream error")
+
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="kaspi sync failed")
 
 
 @router.get(

--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+def safe_error_message(exc: Exception, limit: int = 500) -> str:
+    msg = str(exc) or exc.__class__.__name__
+    return msg[:limit]

--- a/app/services/kaspi_service.py
+++ b/app/services/kaspi_service.py
@@ -55,11 +55,6 @@ def _as_str(v: Any) -> str:
     return "" if v is None else str(v)
 
 
-def _safe_error_message(exc: Exception, limit: int = 500) -> str:
-    msg = str(exc) or exc.__class__.__name__
-    return msg[:limit]
-
-
 def _first_present(data: Mapping[str, Any], *keys: str) -> Any | None:
     for key in keys:
         if key in data:
@@ -857,6 +852,17 @@ class KaspiService:
 
     def classify_sync_error(self, exc: Exception) -> str:
         return self._classify_sync_error(exc)
+
+    def get_retry_after_seconds(self, exc: Exception) -> int | None:
+        if isinstance(exc, httpx.HTTPStatusError):
+            try:
+                value = exc.response.headers.get("Retry-After")
+                if value is None:
+                    return None
+                return int(value)
+            except Exception:
+                return None
+        return None
 
     async def _record_sync_error(
         self,

--- a/tests/app/api/test_kaspi_orders_sync.py
+++ b/tests/app/api/test_kaspi_orders_sync.py
@@ -609,3 +609,43 @@ async def test_sync_state_clears_last_error_after_success(monkeypatch, async_cli
     assert data["last_error_code"] is None
     assert data["last_error_message"] is None
     assert data["last_error_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_sync_returns_429_with_retry_after(monkeypatch, async_client, company_a_admin_headers):
+    async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        req = httpx.Request("GET", "http://kaspi.test/orders")
+        resp = httpx.Response(429, headers={"Retry-After": "7"}, request=req)
+        raise httpx.HTTPStatusError("rate limited", request=req, response=resp)
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders)
+
+    resp = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert resp.status_code == 429
+    assert resp.headers.get("Retry-After") == "7"
+    assert "rate" in resp.json().get("detail", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_sync_timeout_maps_to_504(monkeypatch, async_client, company_a_admin_headers):
+    async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        raise httpx.TimeoutException("kaspi timeout")
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders)
+
+    resp = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert resp.status_code == 504
+    assert "timeout" in resp.json().get("detail", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_sync_internal_error_is_generic(monkeypatch, async_client, company_a_admin_headers):
+    async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        raise RuntimeError("secret boom")
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders)
+
+    resp = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert resp.status_code == 500
+    body = resp.json()
+    assert "boom" not in str(body.get("detail", "")).lower()


### PR DESCRIPTION
Maps Kaspi orders sync failures to correct HTTP statuses (429 with Retry-After, 504 for timeouts, 500 for internal). Moves safe error helpers to app/core/errors.py and adds tests. Ruff + pytest green.