### PR TITLE
docs(journal): backfill history + coverage report

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -695,4 +695,3 @@ Commits (per git show):
 - python -m ruff check app tests
 - pytest -q *(fails: missing wallet_accounts/wallet_ledger/wallet_payments tables after alembic upgrade in test DB)*
 
->>>>>>> Stashed changes

--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -1,5 +1,3 @@
-<<<<<<< Updated upstream
-=======
 ## [2025-09-11] Repo bootstrap
 
 ### Added
@@ -21,7 +19,6 @@
 - python -m ruff check app tests
 - pytest -q *(fails: missing wallet_accounts/wallet_ledger/wallet_payments tables after alembic upgrade in test DB)*
 
->>>>>>> Stashed changes
 ## [2026-01-06] Kaspi sync state last_error fields
 
 ### Added

--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -1,3 +1,27 @@
+<<<<<<< Updated upstream
+=======
+## [2025-09-11] Repo bootstrap
+
+### Added
+- Repo created from uploaded archive (files 10.zip), immediately unpacked then replaced with a clean FastAPI/Alembic project skeleton (billing, wallet, payments, product models; routes; alembic baseline 20230910_161100_init; tests) per commits 0d718e6 → d575070.
+- Dockerfile, docker-compose, CI workflow, and pytest scaffolding seeded from the cleaned structure.
+
+### Notes
+- Earlier SmartSell work lived in other repositories and was migrated here before this initial upload; this repo’s history starts from the imported archive.
+
+## [2026-01-06] Kaspi sync state metrics
+
+### Added
+- Persisted Kaspi sync state metrics: last_attempt_at, last_duration_ms, last_result, last_fetched/inserted/updated with success/failure/locked outcomes and safe error recording.
+- `/api/v1/kaspi/orders/sync/state` returns persisted metrics and error info; schemas updated accordingly.
+- Coverage for defaults, success, failure, and locked runs with state assertions.
+
+### Verified
+- python -m ruff format app tests
+- python -m ruff check app tests
+- pytest -q *(fails: missing wallet_accounts/wallet_ledger/wallet_payments tables after alembic upgrade in test DB)*
+
+>>>>>>> Stashed changes
 ## [2026-01-06] Kaspi sync state last_error fields
 
 ### Added
@@ -153,6 +177,19 @@ Commits (per git show):
 ## [2025-12-30] Tests/Style
 - resolve ruff pyupgrade warnings (isinstance unions) and fix conftest lint/UP038 issues
 
+## [2025-12-28] DB/CI cleanup and artifact hygiene
+
+### Changed
+- Pinned security scan workflow (trivy-action 0.33.1) and ignored bulky local scan artifacts to keep pipelines stable (84bd528, 7c81655).
+- Widened alembic_version length and hardened offline migrations/tests; improved ICU reset defaults (kk-KZ-x-icu) and documented UTF-8 workflow with utf8_probe script (a1b9c36, b58fba1, 3211767).
+- Removed generated DB_SETUP reports and repository artifacts to keep the tree clean (abc2b84, c5e30c4, 32212d0).
+
+### Fixed
+- Addressed pydantic/sqlalchemy deprecation warnings and stabilized test rollback behavior (5647f30).
+
+### Notes
+- Security/CI pinning and DB cleanup done ahead of end-of-year releases.
+
 ## [2025-12-29] Repo/DB
 - enforce strict ruff+pytest gate (mypy soft-fail); clean legacy migration archives and ignore paths
 - stabilize DB URL resolution and guard default DB usage; normalize drivers and debug route gating
@@ -213,6 +250,108 @@ Commits (per git show):
 - added: `integration_provider_configs` table with encrypted payloads + key metadata; service-layer set/get/redaction/healthcheck; admin API endpoints for config read/write/healthcheck with idempotency and events; healthcheck resilient to redis failure; migration test added
 - tests: config redaction/no secret leakage, healthcheck survives redis down, provider switch still works with resolver after config writes; alembic upgrade head smoke test
 
+## [2025-12-25] Auth hardening and token fixes
+
+### Fixed
+- change_password now verifies current password and revokes sessions; token generation and OTP audit stabilized; user name properties corrected (ec1d322, ec34c2a, cbf38d4).
+
+### Changed
+- Ignored local test output artifacts to keep the tree clean (75e3e30).
+
+### Notes
+- Auth/e2e/campaign tests were updated to run via async_client with dependency overrides earlier in the week (5b655f2).
+
+## [2025-12-24] Auth router + Alembic-first schema
+
+### Added
+- Mounted real `/api/auth` router and implemented `/api/auth/me`; bootstrap_schema.py marked DEV-ONLY and temp files ignored (a032613, 451e843, 5fc6770).
+
+### Changed
+- Disabled runtime create_all; enforced Alembic-managed schema and switched tests to `alembic upgrade head` (973f803, 78b70a3).
+- Baseline migration corrected (deferred FKs, JSONB) and audit logger/bootstrap schema fixes (0c2ee83, b2793f0).
+
+### Notes
+- Campaign/auth/test wiring moved to dependency overrides for async sessions (5b655f2).
+
+## [2025-12-23] API cleanup before auth/migration repair
+
+### Changed
+- Unified auth routing and removed legacy routers/duplicate models; aligned DB bootstrap and Kaspi/subscription models (7efbaac).
+- WIP migration order and async/sync session fixes started (c54aebd).
+
+### Notes
+- Auth/e2e/campaign tests adjusted to async_client with dependency overrides to unblock CI (5b655f2).
+
+## [2025-12-13] Repo re-import for dev/main alignment
+
+### Added
+- Re-imported full FastAPI stack (API v1, services, Alembic backups, frontend, tests, docs) with CI/CD/security workflows and alembic backups under _alembic_backup (1ed689e).
+- Preserved legacy migrations/quarantine scripts for reference while preparing dev/main alignment.
+
+### Notes
+- Snapshot kept on backup/main-before-dev-2025-12-26.
+
+## [2025-10-13] Repository hygiene and ignore normalization
+
+### Changed
+- Dropped committed venv/local DB artifacts; hardened .gitignore and .gitattributes; merged feat/all-in-one and backup/pre-sync snapshots (7842477, 9c9f7db, faca159, 603fc8c).
+- Created sync-20251013-0105 tag/backups to preserve state before merging ignore changes (bbe70c5).
+
+### Notes
+- Upstream ignore files from origin/main were preserved for comparison.
+
+## [2025-10-12] Ignore and attributes cleanup
+
+### Changed
+- Cleaned and reorganized .gitignore entries (a720bbf) and clarified .gitattributes (f8a13ae) to reduce churn ahead of snapshotting.
+
+## [2025-10-03] Git attributes and CI hygiene
+
+### Changed
+- Refined .gitattributes for consistent text handling and merged feat/all-in-one via PR #1 (eec8b9d, df68d99, 724c3f1).
+- Split CI/CD/security workflows and marked skip-CI/WIP commits while cleanup was in progress (11103bd, 5cb839e, 09f763b, 2aecba5).
+
+## [2025-10-02] Initial SmartSell sync import
+
+### Added
+- Imported full FastAPI application with auth, campaigns, wallet/payments, OTP (Mobizon), Kaspi service, services/workers, Alembic migrations, and frontend scaffold (f24b8f9).
+- Introduced CI/CD/security workflows, env templates, Makefile, requirements, and compliance/licensing docs; added database fixtures and tools.
+
+### Changed
+- Split CI/CD/security workflows and hardened .gitignore (local db/venv dropped) (11103bd, 7842477).
+
+## [2025-09-16] Python 3.11 target
+
+### Changed
+- Set toolchain to Python 3.11 in setup.cfg, pyproject, and .python-version (7791c66, 3c0b339, 95bede3).
+
+## [2025-09-17] Python 3.11 baseline and repo cleanup
+
+### Changed
+- Standardized Python target to 3.11 across setup.cfg, pyproject, and .python-version (7791c66, 95bede3).
+- Removed .github bot directory, app/core, and bot usage docs to restart from a cleaned stack (2aa2c48, 5440097, b1a9989, 530387c, 5a3c89f).
+
+## [2025-09-13] Bot automation and specs
+
+### Added
+- SmartSell Bot automation workflows with status/permissions checks and conflict-resolution commands; bot automation documentation (a27ef98, 6dc7248, 5ceb026, f375647).
+- Added SmartSell Bot system instructions and platform specs (ТЗ на Flask / ТЗ на FastAPI) and GitHub Actions bot automation (1065091).
+
+### Removed
+- Legacy backend files cleared to restart clean (0ee7668).
+
+### Notes
+- Multiple Copilot fix PRs merged to stabilize bot workflow.
+
+## [2025-09-12] FastAPI app + CI scaffolding
+
+### Added
+- Defined FastAPI app in app/main.py and aligned conftest imports; requirements updated for FastAPI dependencies; Swagger setup refactored (db3a10a, 70edd76, 4cfdf03, fa175a8).
+- Added GitHub Actions auto-merge workflow and CI config to gate PRs (affde9b, 432c9be, 325d691).
+
+### Notes
+- Early CI adjustments kept dependency overrides working for tests (d6ecc04).
+
 ## [2025-12-31] Docs/env
 
 ### Added
@@ -240,6 +379,19 @@ Commits (per git show):
 
 ### Notes
 - main and dev are aligned and CI is green.
+
+
+## [2026-01-02] Tenant scoping expansion + CI stability
+
+### Added
+- Tenant-scoped wallet/payments/subscriptions APIs and isolation tests landed (ca7e08b, b7db8e0, fdbeb42).
+
+### Changed
+- Standardized DB names for main/test and removed probe DB references; lazy-init wallet/payments storage and fail-fast imports to keep CI stable (1caeea1, 807f268, f1f3c24).
+- Added safe_inspect fallback for offline Alembic and stabilized billing tenant tests; formatted wallet/payments tenant tests (32b6e1b, fedb8c7).
+
+### Notes
+- Local audit/report artifacts were removed from version control to keep the tree clean (c5e30c4, 32212d0).
 
 
 ## [2026-01-03] Migrations + Tenant Isolation (Invoices/Subscriptions) + CI green
@@ -520,3 +672,15 @@ Commits (per git show):
 - added: unique constraint for OrderStatusHistory to prevent duplicates by (order_id, status, changed_at) + migration 29a2929fc59b_kaspi_order_status_history_unique
 - changed: Kaspi orders sync refreshes Order status/updated_at from payload timestamps and records status history idempotently (ON CONFLICT DO NOTHING)
 - tests: extended kaspi orders sync tests to cover status updates + non-duplicating status history
+
+## [2026-01-07] Current project state snapshot
+
+### Notes
+- API v1 is async-only (AsyncSession deps) with tenant scoping centralized in `resolve_tenant_company_id`; platform-admin overrides removed across wallet/payments/billing/campaigns/analytics/kaspi.
+- Integration Center supports provider config storage and resolver hot-switching for OTP/messaging/payments with admin endpoints and health checks.
+- Kaspi orders sync MVP ships with advisory lock, incremental watermarking, idempotent items/status history, and persisted sync metrics/error fields exposed via `/api/v1/kaspi/orders/sync/state`.
+- CI baseline relies on ruff format/check + pytest gates; Alembic smoke runs and v0.1.0/v0.1.1 releases are published; latest feature branch builds inherit the green baseline from 2026-01-06 checks.
+- Migrations cover wallet/payments tenant scope, kaspi state metrics, and offline-safe patterns; DB URL resolution is deterministic for async engines.
+
+### Verified
+- HEAD 8b36cc5 (feat/kaspi-sync-state-metrics-v1); rerun full suite (`python -m ruff format --check app tests tools`, `python -m ruff check app tests tools`, `python -m pytest -q`) after further changes.

--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -681,3 +681,18 @@ Commits (per git show):
 
 ### Verified
 - HEAD 8b36cc5 (feat/kaspi-sync-state-metrics-v1); rerun full suite (`python -m ruff format --check app tests tools`, `python -m ruff check app tests tools`, `python -m pytest -q`) after further changes.
+
+## [2026-01-06] Kaspi sync state metrics (Recovered from c60547e^)
+
+
+### Added
+- Persisted Kaspi sync state metrics: last_attempt_at, last_duration_ms, last_result, last_fetched/inserted/updated with success/failure/locked outcomes and safe error recording.
+- `/api/v1/kaspi/orders/sync/state` returns persisted metrics and error info; schemas updated accordingly.
+- Coverage for defaults, success, failure, and locked runs with state assertions.
+
+### Verified
+- python -m ruff format app tests
+- python -m ruff check app tests
+- pytest -q *(fails: missing wallet_accounts/wallet_ledger/wallet_payments tables after alembic upgrade in test DB)*
+
+>>>>>>> Stashed changes

--- a/docs/journal_audit/JOURNAL_COVERAGE_REPORT.md
+++ b/docs/journal_audit/JOURNAL_COVERAGE_REPORT.md
@@ -1,0 +1,35 @@
+# JOURNAL_COVERAGE_REPORT
+
+- BASE_SHA: 0d718e6520b28ff8302939fa0f63b34c9e7c2b97 (Add files via upload, 2025-09-11; earliest root in history)
+- HEAD: 8b36cc5912f7f03483b44ae90f099387a75ae643 (feat/kaspi-sync-state-metrics-v1, 2026-01-07)
+- Commits analyzed: 345 (git rev-list --all --count)
+- PR merges analyzed (git log --merges --all): 79
+
+Dates with commits but no journal entry in the prior snapshot
+- 2025-09-11, 2025-09-12, 2025-09-13, 2025-09-16, 2025-09-17
+- 2025-10-02, 2025-10-03, 2025-10-12, 2025-10-13
+- 2025-12-13, 2025-12-23, 2025-12-24, 2025-12-25, 2025-12-28
+- 2026-01-02, 2026-01-07
+
+Entries added during this pass
+- 2026-01-07 Current project state snapshot
+- 2026-01-02 Tenant scoping expansion + CI stability
+- 2025-12-28 DB/CI cleanup and artifact hygiene
+- 2025-12-25 Auth hardening and token fixes
+- 2025-12-24 Auth router + Alembic-first schema
+- 2025-12-23 API cleanup before auth/migration repair
+- 2025-12-13 Repo re-import for dev/main alignment
+- 2025-10-13 Repository hygiene and ignore normalization
+- 2025-10-12 Ignore and attributes cleanup
+- 2025-10-03 Git attributes and CI hygiene
+- 2025-10-02 Initial SmartSell sync import
+- 2025-09-17 Python 3.11 baseline and repo cleanup
+- 2025-09-16 Python 3.11 target
+- 2025-09-13 Bot automation and specs
+- 2025-09-12 FastAPI app + CI scaffolding
+- 2025-09-11 Repo bootstrap
+
+Remaining uncertainty
+- Repository has four root commits; BASE_SHA chosen as earliest by date (0d718e6) though other roots exist (31e6dba, 1ed689e, 4fa2694).
+- PR metadata beyond merge commit titles is not stored locally; descriptions rely on commit messages and file paths.
+- WIP commits (e.g., c54aebd on 2025-12-23) documented at a high level; fine-grained intent may need PR context from GitHub.


### PR DESCRIPTION
Backfills PROJECT_JOURNAL.md from repo birth (0d718e6) to HEAD. Adds docs/journal_audit/JOURNAL_COVERAGE_REPORT.md with coverage and uncertainties (multi-root history).