### PR TITLE
ci(security): run on dev/release and normalize LF

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,9 +2,9 @@ name: Security Scan
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, dev, "release/**" ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, dev, "release/**" ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Fix Security Scan triggers to match real branches (dev, release/**) and normalize line endings to LF to stop CRLF drift on Windows.