### PR TITLE
chore(git): EOL policy via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,108 @@
-*.yml  text eol=lf
-*.yaml text eol=lf
+# =========================
+# Global defaults (UTF-8 + LF)
+# =========================
+# Все текстовые файлы по умолчанию считаем текстом, нормализуем переводы строк в LF
+# и указываем кодировку рабочих файлов как UTF-8.
+* text=auto eol=lf working-tree-encoding=UTF-8
+
+# =========================
+# Python
+# =========================
+*.py     text eol=lf
+
+# =========================
+# Config / CI
+# =========================
+*.yml    text eol=lf
+*.yaml   text eol=lf
+*.toml   text eol=lf
+*.json   text eol=lf
+*.env    text eol=lf
+*.ini    text eol=lf
+*.cfg    text eol=lf
+
+# =========================
+# Shell / scripts
+# =========================
+*.sh     text eol=lf
+# Windows-скрипты: CRLF, но всё равно UTF-8 в рабочем дереве
+*.ps1    text eol=crlf working-tree-encoding=UTF-8
+*.bat    text eol=crlf working-tree-encoding=UTF-8
+*.cmd    text eol=crlf working-tree-encoding=UTF-8
+
+# =========================
+# Web / frontend
+# =========================
+*.js     text eol=lf
+*.mjs    text eol=lf
+*.cjs    text eol=lf
+*.ts     text eol=lf
+*.jsx    text eol=lf
+*.tsx    text eol=lf
+*.css    text eol=lf
+*.scss   text eol=lf
+*.sass   text eol=lf
+*.less   text eol=lf
+*.html   text eol=lf
+*.svg    text eol=lf
+
+# =========================
+# Docs / text
+# =========================
+*.md     text eol=lf
+*.rst    text eol=lf
+*.txt    text eol=lf
+LICENSE  text eol=lf
+
+# =========================
+# SQL / data (текстовая)
+# =========================
+*.sql    text eol=lf
+*.csv    text eol=lf
+*.tsv    text eol=lf
+
+# =========================
+# Alembic bytecode cache (версии коммитим, кэш — нет diff)
+# =========================
+migrations/versions/__pycache__/* text eol=lf -diff
+
+# =========================
+# Binary & archives (никогда не перекодировать/не диффить)
+# =========================
+*.png    -text -diff
+*.jpg    -text -diff
+*.jpeg   -text -diff
+*.gif    -text -diff
+*.webp   -text -diff
+*.ico    -text -diff
+*.pdf    -text -diff
+*.zip    -text -diff
+*.tar    -text -diff
+*.gz     -text -diff
+*.bz2    -text -diff
+*.xz     -text -diff
+*.7z     -text -diff
+*.rar    -text -diff
+*.mp3    -text -diff
+*.wav    -text -diff
+*.mp4    -text -diff
+*.mov    -text -diff
+*.avi    -text -diff
+*.wmv    -text -diff
+*.flac   -text -diff
+*.ogg    -text -diff
+*.wasm   -text -diff
+
+# Шрифты
+*.ttf    -text -diff
+*.otf    -text -diff
+*.woff   -text -diff
+*.woff2  -text -diff
+
+# Бинарные БД/слепки/прочее
+*.sqlite* -text -diff
+*.db      -text -diff
+*.bak     -text -diff
+*.dmp     -text -diff
+*.dump    -text -diff
+


### PR DESCRIPTION
Enforces LF by default and CRLF only for Windows scripts to stop phantom diffs on Windows. Fixes cache path to migrations/versions.