### PR TITLE
fix(kaspi): autosync default-off + disabled guards

### DIFF
--- a/KASPI_AUTOSYNC_IMPLEMENTATION.md
+++ b/KASPI_AUTOSYNC_IMPLEMENTATION.md
@@ -20,7 +20,7 @@ Production-grade background job for automatic synchronization of Kaspi orders ac
 
 ```python
 KASPI_AUTOSYNC_ENABLED: bool = Field(
-    default=True, 
+    default=False,  # Disabled by default for production safety
     description="Enable automatic Kaspi orders synchronization"
 )
 KASPI_AUTOSYNC_INTERVAL_MINUTES: int = Field(
@@ -32,6 +32,8 @@ KASPI_AUTOSYNC_MAX_CONCURRENCY: int = Field(
     description="Maximum number of companies to sync in parallel"
 )
 ```
+
+**Note**: Auto-sync is **disabled by default** for production safety. Set `KASPI_AUTOSYNC_ENABLED=true` in environment to enable.
 
 ### 3. Core Functionality
 
@@ -69,25 +71,35 @@ KASPI_AUTOSYNC_MAX_CONCURRENCY: int = Field(
 #### GET /api/v1/kaspi/autosync/status
 - **Returns**: Last run summary
 - **Fields**:
+  - `enabled` (bool) - whether auto-sync is enabled
   - `last_run_at` (ISO timestamp)
   - `eligible_companies` (count)
   - `success` (count)
   - `locked` (count)
   - `failed` (count)
+- **Behavior**: Returns `enabled=false` with zero stats when disabled
 
 #### POST /api/v1/kaspi/autosync/trigger
 - **Action**: Manual trigger of auto-sync
 - **Returns**: Updated run summary
 - **Use Case**: Immediate sync without waiting for next scheduled run
+- **Disabled State**: Returns 409 Conflict with error message when auto-sync is disabled
 
 ### 5. Test Coverage
-**File**: `tests/test_kaspi_autosync.py` (240 lines, 6 tests)
+**File**: `tests/test_kaspi_autosync.py` (290 lines, 8 tests)
 
 | Test | Status | Purpose |
 |------|--------|---------|
 | test_get_eligible_companies_filters_correctly | ✅ PASS | Validates company selection logic |
 | test_sync_respects_concurrency_limit | ✅ PASS | Ensures max_concurrency honored |
 | test_locked_companies_dont_stop_batch | ✅ PASS | Advisory lock doesn't break batch |
+| test_failed_companies_tracked_in_summary | ✅ PASS | Errors tracked, don't crash job |
+| test_manual_trigger_via_endpoint | ⏭️ SKIP | API trigger (needs fixture refactor) |
+| test_autosync_status_endpoint | ✅ PASS | Status endpoint returns valid data |
+| test_autosync_status_disabled | ✅ PASS | Status shows disabled when KASPI_AUTOSYNC_ENABLED=false |
+| test_autosync_trigger_disabled | ✅ PASS | Trigger returns 409 when disabled |
+
+**Overall**: 7 passed, 1 skipped
 | test_failed_companies_tracked_in_summary | ✅ PASS | Errors tracked, don't crash job |
 | test_manual_trigger_via_endpoint | ⏭️ SKIP | API trigger (needs fixture refactor) |
 | test_autosync_status_endpoint | ✅ PASS | Status endpoint returns valid data |
@@ -147,10 +159,12 @@ Kaspi auto-sync: company_id=9 failed: Connection timeout
 
 ### Typical Execution Times
 - **Single company**: 2-5 seconds (depends on order count)
-- **10 companies (concurrency=3)**: ~10-15 seconds
-- **100 companies (concurrency=5)**: ~2-3 minutes
+- **10 companies (concufalse  # Disabled by default, set to true to enable
+KASPI_AUTOSYNC_INTERVAL_MINUTES=15
+KASPI_AUTOSYNC_MAX_CONCURRENCY=3
+```
 
-## Deployment Notes
+**Important**: Auto-sync is disabled by default for production safety. Enable explicitly when ready.Deployment Notes
 
 ### Environment Variables
 ```bash

--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -517,6 +517,7 @@ def kaspi_debug_ping():
 class KaspiAutoSyncStatusOut(BaseModel):
     """Ответ о статусе последнего запуска авто-синхронизации."""
 
+    enabled: bool = Field(..., description="Включена ли автоматическая синхронизация")
     last_run_at: str | None = Field(None, description="ISO время последнего запуска")
     eligible_companies: int = Field(0, description="Сколько компаний подходят для синхронизации")
     success: int = Field(0, description="Успешно синхронизировано")
@@ -536,11 +537,26 @@ async def kaspi_autosync_status(
     Возвращает статус последнего запуска автоматической синхронизации заказов Kaspi.
     Не требует админских прав, но показывает глобальную статистику по всем компаниям.
     """
+    from app.core.config import settings
+
+    enabled = getattr(settings, "KASPI_AUTOSYNC_ENABLED", False)
+
+    if not enabled:
+        return KaspiAutoSyncStatusOut(
+            enabled=False,
+            last_run_at=None,
+            eligible_companies=0,
+            success=0,
+            locked=0,
+            failed=0,
+        )
+
     try:
         from app.worker.kaspi_autosync import get_last_run_summary
 
         summary = get_last_run_summary()
         return KaspiAutoSyncStatusOut(
+            enabled=True,
             last_run_at=summary.get("last_run_at"),
             eligible_companies=summary.get("eligible_companies", 0),
             success=summary.get("success", 0),
@@ -566,6 +582,16 @@ async def kaspi_autosync_trigger(
     Запускает синхронизацию заказов Kaspi для всех активных компаний вручную.
     Полезно для диагностики или немедленного обновления без ожидания следующего цикла.
     """
+    from app.core.config import settings
+
+    enabled = getattr(settings, "KASPI_AUTOSYNC_ENABLED", False)
+
+    if not enabled:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Kaspi auto-sync is disabled. Set KASPI_AUTOSYNC_ENABLED=true to enable.",
+        )
+
     # Можно добавить проверку на админские права:
     # if not current_user.is_admin:
     #     raise HTTPException(status_code=403, detail="Admin only")
@@ -581,6 +607,7 @@ async def kaspi_autosync_trigger(
 
         summary = get_last_run_summary()
         return KaspiAutoSyncStatusOut(
+            enabled=True,
             last_run_at=summary.get("last_run_at"),
             eligible_companies=summary.get("eligible_companies", 0),
             success=summary.get("success", 0),

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -435,7 +435,7 @@ class Settings(BaseSettings):
 
     # Kaspi Auto-Sync Settings
     KASPI_AUTOSYNC_ENABLED: bool = Field(
-        default=True,
+        default=False,
         description="Enable automatic Kaspi orders sync",
         validation_alias="KASPI_AUTOSYNC_ENABLED",
     )

--- a/docs/ENGINEERING_JOURNAL.md
+++ b/docs/ENGINEERING_JOURNAL.md
@@ -1,5 +1,37 @@
 # Engineering Journal
 
+## [2026-01-10] Kaspi Auto-Sync: Production Safety (Disabled by Default)
+
+### Changed
+- **Configuration Default**: Changed `KASPI_AUTOSYNC_ENABLED` from `default=True` to `default=False` in `app/core/config.py`
+  - **Rationale**: Production safety - auto-sync must be explicitly enabled
+  - **Impact**: New deployments will not auto-sync until enabled via environment variable
+
+- **API Endpoints Enhanced**: Updated `app/api/v1/kaspi.py`
+  - `GET /api/v1/kaspi/autosync/status` now returns `enabled: bool` field
+  - Returns `enabled=false` with zero stats when disabled
+  - `POST /api/v1/kaspi/autosync/trigger` now returns 409 Conflict when disabled
+  - Clear error message: "Kaspi auto-sync is disabled. Set KASPI_AUTOSYNC_ENABLED=true to enable."
+
+### Added Tests
+- `test_autosync_status_disabled` - Verifies status endpoint shows disabled state
+- `test_autosync_trigger_disabled` - Verifies trigger returns 409 when disabled
+- Updated existing tests to check for `enabled` field
+
+### Updated Documentation
+- `KASPI_AUTOSYNC_IMPLEMENTATION.md` - Updated configuration defaults section
+- Added warning about production safety in deployment notes
+
+### Decision Rationale
+- **Why disabled by default?**: Prevents unexpected behavior in production environments
+- **Why 409 Conflict?**: Semantic HTTP status for operational state conflict
+- **Why explicit enable?**: Forces conscious decision to enable background jobs
+
+### Verified
+- All tests passing (243 passed, 6 skipped)
+- ruff format/check clean
+- API endpoints behave correctly in disabled state
+
 ## [2026-01-10] Kaspi Orders Auto-Sync Scheduler (Production-Grade)
 
 ### Added
@@ -27,7 +59,7 @@
   - `POST /api/v1/kaspi/autosync/trigger` - Manual trigger for immediate sync
 
 - **Configuration**: Three new settings in `app/core/config.py` (lines 431-450)
-  - `KASPI_AUTOSYNC_ENABLED: bool` - Enable/disable auto-sync (default: True)
+  - `KASPI_AUTOSYNC_ENABLED: bool` - Enable/disable auto-sync (default: False, changed for production safety)
   - `KASPI_AUTOSYNC_INTERVAL_MINUTES: int` - Sync frequency (default: 15)
   - `KASPI_AUTOSYNC_MAX_CONCURRENCY: int` - Parallel sync limit (default: 3)
 

--- a/tests/test_kaspi_autosync.py
+++ b/tests/test_kaspi_autosync.py
@@ -233,8 +233,46 @@ async def test_autosync_status_endpoint(async_client, auth_headers):
 
     assert response.status_code == 200
     data = response.json()
+    assert "enabled" in data
     assert "last_run_at" in data
     assert "eligible_companies" in data
     assert "success" in data
     assert "locked" in data
     assert "failed" in data
+
+
+@pytest.mark.asyncio
+async def test_autosync_status_disabled(async_client, auth_headers):
+    """
+    Тест: GET /api/v1/kaspi/autosync/status должен показывать enabled=False когда отключено.
+    """
+    with patch("app.core.config.settings") as mock_settings:
+        mock_settings.KASPI_AUTOSYNC_ENABLED = False
+
+        response = await async_client.get("/api/v1/kaspi/autosync/status", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is False
+        assert data["last_run_at"] is None
+        assert data["eligible_companies"] == 0
+        assert data["success"] == 0
+        assert data["locked"] == 0
+        assert data["failed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_autosync_trigger_disabled(async_client, auth_headers):
+    """
+    Тест: POST /api/v1/kaspi/autosync/trigger должен возвращать 409 когда autosync отключен.
+    """
+    with patch("app.core.config.settings") as mock_settings:
+        mock_settings.KASPI_AUTOSYNC_ENABLED = False
+
+        response = await async_client.post("/api/v1/kaspi/autosync/trigger", headers=auth_headers)
+
+        assert response.status_code == 409
+        data = response.json()
+        assert "detail" in data
+        assert "disabled" in data["detail"].lower()
+        assert "KASPI_AUTOSYNC_ENABLED" in data["detail"]


### PR DESCRIPTION
Autosync is now OFF by default (prod-safe). Adds API guards: status reports enabled flag; trigger returns 409 when disabled. Adds tests for disabled mode + updates docs and engineering journal. Full suite: 243 passed, 6 skipped.