### PR TITLE
fix(kaspi): hold advisory lock for full orders sync

### DIFF
--- a/app/services/kaspi_service.py
+++ b/app/services/kaspi_service.py
@@ -312,153 +312,154 @@ class KaspiService:
                     await db.execute(text("SET LOCAL lock_timeout = '2s'"))
                     await db.execute(text("SET LOCAL statement_timeout = '10s'"))
 
+                    # Hold advisory lock for the entire sync to prevent concurrent watermark reads/updates.
                     async with self._company_lock(db, company_id):
                         state = await self._load_or_create_state(db, company_id)
 
-                    state.last_attempt_at = attempt_at
-                    state.last_result = None
-                    state.last_duration_ms = None
-                    state.last_fetched = None
-                    state.last_inserted = None
-                    state.last_updated = None
+                        state.last_attempt_at = attempt_at
+                        state.last_result = None
+                        state.last_duration_ms = None
+                        state.last_fetched = None
+                        state.last_inserted = None
+                        state.last_updated = None
 
-                    prev_last_synced = state.last_synced_at
-                    prev_last_ext = state.last_external_order_id
-                    is_new_state = prev_last_synced is None and prev_last_ext is None
+                        prev_last_synced = state.last_synced_at
+                        prev_last_ext = state.last_external_order_id
+                        is_new_state = prev_last_synced is None and prev_last_ext is None
 
-                    base_from = date_from or prev_last_synced or (effective_to - timedelta(days=1))
-                    effective_from = base_from - overlap
+                        base_from = date_from or prev_last_synced or (effective_to - timedelta(days=1))
+                        effective_from = base_from - overlap
 
-                    watermark = prev_last_synced or base_from
-                    last_ext = prev_last_ext
-                    made_progress = False
+                        watermark = prev_last_synced or base_from
+                        last_ext = prev_last_ext
+                        made_progress = False
 
-                    for status in statuses or [None]:
-                        async for batch in self._iter_orders_pages(
-                            date_from=effective_from,
-                            date_to=effective_to,
-                            status=status,
-                            page_size=100,
-                            company_id=company_id,
-                        ):
-                            fetched += len(batch)
-                            for payload in batch:
-                                ext_id = _as_str(payload.get("id")).strip()
-                                if not ext_id:
-                                    continue
+                        for status in statuses or [None]:
+                            async for batch in self._iter_orders_pages(
+                                date_from=effective_from,
+                                date_to=effective_to,
+                                status=status,
+                                page_size=100,
+                                company_id=company_id,
+                            ):
+                                fetched += len(batch)
+                                for payload in batch:
+                                    ext_id = _as_str(payload.get("id")).strip()
+                                    if not ext_id:
+                                        continue
 
-                                mapped_status = self._map_kaspi_status(_as_str(payload.get("status")))
-                                order_number = self._order_number_from_payload(company_id, ext_id, payload)
-                                customer = payload.get("customer") or {}
-                                currency = _as_str(payload.get("currency")) or "KZT"
-                                total_amount = self._decimal_or_zero(
-                                    payload.get("totalPrice")
-                                    or payload.get("total_amount")
-                                    or payload.get("total")
-                                    or 0
-                                )
-                                status_changed_at = self._extract_order_timestamp(payload)
-                                updated_ts = status_changed_at or effective_to
-                                effective_updated = updated_ts or attempt_at
-
-                                stmt = (
-                                    insert(Order)
-                                    .values(
-                                        company_id=company_id,
-                                        order_number=order_number,
-                                        external_id=ext_id,
-                                        source=OrderSource.KASPI,
-                                        status=mapped_status,
-                                        customer_phone=customer.get("phone") or None,
-                                        customer_name=customer.get("name") or None,
-                                        customer_address=payload.get("deliveryAddress")
-                                        or payload.get("delivery_address")
-                                        or None,
-                                        delivery_method=payload.get("deliveryMode")
-                                        or payload.get("delivery_mode")
-                                        or None,
-                                        total_amount=total_amount,
-                                        currency=currency,
-                                        updated_at=effective_updated,
+                                    mapped_status = self._map_kaspi_status(_as_str(payload.get("status")))
+                                    order_number = self._order_number_from_payload(company_id, ext_id, payload)
+                                    customer = payload.get("customer") or {}
+                                    currency = _as_str(payload.get("currency")) or "KZT"
+                                    total_amount = self._decimal_or_zero(
+                                        payload.get("totalPrice")
+                                        or payload.get("total_amount")
+                                        or payload.get("total")
+                                        or 0
                                     )
-                                    .on_conflict_do_update(
-                                        index_elements=[Order.company_id, Order.external_id],
-                                        set_={
-                                            "status": mapped_status,
-                                            "source": OrderSource.KASPI,
-                                            "order_number": order_number,
-                                            "customer_phone": customer.get("phone") or None,
-                                            "customer_name": customer.get("name") or None,
-                                            "customer_address": payload.get("deliveryAddress")
+                                    status_changed_at = self._extract_order_timestamp(payload)
+                                    updated_ts = status_changed_at or effective_to
+                                    effective_updated = updated_ts or attempt_at
+
+                                    stmt = (
+                                        insert(Order)
+                                        .values(
+                                            company_id=company_id,
+                                            order_number=order_number,
+                                            external_id=ext_id,
+                                            source=OrderSource.KASPI,
+                                            status=mapped_status,
+                                            customer_phone=customer.get("phone") or None,
+                                            customer_name=customer.get("name") or None,
+                                            customer_address=payload.get("deliveryAddress")
                                             or payload.get("delivery_address")
                                             or None,
-                                            "delivery_method": payload.get("deliveryMode")
+                                            delivery_method=payload.get("deliveryMode")
                                             or payload.get("delivery_mode")
                                             or None,
-                                            "total_amount": total_amount,
-                                            "currency": currency,
-                                            "updated_at": effective_updated,
-                                        },
+                                            total_amount=total_amount,
+                                            currency=currency,
+                                            updated_at=effective_updated,
+                                        )
+                                        .on_conflict_do_update(
+                                            index_elements=[Order.company_id, Order.external_id],
+                                            set_={
+                                                "status": mapped_status,
+                                                "source": OrderSource.KASPI,
+                                                "order_number": order_number,
+                                                "customer_phone": customer.get("phone") or None,
+                                                "customer_name": customer.get("name") or None,
+                                                "customer_address": payload.get("deliveryAddress")
+                                                or payload.get("delivery_address")
+                                                or None,
+                                                "delivery_method": payload.get("deliveryMode")
+                                                or payload.get("delivery_mode")
+                                                or None,
+                                                "total_amount": total_amount,
+                                                "currency": currency,
+                                                "updated_at": effective_updated,
+                                            },
+                                        )
+                                        .returning(Order.id, literal_column("xmax = 0").label("inserted"))
                                     )
-                                    .returning(Order.id, literal_column("xmax = 0").label("inserted"))
-                                )
 
-                                async with db.begin_nested():
-                                    res = await db.execute(stmt)
+                                    async with db.begin_nested():
+                                        res = await db.execute(stmt)
 
-                                row = res.one()
-                                inserted_flag: bool = bool(row.inserted)
-                                if inserted_flag:
-                                    inserted += 1
-                                else:
-                                    updated += 1
+                                    row = res.one()
+                                    inserted_flag: bool = bool(row.inserted)
+                                    if inserted_flag:
+                                        inserted += 1
+                                    else:
+                                        updated += 1
 
-                                order_pk = row.id
+                                    order_pk = row.id
 
-                                if updated_ts > watermark or (
-                                    updated_ts == watermark and ext_id and ext_id > (last_ext or "")
-                                ):
-                                    watermark = updated_ts
-                                    last_ext = ext_id
-                                made_progress = True
+                                    if updated_ts > watermark or (
+                                        updated_ts == watermark and ext_id and ext_id > (last_ext or "")
+                                    ):
+                                        watermark = updated_ts
+                                        last_ext = ext_id
+                                    made_progress = True
 
-                                items_updated = await self._upsert_order_items(
-                                    db, order_id=order_pk, company_id=company_id, payload=payload
-                                )
+                                    items_updated = await self._upsert_order_items(
+                                        db, order_id=order_pk, company_id=company_id, payload=payload
+                                    )
 
-                                if items_updated:
-                                    await self._recalculate_order_totals(db, order_id=order_pk)
+                                    if items_updated:
+                                        await self._recalculate_order_totals(db, order_id=order_pk)
 
-                                await self._upsert_status_history(
-                                    db,
-                                    order_id=order_pk,
-                                    new_status=mapped_status,
-                                    changed_at=status_changed_at,
-                                )
+                                    await self._upsert_status_history(
+                                        db,
+                                        order_id=order_pk,
+                                        new_status=mapped_status,
+                                        changed_at=status_changed_at,
+                                    )
 
-                            # page handling happens inside _iter_orders_pages
+                                # page handling happens inside _iter_orders_pages
 
-                        if made_progress or is_new_state:
-                            final_wm = watermark if prev_last_synced is None else max(prev_last_synced, watermark)
-                            state.last_synced_at = final_wm
-                            state.last_external_order_id = last_ext
-                        else:
-                            final_wm = prev_last_synced or watermark
-                            state.last_synced_at = prev_last_synced
-                            state.last_external_order_id = prev_last_ext
+                            if made_progress or is_new_state:
+                                final_wm = watermark if prev_last_synced is None else max(prev_last_synced, watermark)
+                                state.last_synced_at = final_wm
+                                state.last_external_order_id = last_ext
+                            else:
+                                final_wm = prev_last_synced or watermark
+                                state.last_synced_at = prev_last_synced
+                                state.last_external_order_id = prev_last_ext
 
-                        finished_at = _utcnow()
-                        duration_ms = int((perf_counter() - started_at) * 1000)
-                        state.updated_at = finished_at
-                        state.last_error_at = None
-                        state.last_error_code = None
-                        state.last_error_message = None
-                        state.last_result = "success"
-                        state.last_duration_ms = duration_ms
-                        state.last_attempt_at = attempt_at
-                        state.last_fetched = fetched
-                        state.last_inserted = inserted
-                        state.last_updated = updated
+                            finished_at = _utcnow()
+                            duration_ms = int((perf_counter() - started_at) * 1000)
+                            state.updated_at = finished_at
+                            state.last_error_at = None
+                            state.last_error_code = None
+                            state.last_error_message = None
+                            state.last_result = "success"
+                            state.last_duration_ms = duration_ms
+                            state.last_attempt_at = attempt_at
+                            state.last_fetched = fetched
+                            state.last_inserted = inserted
+                            state.last_updated = updated
                 if db.in_transaction():
                     await db.commit()
         except KaspiSyncAlreadyRunning:

--- a/tests/app/api/test_kaspi_orders_sync.py
+++ b/tests/app/api/test_kaspi_orders_sync.py
@@ -595,6 +595,31 @@ async def test_concurrent_sync_returns_locked(async_client, async_db_session, co
 
 
 @pytest.mark.asyncio
+async def test_sync_locked_then_succeeds_after_lock_release(
+    monkeypatch, async_client, async_db_session, company_a_admin_headers
+):
+    """Regression: lock held during first call returns 409/423, then succeeds after release."""
+
+    svc = KaspiService()
+    lock_key = svc._company_lock_key(1001)
+
+    # Hold advisory lock inside a short transaction to block the first sync attempt
+    async with async_db_session.begin():
+        await async_db_session.execute(sa.text("SELECT pg_advisory_xact_lock(:k)").bindparams(k=lock_key))
+        resp_locked = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+        assert resp_locked.status_code in {409, 423}
+
+    # After lock is released, sync should proceed normally
+    async def fake_get_orders(self, *, date_from=None, date_to=None, status=None, page=1, page_size=100):  # noqa: ARG001
+        return []
+
+    monkeypatch.setattr(KaspiService, "get_orders", fake_get_orders)
+
+    resp_ok = await async_client.post("/api/v1/kaspi/orders/sync", headers=company_a_admin_headers)
+    assert resp_ok.status_code == 200, resp_ok.text
+
+
+@pytest.mark.asyncio
 async def test_sync_state_endpoint_returns_defaults(async_client, company_a_admin_headers):
     resp = await async_client.get("/api/v1/kaspi/orders/sync/state", headers=company_a_admin_headers)
     assert resp.status_code == 200


### PR DESCRIPTION
Extends advisory lock scope to cover the entire Kaspi orders sync (state load → fetch/upsert loop → watermark finalize → state persist). Adds regression test: first call returns 409/423 while xact lock is held, then succeeds after release. Transaction logic unchanged.