### PR TITLE
fix(core): guard startup hook for tests/roles

### DIFF
--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -30,7 +30,7 @@ from fastapi.responses import JSONResponse, PlainTextResponse
 
 # --- Settings ---
 try:
-    from app.core.config import get_settings, settings  # type: ignore
+    from app.core.config import get_settings, settings, should_disable_startup_hooks  # type: ignore
 except Exception as e:  # pragma: no cover
     raise RuntimeError("Failed to import settings from app.core.config") from e
 
@@ -478,9 +478,20 @@ def init_core(app: FastAPI) -> None:
     # Startup hook: Alembic (best-effort)
     @app.on_event("startup")
     async def _on_startup() -> None:
+        log = get_logger("startup")
+
+        # tests/CI short-circuit
+        if should_disable_startup_hooks():
+            log.info("Core startup hook skipped (tests/CI)")
+            return
+
+        role = getattr(settings, "PROCESS_ROLE", os.getenv("PROCESS_ROLE", "web")) or "web"
+        if role not in ("web", "migrator"):
+            log.info("Core startup hook skipped for role", role=role)
+            return
+
         # предупреждения по критичным ENV
         issues = _critical_env_warnings()
-        log = get_logger("startup")
         if issues:
             log.warning("Critical ENV issues", issues=issues)
         # alembic

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -739,6 +739,11 @@ class Settings(BaseSettings):
     )
     UVICORN_WORKERS: int = Field(default=1, description="Uvicorn workers count", validation_alias="UVICORN_WORKERS")
     ROOT_PATH: str = Field(default="", description="ASGI root_path for reverse proxy", validation_alias="ROOT_PATH")
+    PROCESS_ROLE: str = Field(
+        default="web",
+        description="Process role: web/scheduler/runner/worker/migrator",
+        validation_alias="PROCESS_ROLE",
+    )
 
     # ---- PostgreSQL доп-настройки
     POSTGRES_STATEMENT_TIMEOUT_MS: int | None = Field(default=None, validation_alias="POSTGRES_STATEMENT_TIMEOUT_MS")

--- a/tests/test_core_startup_hook_guards.py
+++ b/tests/test_core_startup_hook_guards.py
@@ -1,0 +1,65 @@
+import os
+
+import pytest
+from fastapi import FastAPI
+
+import app.core.__init__ as core
+from app.core import init_core
+
+
+@pytest.mark.asyncio
+async def test_startup_hooks_disabled(monkeypatch):
+    """Startup hooks are skipped entirely in tests/CI mode."""
+
+    def _should_not_run():
+        raise AssertionError("should not run")
+
+    monkeypatch.setattr(core, "should_disable_startup_hooks", lambda: True)
+    monkeypatch.setattr(core, "_run_alembic_migrations_if_needed", _should_not_run)
+
+    app = FastAPI()
+    init_core(app)
+
+    await app.router.startup()  # Should not raise
+
+
+@pytest.mark.asyncio
+async def test_startup_skipped_for_non_web_role(monkeypatch):
+    """Startup hooks are skipped for non-web roles (e.g., scheduler)."""
+
+    def _should_not_run():
+        raise AssertionError("should not run")
+
+    monkeypatch.setattr(core, "should_disable_startup_hooks", lambda: False)
+    monkeypatch.setattr(core.settings, "PROCESS_ROLE", "scheduler")
+    monkeypatch.setattr(core, "_run_alembic_migrations_if_needed", _should_not_run)
+
+    app = FastAPI()
+    init_core(app)
+
+    await app.router.startup()  # Should not raise
+
+
+@pytest.mark.asyncio
+async def test_startup_web_role_respects_migration_flag(monkeypatch):
+    """Web role runs startup hook but respects RUN_MIGRATIONS_ON_START flag."""
+
+    monkeypatch.setattr(core, "should_disable_startup_hooks", lambda: False)
+    monkeypatch.setattr(core.settings, "PROCESS_ROLE", "web")
+    monkeypatch.delenv("RUN_MIGRATIONS_ON_START", raising=False)
+
+    calls = {"count": 0}
+
+    def _record_if_enabled():
+        if os.getenv("RUN_MIGRATIONS_ON_START", "0") in ("1", "true", "True"):
+            calls["count"] += 1
+
+    monkeypatch.setattr(core, "_run_alembic_migrations_if_needed", _record_if_enabled)
+
+    app = FastAPI()
+    init_core(app)
+
+    await app.router.startup()
+
+    # Since RUN_MIGRATIONS_ON_START is unset/false, migration callable should not increment
+    assert calls["count"] == 0


### PR DESCRIPTION
Guards core startup hook with should_disable_startup_hooks() and PROCESS_ROLE. Adds regression tests to ensure startup side-effects are skipped in tests and non-web roles.