### PR TITLE
fix(kaspi): normalize PowerShell JSON output + logging + regression tests

### DIFF
--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -487,7 +487,7 @@ def init_core(app: FastAPI) -> None:
 
         role = getattr(settings, "PROCESS_ROLE", os.getenv("PROCESS_ROLE", "web")) or "web"
         if role not in ("web", "migrator"):
-            log.info("Core startup hook skipped for role", role=role)
+            log.info("Core startup hook skipped for role", extra={"role": role})
             return
 
         # предупреждения по критичным ENV

--- a/app/integrations/kaspi_adapter.py
+++ b/app/integrations/kaspi_adapter.py
@@ -62,7 +62,7 @@ class KaspiAdapter:
         try:
             parsed = json.loads(json_line)
             # Гарантируем, что наружу возвращается объект/массив, а не JSON-строка
-            if isinstance(parsed, (dict, list)):
+            if isinstance(parsed, dict | list):
                 return parsed
             return {"raw": parsed}
         except json.JSONDecodeError:

--- a/app/integrations/kaspi_adapter.py
+++ b/app/integrations/kaspi_adapter.py
@@ -60,7 +60,11 @@ class KaspiAdapter:
         json_line = lines[-1]
         
         try:
-            return json.loads(json_line)
+            parsed = json.loads(json_line)
+            # Гарантируем, что наружу возвращается объект/массив, а не JSON-строка
+            if isinstance(parsed, (dict, list)):
+                return parsed
+            return {"raw": parsed}
         except json.JSONDecodeError:
             # Если пришёл не JSON — завернём как текст
             return {"raw": json_line}

--- a/app/integrations/kaspi_adapter.py
+++ b/app/integrations/kaspi_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shlex
 import subprocess
 from typing import Any, Optional
@@ -22,10 +23,16 @@ class KaspiAdapter:
         self.pwsh = pwsh or settings.KASPI_POWERSHELL
         self.script_path = script_path or settings.KASPI_SCRIPT_PATH
 
+    @staticmethod
+    def _strip_ansi(text: str) -> str:
+        """Remove ANSI escape sequences from text."""
+        ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+        return ansi_escape.sub('', text)
+
     def _run_json(self, ps_command: str) -> Any:
         """
         Выполняет PowerShell команду и возвращает JSON->Python.
-        ps_command уже должен включать dot-source скрипта и ConvertTo-Json.
+        PowerShell функции уже возвращают JSON, не нужно добавлять ConvertTo-Json.
         """
         # Запускаем pwsh -NoProfile -Command "<cmd>"
         completed = subprocess.run(
@@ -35,34 +42,46 @@ class KaspiAdapter:
             encoding="utf-8",
         )
         if completed.returncode != 0:
-            raise KaspiAdapterError(f"Kaspi.ps1 error: {completed.stderr.strip()}")
+            stderr = self._strip_ansi(completed.stderr.strip())
+            raise KaspiAdapterError(f"Kaspi.ps1 error: {stderr}")
+        
         stdout = completed.stdout.strip()
         if not stdout:
             return None
+        
+        # Strip ANSI sequences
+        stdout = self._strip_ansi(stdout)
+        
+        # Handle multi-line output: take the last non-empty line (should be JSON)
+        lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+        if not lines:
+            return None
+        
+        json_line = lines[-1]
+        
         try:
-            return json.loads(stdout)
+            return json.loads(json_line)
         except json.JSONDecodeError:
             # Если пришёл не JSON — завернём как текст
-            return {"raw": stdout}
+            return {"raw": json_line}
 
     def health(self, store: str) -> Any:
-        cmd = f". '{self.script_path}'; ks:health -Store {shlex.quote(store)} | ConvertTo-Json -Depth 8"
+        cmd = f". '{self.script_path}'; ks:health -Store {shlex.quote(store)}"
         return self._run_json(cmd)
 
     def orders(self, store: str, state: Optional[str] = None) -> Any:
         state_part = f"-State {shlex.quote(state)}" if state else ""
-        cmd = f". '{self.script_path}'; ks:orders -Store {shlex.quote(store)} {state_part} | ConvertTo-Json -Depth 8"
+        cmd = f". '{self.script_path}'; ks:orders -Store {shlex.quote(store)} {state_part}"
         return self._run_json(cmd)
 
     def publish_feed(self, store: str, offers_json_path: str) -> Any:
         cmd = (
             f". '{self.script_path}'; "
-            f"ks:publishFeed -Store {shlex.quote(store)} -OffersJsonPath {shlex.quote(offers_json_path)} "
-            f"| ConvertTo-Json -Depth 8"
+            f"ks:publishFeed -Store {shlex.quote(store)} -OffersJsonPath {shlex.quote(offers_json_path)}"
         )
         return self._run_json(cmd)
 
     def import_status(self, store: str, import_id: Optional[str] = None) -> Any:
         import_part = f"-ImportId {shlex.quote(import_id)}" if import_id else ""
-        cmd = f". '{self.script_path}'; ks:import -Store {shlex.quote(store)} {import_part} -StatusOnly | ConvertTo-Json -Depth 8"
+        cmd = f". '{self.script_path}'; ks:import -Store {shlex.quote(store)} {import_part} -StatusOnly"
         return self._run_json(cmd)

--- a/app/main.py
+++ b/app/main.py
@@ -823,7 +823,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # type: ignore[overrid
             settings, "ENABLE_SCHEDULER", False
         )
         if role != "scheduler":
-            logger.info("Scheduler start skipped for role", role=role, enable_scheduler=enable_scheduler)
+            logger.info("Scheduler start skipped for role", extra={"role": role, "enable_scheduler": enable_scheduler})
         elif disable_hooks:
             logger.info("Scheduler start skipped: startup hooks disabled")
         elif not enable_scheduler:
@@ -848,7 +848,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # type: ignore[overrid
         role = getattr(settings, "PROCESS_ROLE", os.getenv("PROCESS_ROLE", "web")) or "web"
         enable_kaspi_sync = _env_truthy(os.getenv("ENABLE_KASPI_SYNC_RUNNER", "0"))
         if role not in ("web", "runner"):
-            logger.info("Kaspi sync runner start skipped for role", role=role, enable_kaspi_sync=enable_kaspi_sync)
+            logger.info("Kaspi sync runner start skipped for role", extra={"role": role, "enable_kaspi_sync": enable_kaspi_sync})
         elif disable_hooks:
             logger.info("Kaspi sync runner start skipped: startup hooks disabled")
         elif not enable_kaspi_sync:

--- a/tests/app/api/test_kaspi_endpoints.py
+++ b/tests/app/api/test_kaspi_endpoints.py
@@ -4,6 +4,30 @@ from app.api.v1 import kaspi as kaspi_module
 
 
 @pytest.mark.asyncio
+async def test_kaspi_health_returns_proper_json(monkeypatch, async_client):
+    """Test that /api/v1/kaspi/health/{store} returns proper JSON object, not double-encoded string."""
+
+    class _FakeKaspiAdapter:
+        def health(self, store: str) -> dict:  # noqa: ANN001, ARG002
+            # Simulate what PowerShell script returns after parsing
+            return {"ok": True, "store": store, "cmd": "ks:health", "note": "test health"}
+
+    monkeypatch.setattr(kaspi_module, "KaspiAdapter", _FakeKaspiAdapter)
+
+    resp = await async_client.get("/api/v1/kaspi/health/default")
+    assert resp.status_code == 200, resp.text
+
+    # Check that response is proper JSON object, not a string
+    data = resp.json()
+    assert isinstance(data, dict), f"Expected dict, got {type(data)}: {data}"
+    assert data["ok"] is True
+    assert data["store"] == "default"
+
+    # Verify response text is NOT double-encoded (should not start with quote)
+    assert not resp.text.startswith('"'), f"Response should not be quoted JSON string: {resp.text[:100]}"
+
+
+@pytest.mark.asyncio
 async def test_kaspi_orders_sync_allows_empty_body(monkeypatch, async_client, company_a_admin_headers):
     called = {"count": 0, "company_id": None}
 


### PR DESCRIPTION
Fixes double-encoded JSON from Kaspi PowerShell adapter (no extra ConvertTo-Json, robust parsing/ANSI strip, scalar JSON normalized). Adds regression test for /api/v1/kaspi/health response shape. Also fixes startup logging kwargs for stdlib logger. Ruff/pytest green.