### PR TITLE
feat(kaspi): product catalog sync MVP

### DIFF
--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -45,6 +45,7 @@ from app.core.security import get_current_user, resolve_tenant_company_id
 from app.integrations.kaspi_adapter import KaspiAdapter, KaspiAdapterError
 from app.models import Product
 from app.models.company import Company
+from app.models.kaspi_catalog_product import KaspiCatalogProduct
 from app.models.kaspi_order_sync_state import KaspiOrderSyncState
 from app.models.marketplace import KaspiStoreToken
 from app.models.user import User
@@ -823,4 +824,149 @@ async def kaspi_autosync_trigger(
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Kaspi auto-sync module not available",
+        )
+
+
+# ============================= CATALOG PRODUCTS ==============================
+
+
+class KaspiProductSyncOut(BaseModel):
+    """Response model for catalog sync operation."""
+
+    ok: bool
+    company_id: int
+    fetched: int
+    inserted: int
+    updated: int
+
+
+class KaspiProductOut(BaseModel):
+    """Response model for single product in catalog list."""
+
+    offer_id: str
+    name: str | None = None
+    sku: str | None = None
+    price: str | None = None
+    qty: int | None = None
+    is_active: bool
+
+
+class KaspiProductListOut(BaseModel):
+    """Response model for catalog products list."""
+
+    items: list[KaspiProductOut]
+    total: int
+    limit: int
+    offset: int
+
+
+@router.post(
+    "/products/sync",
+    summary="Синхронизировать каталог Kaspi в локальную БД",
+    response_model=KaspiProductSyncOut,
+)
+async def kaspi_products_sync(
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    """
+    Синхронизирует каталог продуктов Kaspi для текущей компании.
+    Использует tenant isolation через resolved_company_id.
+    Идемпотентен: повторный запуск обновляет существующие записи.
+    """
+    from app.services.kaspi_products_sync_service import sync_kaspi_catalog_products
+
+    company_id = _resolve_company_id(current_user)
+
+    try:
+        result = await sync_kaspi_catalog_products(session, company_id)
+        return KaspiProductSyncOut(**result)
+    except Exception as e:
+        logger.error("Kaspi products sync failed: company_id=%s error=%s", company_id, e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to sync products from Kaspi",
+        )
+
+
+@router.get(
+    "/products",
+    summary="Получить список каталога Kaspi",
+    response_model=KaspiProductListOut,
+)
+async def kaspi_products_list(
+    limit: int = 50,
+    offset: int = 0,
+    q: str | None = None,
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    """
+    Возвращает список продуктов каталога Kaspi для текущей компании.
+
+    Args:
+        limit: Максимум записей (default 50, max 200)
+        offset: Смещение для пагинации (default 0)
+        q: Опциональный поиск по name/sku (ILIKE)
+
+    Returns:
+        Список продуктов с безопасными полями (без raw)
+    """
+    company_id = _resolve_company_id(current_user)
+
+    # Validate limit
+    limit = max(1, min(limit, 200))
+    offset = max(0, offset)
+
+    try:
+        # Build query
+        query = sa.select(KaspiCatalogProduct).where(KaspiCatalogProduct.company_id == company_id)
+
+        # Optional search
+        if q:
+            search_pattern = f"%{q}%"
+            query = query.where(
+                sa.or_(
+                    KaspiCatalogProduct.name.ilike(search_pattern),
+                    KaspiCatalogProduct.sku.ilike(search_pattern),
+                )
+            )
+
+        # Count total
+        count_query = sa.select(sa.func.count()).select_from(query.subquery())
+        total_result = await session.execute(count_query)
+        total = total_result.scalar() or 0
+
+        # Apply pagination
+        query = query.limit(limit).offset(offset).order_by(KaspiCatalogProduct.id)
+
+        # Execute
+        result = await session.execute(query)
+        products = result.scalars().all()
+
+        # Map to response model (safe fields only)
+        items = [
+            KaspiProductOut(
+                offer_id=p.offer_id,
+                name=p.name,
+                sku=p.sku,
+                price=str(p.price) if p.price is not None else None,
+                qty=p.qty,
+                is_active=p.is_active,
+            )
+            for p in products
+        ]
+
+        return KaspiProductListOut(
+            items=items,
+            total=total,
+            limit=limit,
+            offset=offset,
+        )
+
+    except Exception as e:
+        logger.error("Kaspi products list failed: company_id=%s error=%s", company_id, e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve products",
         )

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -184,6 +184,7 @@ _LAZY_MODELS: dict[str, tuple[str, str]] = {
         "IntegrationProviderConfig",
     ),
     "KaspiOrderSyncState": ("app.models.kaspi_order_sync_state", "KaspiOrderSyncState"),
+    "KaspiCatalogProduct": ("app.models.kaspi_catalog_product", "KaspiCatalogProduct"),
 }
 
 # Поддерживаемые модули доменов для «массового» импорта (ручной whitelisting).
@@ -200,6 +201,7 @@ _DOMAIN_MODULES: tuple[str, ...] = (
     "app.models.warehouse",
     "app.models.inventory_outbox",
     "app.models.kaspi_order_sync_state",
+    "app.models.kaspi_catalog_product",
     "app.models.system_integrations",
     "app.models.integration_provider",
     "app.models.integration_provider_config",
@@ -403,6 +405,9 @@ __all__ = [
     "reload_all_model_modules",
     # Test helpers
     "import_models_once",
+    # Kaspi
+    "KaspiOrderSyncState",
+    "KaspiCatalogProduct",
 ]
 
 

--- a/app/models/kaspi_catalog_product.py
+++ b/app/models/kaspi_catalog_product.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, Numeric, String, UniqueConstraint, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import relationship
+
+from app.models.base import Base
+
+
+class KaspiCatalogProduct(Base):
+    __tablename__ = "kaspi_catalog_products"
+
+    id = Column(Integer, primary_key=True)
+    company_id = Column(ForeignKey("companies.id", ondelete="CASCADE"), nullable=False, index=True)
+    offer_id = Column(String(128), nullable=False)
+    name = Column(String(255), nullable=True)
+    sku = Column(String(128), nullable=True)
+    price = Column(Numeric(18, 2), nullable=True)
+    qty = Column(Integer, nullable=True)
+    is_active = Column(Boolean, nullable=False, server_default=text("true"))
+    raw = Column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    company = relationship("Company", backref="kaspi_catalog_products")
+
+    __table_args__ = (
+        UniqueConstraint("company_id", "offer_id", name="uq_kaspi_catalog_products_company_offer"),
+        Index("ix_kaspi_catalog_products_company_offer", "company_id", "offer_id"),
+    )

--- a/app/services/kaspi_products_sync_service.py
+++ b/app/services/kaspi_products_sync_service.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+"""
+Kaspi catalog products synchronization service.
+
+Fetches product catalog from Kaspi API and syncs to local database with idempotent upsert.
+Tenant-scoped: each company has isolated catalog.
+"""
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.logging import get_logger
+from app.models.kaspi_catalog_product import KaspiCatalogProduct
+from app.services.kaspi_service import KaspiService
+
+logger = get_logger(__name__)
+
+
+async def sync_kaspi_catalog_products(
+    session: AsyncSession,
+    company_id: int,
+    kaspi: KaspiService | None = None,
+) -> dict[str, Any]:
+    """
+    Synchronize Kaspi catalog products to local database.
+
+    Args:
+        session: Async database session
+        company_id: Company ID (tenant isolation)
+        kaspi: KaspiService instance (if None, creates new one)
+
+    Returns:
+        Summary dict with keys: ok, company_id, fetched, inserted, updated
+    """
+    if kaspi is None:
+        kaspi = KaspiService()
+
+    fetched = 0
+    inserted = 0
+    updated = 0
+
+    logger.info("Kaspi catalog sync start: company_id=%s", company_id)
+
+    try:
+        # Fetch products from Kaspi API (page 1, default page_size)
+        items = await kaspi.get_products(page=1, page_size=100)
+        fetched = len(items)
+
+        logger.info("Kaspi catalog sync: company_id=%s fetched=%s", company_id, fetched)
+
+        # Process each product item
+        for item in items:
+            # Extract offer_id (priority: offer_id, then id)
+            offer_id = item.get("offer_id") or item.get("id")
+            if not offer_id:
+                logger.warning("Kaspi catalog sync: skipping item without offer_id/id")
+                continue
+
+            # Check if product already exists
+            check_stmt = select(KaspiCatalogProduct.id).where(
+                KaspiCatalogProduct.company_id == company_id,
+                KaspiCatalogProduct.offer_id == str(offer_id),
+            )
+            result_check = await session.execute(check_stmt)
+            exists = result_check.scalar_one_or_none()
+
+            # Extract fields
+            name = item.get("name") or item.get("title")
+            sku = item.get("sku") or item.get("code")
+            price = item.get("price")
+            qty = item.get("qty") or item.get("quantity") or item.get("stock")
+            is_active = item.get("is_active", True)
+
+            # Build upsert statement (ON CONFLICT DO UPDATE)
+            stmt = (
+                insert(KaspiCatalogProduct)
+                .values(
+                    company_id=company_id,
+                    offer_id=str(offer_id),
+                    name=str(name) if name else None,
+                    sku=str(sku) if sku else None,
+                    price=float(price) if price is not None else None,
+                    qty=int(qty) if qty is not None else None,
+                    is_active=bool(is_active),
+                    raw=item,
+                    created_at=datetime.utcnow(),
+                    updated_at=datetime.utcnow(),
+                )
+                .on_conflict_do_update(
+                    index_elements=["company_id", "offer_id"],
+                    set_={
+                        "name": str(name) if name else None,
+                        "sku": str(sku) if sku else None,
+                        "price": float(price) if price is not None else None,
+                        "qty": int(qty) if qty is not None else None,
+                        "is_active": bool(is_active),
+                        "raw": item,
+                        "updated_at": datetime.utcnow(),
+                    },
+                )
+            )
+
+            await session.execute(stmt)
+
+            # Track insert vs update
+            if exists:
+                updated += 1
+            else:
+                inserted += 1
+
+        # Commit transaction
+        await session.commit()
+
+        logger.info(
+            "Kaspi catalog sync success: company_id=%s fetched=%s inserted=%s updated=%s",
+            company_id,
+            fetched,
+            inserted,
+            updated,
+        )
+
+        return {
+            "ok": True,
+            "company_id": company_id,
+            "fetched": fetched,
+            "inserted": inserted,
+            "updated": updated,
+        }
+
+    except Exception as e:
+        logger.error("Kaspi catalog sync failed: company_id=%s error=%s", company_id, e)
+        await session.rollback()
+        raise

--- a/migrations/versions/20260114_kaspi_catalog_products.py
+++ b/migrations/versions/20260114_kaspi_catalog_products.py
@@ -1,0 +1,44 @@
+"""feat(kaspi): add kaspi catalog products
+
+Revision ID: 20260114_kaspi_catalog_products
+Revises: 3a4e0c5f9c2b
+Create Date: 2026-01-14 07:30:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260114_kaspi_catalog_products"
+down_revision: Union[str, Sequence[str], None] = "e94854a3fe4b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "kaspi_catalog_products",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("company_id", sa.Integer(), sa.ForeignKey("companies.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("offer_id", sa.String(length=128), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column("sku", sa.String(length=128), nullable=True),
+        sa.Column("price", sa.Numeric(18, 2), nullable=True),
+        sa.Column("qty", sa.Integer(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("raw", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("company_id", "offer_id", name="uq_kaspi_catalog_products_company_offer"),
+    )
+    op.create_index("ix_kaspi_catalog_products_company_offer", "kaspi_catalog_products", ["company_id", "offer_id"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_kaspi_catalog_products_company_offer", table_name="kaspi_catalog_products")
+    op.drop_table("kaspi_catalog_products")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,13 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from typing import Any
 from urllib.parse import quote
 
+# Guard against pytest-xdist usage (not supported in this repo)
+if os.environ.get("PYTEST_XDIST_WORKER") or os.environ.get("XDIST_WORKER"):
+    raise RuntimeError(
+        "pytest-xdist is not supported in this repository. "
+        "Please run tests with: python -m pytest -q"
+    )
+
 import httpx
 import pytest
 import pytest_asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,7 @@ from urllib.parse import quote
 # Guard against pytest-xdist usage (not supported in this repo)
 if os.environ.get("PYTEST_XDIST_WORKER") or os.environ.get("XDIST_WORKER"):
     raise RuntimeError(
-        "pytest-xdist is not supported in this repository. "
-        "Please run tests with: python -m pytest -q"
+        "pytest-xdist is not supported in this repository. " "Please run tests with: python -m pytest -q"
     )
 
 import httpx

--- a/tests/test_kaspi_products_catalog_sync.py
+++ b/tests/test_kaspi_products_catalog_sync.py
@@ -1,0 +1,235 @@
+"""
+Tests for Kaspi catalog products sync MVP.
+
+Scenarios:
+1. Sync creates records and list returns them (single company)
+2. Repeated sync is idempotent (count doesn't grow)
+3. Tenant isolation: company A data not visible to company B
+"""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+
+from app.models.kaspi_catalog_product import KaspiCatalogProduct
+
+
+def _fake_products_payload() -> list[dict]:
+    """Generate fake Kaspi products response."""
+    return [
+        {
+            "id": "kaspi-product-001",
+            "offer_id": "OFFER-001",
+            "name": "Test Product 1",
+            "sku": "SKU-001",
+            "price": 10000,
+            "qty": 50,
+            "is_active": True,
+        },
+        {
+            "id": "kaspi-product-002",
+            "offer_id": "OFFER-002",
+            "name": "Test Product 2",
+            "sku": "SKU-002",
+            "price": 15000,
+            "qty": 30,
+            "is_active": True,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_kaspi_products_sync_creates_and_lists(
+    monkeypatch,
+    async_client,
+    async_db_session,
+    company_a_admin_headers,
+):
+    """
+    Test that sync creates product records and list endpoint returns them.
+
+    Scenario:
+    1. Mock KaspiService.get_products to return 2 products
+    2. Call POST /api/v1/kaspi/products/sync
+    3. Verify: inserted=2, updated=0
+    4. Call GET /api/v1/kaspi/products
+    5. Verify: 2 products returned with correct fields
+    """
+    from app.services.kaspi_service import KaspiService
+
+    # Mock get_products
+    async def fake_get_products(self, *, page=1, page_size=100):  # noqa: ARG001
+        return _fake_products_payload()
+
+    monkeypatch.setattr(KaspiService, "get_products", fake_get_products)
+
+    # First sync
+    resp = await async_client.post("/api/v1/kaspi/products/sync", headers=company_a_admin_headers)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    assert data["ok"] is True
+    assert data["company_id"] == 1001
+    assert data["fetched"] == 2
+    assert data["inserted"] == 2
+    assert data["updated"] == 0
+
+    # Verify in database
+    res = await async_db_session.execute(
+        sa.select(sa.func.count(KaspiCatalogProduct.id)).where(KaspiCatalogProduct.company_id == 1001)
+    )
+    count = res.scalar_one()
+    assert count == 2
+
+    # Get list
+    list_resp = await async_client.get("/api/v1/kaspi/products", headers=company_a_admin_headers)
+    assert list_resp.status_code == 200, list_resp.text
+    list_data = list_resp.json()
+
+    assert list_data["total"] == 2
+    assert len(list_data["items"]) == 2
+    assert list_data["items"][0]["offer_id"] in {"OFFER-001", "OFFER-002"}
+    assert list_data["items"][0]["name"] in {"Test Product 1", "Test Product 2"}
+
+
+@pytest.mark.asyncio
+async def test_kaspi_products_sync_idempotent(
+    monkeypatch,
+    async_client,
+    async_db_session,
+    company_a_admin_headers,
+):
+    """
+    Test that repeated sync is idempotent (no duplicate records).
+
+    Scenario:
+    1. First sync: inserted=2
+    2. Second sync: inserted=0, updated=2 (same data)
+    3. Verify: still only 2 records in DB
+    """
+    from app.services.kaspi_service import KaspiService
+
+    # Mock get_products
+    async def fake_get_products(self, *, page=1, page_size=100):  # noqa: ARG001
+        return _fake_products_payload()
+
+    monkeypatch.setattr(KaspiService, "get_products", fake_get_products)
+
+    # First sync
+    resp1 = await async_client.post("/api/v1/kaspi/products/sync", headers=company_a_admin_headers)
+    assert resp1.status_code == 200
+    data1 = resp1.json()
+    assert data1["inserted"] == 2
+    assert data1["updated"] == 0
+
+    # Second sync
+    resp2 = await async_client.post("/api/v1/kaspi/products/sync", headers=company_a_admin_headers)
+    assert resp2.status_code == 200
+    data2 = resp2.json()
+    assert data2["inserted"] == 0
+    assert data2["updated"] == 2  # Same products updated
+
+    # Verify no duplicates
+    res = await async_db_session.execute(
+        sa.select(sa.func.count(KaspiCatalogProduct.id)).where(KaspiCatalogProduct.company_id == 1001)
+    )
+    count = res.scalar_one()
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_kaspi_products_tenant_isolation(
+    monkeypatch,
+    async_client,
+    async_db_session,
+    company_a_admin_headers,
+    company_b_admin_headers,
+):
+    """
+    Test tenant isolation: company A products not visible to company B.
+
+    Scenario:
+    1. Sync products for company A (2 products)
+    2. Sync products for company B (different 2 products)
+    3. List products for company A: should see only A's products
+    4. List products for company B: should see only B's products
+    """
+    from app.services.kaspi_service import KaspiService
+
+    # Mock get_products to return different data based on call count
+    call_count = [0]
+
+    async def fake_get_products(self, *, page=1, page_size=100):  # noqa: ARG001
+        call_count[0] += 1
+        if call_count[0] == 1:
+            # Company A products
+            return [
+                {
+                    "id": "kaspi-a-001",
+                    "offer_id": "OFFER-A-001",
+                    "name": "Company A Product 1",
+                    "sku": "SKU-A-001",
+                    "price": 5000,
+                    "qty": 10,
+                },
+                {
+                    "id": "kaspi-a-002",
+                    "offer_id": "OFFER-A-002",
+                    "name": "Company A Product 2",
+                    "sku": "SKU-A-002",
+                    "price": 6000,
+                    "qty": 20,
+                },
+            ]
+        else:
+            # Company B products
+            return [
+                {
+                    "id": "kaspi-b-001",
+                    "offer_id": "OFFER-B-001",
+                    "name": "Company B Product 1",
+                    "sku": "SKU-B-001",
+                    "price": 7000,
+                    "qty": 30,
+                },
+                {
+                    "id": "kaspi-b-002",
+                    "offer_id": "OFFER-B-002",
+                    "name": "Company B Product 2",
+                    "sku": "SKU-B-002",
+                    "price": 8000,
+                    "qty": 40,
+                },
+            ]
+
+    monkeypatch.setattr(KaspiService, "get_products", fake_get_products)
+
+    # Sync for company A
+    resp_a = await async_client.post("/api/v1/kaspi/products/sync", headers=company_a_admin_headers)
+    assert resp_a.status_code == 200
+    assert resp_a.json()["inserted"] == 2
+
+    # Sync for company B
+    resp_b = await async_client.post("/api/v1/kaspi/products/sync", headers=company_b_admin_headers)
+    assert resp_b.status_code == 200
+    assert resp_b.json()["inserted"] == 2
+
+    # List for company A
+    list_a = await async_client.get("/api/v1/kaspi/products", headers=company_a_admin_headers)
+    assert list_a.status_code == 200
+    data_a = list_a.json()
+    assert data_a["total"] == 2
+    offer_ids_a = {item["offer_id"] for item in data_a["items"]}
+    assert offer_ids_a == {"OFFER-A-001", "OFFER-A-002"}
+
+    # List for company B
+    list_b = await async_client.get("/api/v1/kaspi/products", headers=company_b_admin_headers)
+    assert list_b.status_code == 200
+    data_b = list_b.json()
+    assert data_b["total"] == 2
+    offer_ids_b = {item["offer_id"] for item in data_b["items"]}
+    assert offer_ids_b == {"OFFER-B-001", "OFFER-B-002"}
+
+    # Verify no cross-contamination
+    assert offer_ids_a.isdisjoint(offer_ids_b)


### PR DESCRIPTION
Adds KaspiCatalogProduct + migration, product catalog sync endpoints, idempotent upsert (company_id, offer_id), tenant isolation, tests. Also blocks pytest-xdist (single-process only).