### PR TITLE
feat(kaspi): feed upload MVP

### DIFF
--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -970,3 +970,291 @@ async def kaspi_products_list(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve products",
         )
+
+
+# ============================= FEED EXPORTS ==============================
+
+
+class KaspiFeedExportOut(BaseModel):
+    """Response model for feed export metadata."""
+
+    id: int
+    kind: str
+    format: str
+    status: str  # generated, uploading, uploaded, failed
+    checksum: str
+    stats_json: dict | None = None
+    last_error: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class KaspiFeedGenerateOut(BaseModel):
+    """Response model for feed generation."""
+
+    ok: bool
+    export_id: int
+    company_id: int
+    total: int
+    active: int
+    checksum: str
+    is_new: bool
+
+
+class KaspiFeedUploadOut(BaseModel):
+    """Response model for feed upload."""
+
+    ok: bool
+    export_id: int
+    status: str
+    error: str | None = None
+
+
+class KaspiFeedListOut(BaseModel):
+    """Response model for feed exports list."""
+
+    items: list[KaspiFeedExportOut]
+    total: int
+    limit: int
+    offset: int
+
+
+@router.post(
+    "/feeds/products/generate",
+    summary="Сгенерировать фид продуктов для Kaspi",
+    response_model=KaspiFeedGenerateOut,
+)
+async def kaspi_feed_generate_products(
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    """
+    Генерирует фид продуктов для текущей компании.
+    Идемпотентен: повторный вызов вернёт существующий фид если контент не изменился.
+    """
+    from app.services.kaspi_feed_export_service import generate_products_feed
+
+    company_id = _resolve_company_id(current_user)
+
+    try:
+        result = await generate_products_feed(session, company_id)
+        return KaspiFeedGenerateOut(**result)
+    except Exception as e:
+        logger.error("Kaspi feed generation failed: company_id=%s error=%s", company_id, e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to generate feed",
+        )
+
+
+@router.post(
+    "/feeds/{export_id}/upload",
+    summary="Загрузить фид на Kaspi",
+    response_model=KaspiFeedUploadOut,
+)
+async def kaspi_feed_upload(
+    export_id: int,
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    """
+    Загружает фид на Kaspi. Текущий пользователь должен иметь доступ к компании фида.
+    """
+    from app.services.kaspi_feed_export_service import upload_feed_export
+
+    company_id = _resolve_company_id(current_user)
+
+    try:
+        result = await upload_feed_export(session, export_id, company_id)
+        if not result["ok"]:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=result.get("error", "Export not found"),
+            )
+        return KaspiFeedUploadOut(**result)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Kaspi feed upload failed: export_id=%s company_id=%s error=%s", export_id, company_id, e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to upload feed",
+        )
+
+
+@router.get(
+    "/feeds",
+    summary="Получить список фидов",
+    response_model=KaspiFeedListOut,
+)
+async def kaspi_feeds_list(
+    kind: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    """
+    Возвращает список фидов для текущей компании с опциональной фильтрацией по kind.
+    """
+    from app.models.kaspi_feed_export import KaspiFeedExport
+
+    company_id = _resolve_company_id(current_user)
+
+    # Validate limit
+    limit = max(1, min(limit, 200))
+    offset = max(0, offset)
+
+    try:
+        # Build query
+        query = sa.select(KaspiFeedExport).where(KaspiFeedExport.company_id == company_id)
+
+        # Optional filter by kind
+        if kind:
+            query = query.where(KaspiFeedExport.kind == kind)
+
+        # Count total
+        count_query = sa.select(sa.func.count()).select_from(query.subquery())
+        total_result = await session.execute(count_query)
+        total = total_result.scalar() or 0
+
+        # Apply pagination and ordering
+        query = query.order_by(KaspiFeedExport.created_at.desc()).limit(limit).offset(offset)
+
+        # Execute
+        result = await session.execute(query)
+        exports = result.scalars().all()
+
+        # Map to response models
+        items = [
+            KaspiFeedExportOut(
+                id=e.id,
+                kind=e.kind,
+                format=e.format,
+                status=e.status,
+                checksum=e.checksum,
+                stats_json=e.stats_json,
+                last_error=e.last_error,
+                created_at=e.created_at.isoformat() if e.created_at else None,
+                updated_at=e.updated_at.isoformat() if e.updated_at else None,
+            )
+            for e in exports
+        ]
+
+        return KaspiFeedListOut(
+            items=items,
+            total=total,
+            limit=limit,
+            offset=offset,
+        )
+
+    except Exception as e:
+        logger.error("Kaspi feeds list failed: company_id=%s error=%s", company_id, e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve feeds",
+        )
+
+
+@router.get(
+    "/feeds/{export_id}",
+    summary="Получить метаданные фида",
+    response_model=KaspiFeedExportOut,
+)
+async def kaspi_feed_get(
+    export_id: int,
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    """
+    Возвращает метаданные фида (без payload).
+    """
+    from app.models.kaspi_feed_export import KaspiFeedExport
+
+    company_id = _resolve_company_id(current_user)
+
+    try:
+        stmt = sa.select(KaspiFeedExport).where(
+            sa.and_(
+                KaspiFeedExport.id == export_id,
+                KaspiFeedExport.company_id == company_id,
+            )
+        )
+        result = await session.execute(stmt)
+        export = result.scalars().first()
+
+        if not export:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Export not found",
+            )
+
+        return KaspiFeedExportOut(
+            id=export.id,
+            kind=export.kind,
+            format=export.format,
+            status=export.status,
+            checksum=export.checksum,
+            stats_json=export.stats_json,
+            last_error=export.last_error,
+            created_at=export.created_at.isoformat() if export.created_at else None,
+            updated_at=export.updated_at.isoformat() if export.updated_at else None,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Kaspi feed get failed: export_id=%s company_id=%s error=%s", export_id, company_id, e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve feed",
+        )
+
+
+@router.get(
+    "/feeds/{export_id}/payload",
+    summary="Получить XML фида",
+    response_class=Response,
+)
+async def kaspi_feed_get_payload(
+    export_id: int,
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    """
+    Возвращает XML payload фида с типом application/xml.
+    """
+    from app.models.kaspi_feed_export import KaspiFeedExport
+
+    company_id = _resolve_company_id(current_user)
+
+    try:
+        stmt = sa.select(KaspiFeedExport).where(
+            sa.and_(
+                KaspiFeedExport.id == export_id,
+                KaspiFeedExport.company_id == company_id,
+            )
+        )
+        result = await session.execute(stmt)
+        export = result.scalars().first()
+
+        if not export:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Export not found",
+            )
+
+        return Response(
+            content=export.payload_text,
+            media_type="application/xml",
+            headers={"Content-Disposition": f'attachment; filename="kaspi_feed_{export_id}.xml"'},
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Kaspi feed payload failed: export_id=%s company_id=%s error=%s", export_id, company_id, e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve payload",
+        )

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -185,6 +185,7 @@ _LAZY_MODELS: dict[str, tuple[str, str]] = {
     ),
     "KaspiOrderSyncState": ("app.models.kaspi_order_sync_state", "KaspiOrderSyncState"),
     "KaspiCatalogProduct": ("app.models.kaspi_catalog_product", "KaspiCatalogProduct"),
+    "KaspiFeedExport": ("app.models.kaspi_feed_export", "KaspiFeedExport"),
 }
 
 # Поддерживаемые модули доменов для «массового» импорта (ручной whitelisting).
@@ -202,6 +203,7 @@ _DOMAIN_MODULES: tuple[str, ...] = (
     "app.models.inventory_outbox",
     "app.models.kaspi_order_sync_state",
     "app.models.kaspi_catalog_product",
+    "app.models.kaspi_feed_export",
     "app.models.system_integrations",
     "app.models.integration_provider",
     "app.models.integration_provider_config",
@@ -408,6 +410,7 @@ __all__ = [
     # Kaspi
     "KaspiOrderSyncState",
     "KaspiCatalogProduct",
+    "KaspiFeedExport",
 ]
 
 

--- a/app/models/kaspi_feed_export.py
+++ b/app/models/kaspi_feed_export.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import relationship
+
+from app.models.base import Base
+
+
+class KaspiFeedExport(Base):
+    __tablename__ = "kaspi_feed_exports"
+
+    id = Column(Integer, primary_key=True)
+    company_id = Column(ForeignKey("companies.id", ondelete="CASCADE"), nullable=False, index=True)
+    kind = Column(String(50), nullable=False)  # e.g. "products"
+    format = Column(String(50), nullable=False)  # e.g. "xml"
+    status = Column(
+        String(50), nullable=False, server_default=text("'generated'")
+    )  # generated, uploading, uploaded, failed
+    checksum = Column(String(64), nullable=False)  # sha256 hex
+    payload_text = Column(Text, nullable=False)  # XML content
+    stats_json = Column(JSONB, nullable=True, server_default=text("NULL"))  # {total, active}
+    last_error = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    company = relationship("Company", backref="kaspi_feed_exports")
+
+    __table_args__ = (
+        UniqueConstraint("company_id", "kind", "checksum", name="uq_kaspi_feed_exports_company_kind_checksum"),
+        Index("ix_kaspi_feed_exports_company_created", "company_id", "created_at"),
+        Index("ix_kaspi_feed_exports_company_kind", "company_id", "kind"),
+    )

--- a/app/services/kaspi_feed_export_service.py
+++ b/app/services/kaspi_feed_export_service.py
@@ -1,0 +1,200 @@
+"""Kaspi feed export service: generation and upload pipeline."""
+
+from __future__ import annotations
+
+import hashlib
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import and_, select
+from sqlalchemy.dialects.postgresql import insert
+
+from app.models import KaspiCatalogProduct, KaspiFeedExport
+from app.services.kaspi_service import KaspiService
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def generate_products_feed(
+    session: AsyncSession,
+    company_id: int,
+) -> dict:
+    """
+    Generate a Kaspi products feed export.
+
+    1. Fetch all products for company_id from KaspiCatalogProduct
+    2. Generate XML payload (deterministic by offer_id)
+    3. Compute SHA256 checksum
+    4. Check if export with same checksum exists (idempotency)
+    5. If exists, return existing export; else insert new one with status="generated"
+    6. Return summary {ok, export_id, company_id, total, active, checksum}
+    """
+    # Fetch products
+    stmt = (
+        select(KaspiCatalogProduct)
+        .where(KaspiCatalogProduct.company_id == company_id)
+        .order_by(KaspiCatalogProduct.offer_id)
+    )
+
+    result = await session.execute(stmt)
+    products = result.scalars().all()
+
+    # Generate XML
+    root = ET.Element("products")
+    active_count = 0
+
+    for product in products:
+        if product.is_active:
+            active_count += 1
+
+        prod_elem = ET.SubElement(root, "product")
+
+        offer_id_elem = ET.SubElement(prod_elem, "offerId")
+        offer_id_elem.text = product.offer_id
+
+        if product.name:
+            name_elem = ET.SubElement(prod_elem, "name")
+            name_elem.text = product.name
+
+        if product.sku:
+            sku_elem = ET.SubElement(prod_elem, "sku")
+            sku_elem.text = product.sku
+
+        if product.price is not None:
+            price_elem = ET.SubElement(prod_elem, "price")
+            price_elem.text = str(product.price)
+
+        if product.qty is not None:
+            qty_elem = ET.SubElement(prod_elem, "quantity")
+            qty_elem.text = str(product.qty)
+
+        active_elem = ET.SubElement(prod_elem, "isActive")
+        active_elem.text = "true" if product.is_active else "false"
+
+    # Serialize XML
+    payload_text = ET.tostring(root, encoding="unicode", method="xml")
+
+    # Compute checksum
+    checksum = hashlib.sha256(payload_text.encode("utf-8")).hexdigest()
+
+    # Check if same export exists (idempotency)
+    check_stmt = select(KaspiFeedExport).where(
+        and_(
+            KaspiFeedExport.company_id == company_id,
+            KaspiFeedExport.kind == "products",
+            KaspiFeedExport.checksum == checksum,
+        )
+    )
+
+    check_result = await session.execute(check_stmt)
+    existing = check_result.scalars().first()
+
+    if existing:
+        # Return existing export
+        return {
+            "ok": True,
+            "export_id": existing.id,
+            "company_id": company_id,
+            "total": len(products),
+            "active": active_count,
+            "checksum": checksum,
+            "is_new": False,
+        }
+
+    # Insert new export
+    stats = {
+        "total": len(products),
+        "active": active_count,
+    }
+
+    stmt_insert = insert(KaspiFeedExport).values(
+        company_id=company_id,
+        kind="products",
+        format="xml",
+        status="generated",
+        checksum=checksum,
+        payload_text=payload_text,
+        stats_json=stats,
+    )
+
+    result = await session.execute(stmt_insert)
+    export_id = result.inserted_primary_key[0]
+    await session.commit()
+
+    return {
+        "ok": True,
+        "export_id": export_id,
+        "company_id": company_id,
+        "total": len(products),
+        "active": active_count,
+        "checksum": checksum,
+        "is_new": True,
+    }
+
+
+async def upload_feed_export(
+    session: AsyncSession,
+    export_id: int,
+    company_id: int,
+    kaspi_service: KaspiService | None = None,
+) -> dict:
+    """
+    Upload a feed export to Kaspi.
+
+    1. Load export scoped by company_id
+    2. Update status to "uploading"
+    3. Call KaspiService.upload_products_feed(payload)
+    4. On success: status="uploaded", last_error=None
+    5. On failure: status="failed", last_error=str(error)
+    6. Return summary {ok, export_id, status, error (if any)}
+    """
+    if kaspi_service is None:
+        kaspi_service = KaspiService()
+
+    # Load export
+    stmt = select(KaspiFeedExport).where(
+        and_(
+            KaspiFeedExport.id == export_id,
+            KaspiFeedExport.company_id == company_id,
+        )
+    )
+
+    result = await session.execute(stmt)
+    export = result.scalars().first()
+
+    if not export:
+        return {
+            "ok": False,
+            "export_id": export_id,
+            "status": None,
+            "error": "Export not found or access denied",
+        }
+
+    # Update status to uploading
+    export.status = "uploading"
+    export.updated_at = datetime.utcnow()
+    await session.flush()
+
+    try:
+        # Call kaspi service stub
+        await kaspi_service.upload_products_feed(export.payload_text)
+
+        # Success
+        export.status = "uploaded"
+        export.last_error = None
+    except Exception as e:
+        # Failure
+        export.status = "failed"
+        export.last_error = str(e)
+
+    export.updated_at = datetime.utcnow()
+    await session.commit()
+
+    return {
+        "ok": export.status == "uploaded",
+        "export_id": export_id,
+        "status": export.status,
+        "error": export.last_error,
+    }

--- a/app/services/kaspi_service.py
+++ b/app/services/kaspi_service.py
@@ -314,6 +314,32 @@ class KaspiService:
                 logger.error("Kaspi update_product_availability(%s) error: %s", product_id, e)
                 return False
 
+    async def upload_products_feed(self, xml_payload: str) -> bool:
+        """
+        Upload a products feed (XML) to Kaspi.
+        Stub implementation for MVP: accepts XML and logs it.
+        In production, would POST to Kaspi feed upload endpoint.
+        """
+        try:
+            # Stub: for now just validate XML is valid and log
+            if not xml_payload or not isinstance(xml_payload, str):
+                raise ValueError("Invalid payload: must be non-empty XML string")
+            
+            # In production, would do:
+            # async with self._client() as client:
+            #     resp = await client.post(
+            #         self._url("/feeds/upload"),
+            #         headers={**self.headers, "Content-Type": "application/xml"},
+            #         content=xml_payload.encode("utf-8"),
+            #     )
+            #     resp.raise_for_status()
+            
+            logger.info("Kaspi: feed upload stub called with %d bytes", len(xml_payload))
+            return True
+        except Exception as e:
+            logger.error("Kaspi upload_products_feed error: %s", e)
+            raise RuntimeError(f"Failed to upload products feed to Kaspi: {e}") from e
+
     # ---------------------- Orders sync (DB) ---------------------- #
 
     async def sync_orders(

--- a/app/services/kaspi_service.py
+++ b/app/services/kaspi_service.py
@@ -324,7 +324,7 @@ class KaspiService:
             # Stub: for now just validate XML is valid and log
             if not xml_payload or not isinstance(xml_payload, str):
                 raise ValueError("Invalid payload: must be non-empty XML string")
-            
+
             # In production, would do:
             # async with self._client() as client:
             #     resp = await client.post(
@@ -333,7 +333,7 @@ class KaspiService:
             #         content=xml_payload.encode("utf-8"),
             #     )
             #     resp.raise_for_status()
-            
+
             logger.info("Kaspi: feed upload stub called with %d bytes", len(xml_payload))
             return True
         except Exception as e:

--- a/migrations/versions/20260114_kaspi_feed_exports.py
+++ b/migrations/versions/20260114_kaspi_feed_exports.py
@@ -1,0 +1,46 @@
+"""feat(kaspi): add kaspi feed exports
+
+Revision ID: 20260114_kaspi_feed_exports
+Revises: 20260114_kaspi_catalog_products
+Create Date: 2026-01-14 10:00:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260114_kaspi_feed_exports"
+down_revision: Union[str, Sequence[str], None] = "20260114_kaspi_catalog_products"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "kaspi_feed_exports",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("company_id", sa.Integer(), sa.ForeignKey("companies.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("kind", sa.String(length=50), nullable=False),
+        sa.Column("format", sa.String(length=50), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False, server_default=sa.text("'generated'")),
+        sa.Column("checksum", sa.String(length=64), nullable=False),
+        sa.Column("payload_text", sa.Text(), nullable=False),
+        sa.Column("stats_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("company_id", "kind", "checksum", name="uq_kaspi_feed_exports_company_kind_checksum"),
+    )
+    op.create_index("ix_kaspi_feed_exports_company_created", "kaspi_feed_exports", ["company_id", "created_at"])
+    op.create_index("ix_kaspi_feed_exports_company_kind", "kaspi_feed_exports", ["company_id", "kind"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_kaspi_feed_exports_company_kind", table_name="kaspi_feed_exports")
+    op.drop_index("ix_kaspi_feed_exports_company_created", table_name="kaspi_feed_exports")
+    op.drop_table("kaspi_feed_exports")

--- a/tests/test_kaspi_feed_exports.py
+++ b/tests/test_kaspi_feed_exports.py
@@ -1,0 +1,323 @@
+"""Tests for Kaspi feed export MVP."""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import select
+
+from app.models.kaspi_catalog_product import KaspiCatalogProduct
+from app.models.kaspi_feed_export import KaspiFeedExport
+from app.services.kaspi_service import KaspiService
+
+
+@pytest.mark.asyncio
+async def test_generate_creates_export_and_payload_contains_offers(
+    monkeypatch,
+    async_db_session,
+):
+    """Test that generate_products_feed creates export with valid XML payload."""
+    from app.models.company import Company
+    from app.services.kaspi_feed_export_service import generate_products_feed
+
+    # Create a test company and products
+    company = Company(name="TestCo A")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    products = [
+        KaspiCatalogProduct(
+            company_id=company.id,
+            offer_id="OFFER001",
+            name="Product A",
+            sku="SKU-A",
+            price=100.50,
+            qty=10,
+            is_active=True,
+        ),
+        KaspiCatalogProduct(
+            company_id=company.id,
+            offer_id="OFFER002",
+            name="Product B",
+            sku="SKU-B",
+            price=200.75,
+            qty=0,
+            is_active=False,
+        ),
+    ]
+    for p in products:
+        async_db_session.add(p)
+    await async_db_session.commit()
+
+    result = await generate_products_feed(async_db_session, company.id)
+
+    assert result["ok"] is True
+    assert result["export_id"] is not None
+    assert result["company_id"] == company.id
+    assert result["total"] == 2
+    assert result["active"] == 1
+    assert result["is_new"] is True
+
+    # Verify export in DB
+    stmt = select(KaspiFeedExport).where(KaspiFeedExport.id == result["export_id"])
+    db_result = await async_db_session.execute(stmt)
+    export = db_result.scalars().first()
+
+    assert export is not None
+    assert export.status == "generated"
+    assert export.kind == "products"
+    assert export.format == "xml"
+    assert export.checksum == result["checksum"]
+    assert export.stats_json == {"total": 2, "active": 1}
+
+    # Verify XML payload structure
+    assert "OFFER001" in export.payload_text
+    assert "Product A" in export.payload_text
+    assert "OFFER002" in export.payload_text
+
+
+@pytest.mark.asyncio
+async def test_generate_idempotent_same_checksum_returns_existing_export(
+    async_db_session,
+):
+    """Test that generate_products_feed returns existing export if checksum matches."""
+    from app.models.company import Company
+    from app.services.kaspi_feed_export_service import generate_products_feed
+
+    company = Company(name="TestCo B")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    products = [
+        KaspiCatalogProduct(
+            company_id=company.id,
+            offer_id="OFFER001",
+            name="Product A",
+            sku="SKU-A",
+            price=100.50,
+            qty=10,
+            is_active=True,
+        ),
+        KaspiCatalogProduct(
+            company_id=company.id,
+            offer_id="OFFER002",
+            name="Product B",
+            sku="SKU-B",
+            price=200.75,
+            qty=0,
+            is_active=False,
+        ),
+    ]
+    for p in products:
+        async_db_session.add(p)
+    await async_db_session.commit()
+
+    # First generation
+    result1 = await generate_products_feed(async_db_session, company.id)
+    export_id_1 = result1["export_id"]
+    checksum_1 = result1["checksum"]
+
+    # Count exports
+    count_stmt = select(KaspiFeedExport).where(KaspiFeedExport.company_id == company.id)
+    count_result = await async_db_session.execute(count_stmt)
+    exports_1 = count_result.scalars().all()
+    count_1 = len(exports_1)
+
+    # Second generation (should return same)
+    result2 = await generate_products_feed(async_db_session, company.id)
+    export_id_2 = result2["export_id"]
+    checksum_2 = result2["checksum"]
+
+    assert export_id_1 == export_id_2
+    assert checksum_1 == checksum_2
+    assert result2["is_new"] is False
+
+    # Count exports again (should not increase)
+    count_result = await async_db_session.execute(count_stmt)
+    exports_2 = count_result.scalars().all()
+    count_2 = len(exports_2)
+
+    assert count_1 == count_2  # No new export created
+
+
+@pytest.mark.asyncio
+async def test_tenant_isolation_exports_separate(
+    async_db_session,
+):
+    """Test that company A exports don't leak to company B."""
+    from app.models.company import Company
+    from app.services.kaspi_feed_export_service import generate_products_feed
+
+    company_a = Company(name="TestCo A")
+    company_b = Company(name="TestCo B")
+    async_db_session.add(company_a)
+    async_db_session.add(company_b)
+    await async_db_session.flush()
+
+    # Products for company A
+    for offer_id in ["OFFER001", "OFFER002"]:
+        p = KaspiCatalogProduct(
+            company_id=company_a.id,
+            offer_id=offer_id,
+            name=f"Product {offer_id}",
+            sku=f"SKU-{offer_id}",
+            price=100.00,
+            qty=10,
+            is_active=True,
+        )
+        async_db_session.add(p)
+
+    # Products for company B
+    for offer_id in ["OFFER003", "OFFER004"]:
+        p = KaspiCatalogProduct(
+            company_id=company_b.id,
+            offer_id=offer_id,
+            name=f"Product {offer_id}",
+            sku=f"SKU-{offer_id}",
+            price=200.00,
+            qty=20,
+            is_active=True,
+        )
+        async_db_session.add(p)
+
+    await async_db_session.commit()
+
+    # Generate for company A
+    result_a = await generate_products_feed(async_db_session, company_a.id)
+    assert result_a["total"] == 2
+
+    # Generate for company B
+    result_b = await generate_products_feed(async_db_session, company_b.id)
+    assert result_b["total"] == 2
+
+    # List exports for A (should only see A's export)
+    stmt_a = select(KaspiFeedExport).where(KaspiFeedExport.company_id == company_a.id)
+    result_a_list = await async_db_session.execute(stmt_a)
+    exports_a = result_a_list.scalars().all()
+    assert len(exports_a) == 1
+    assert exports_a[0].id == result_a["export_id"]
+
+    # List exports for B (should only see B's export)
+    stmt_b = select(KaspiFeedExport).where(KaspiFeedExport.company_id == company_b.id)
+    result_b_list = await async_db_session.execute(stmt_b)
+    exports_b = result_b_list.scalars().all()
+    assert len(exports_b) == 1
+    assert exports_b[0].id == result_b["export_id"]
+
+    # Checksums should differ (different products)
+    assert result_a["checksum"] != result_b["checksum"]
+
+
+@pytest.mark.asyncio
+async def test_upload_sets_status_uploaded_on_mock_success(
+    monkeypatch,
+    async_db_session,
+):
+    """Test that upload_feed_export sets status=uploaded on successful upload."""
+    from app.models.company import Company
+    from app.services.kaspi_feed_export_service import generate_products_feed, upload_feed_export
+
+    company = Company(name="TestCo C")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    # Create a product
+    p = KaspiCatalogProduct(
+        company_id=company.id,
+        offer_id="OFFER001",
+        name="Product A",
+        sku="SKU-A",
+        price=100.00,
+        qty=10,
+        is_active=True,
+    )
+    async_db_session.add(p)
+    await async_db_session.commit()
+
+    # Generate export
+    gen_result = await generate_products_feed(async_db_session, company.id)
+    export_id = gen_result["export_id"]
+
+    # Mock successful upload
+    async def mock_upload_success(self, xml_payload: str) -> bool:
+        assert isinstance(xml_payload, str)
+        assert len(xml_payload) > 0
+        return True
+
+    monkeypatch.setattr(KaspiService, "upload_products_feed", mock_upload_success)
+
+    # Upload
+    upload_result = await upload_feed_export(
+        async_db_session,
+        export_id,
+        company.id,
+        kaspi_service=KaspiService(),
+    )
+
+    assert upload_result["ok"] is True
+    assert upload_result["status"] == "uploaded"
+    assert upload_result["error"] is None
+
+    # Verify in DB
+    stmt = select(KaspiFeedExport).where(KaspiFeedExport.id == export_id)
+    db_result = await async_db_session.execute(stmt)
+    export = db_result.scalars().first()
+    assert export.status == "uploaded"
+    assert export.last_error is None
+
+
+@pytest.mark.asyncio
+async def test_upload_sets_status_failed_on_mock_error(
+    monkeypatch,
+    async_db_session,
+):
+    """Test that upload_feed_export sets status=failed and records error on failure."""
+    from app.models.company import Company
+    from app.services.kaspi_feed_export_service import generate_products_feed, upload_feed_export
+
+    company = Company(name="TestCo D")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    # Create a product
+    p = KaspiCatalogProduct(
+        company_id=company.id,
+        offer_id="OFFER001",
+        name="Product A",
+        sku="SKU-A",
+        price=100.00,
+        qty=10,
+        is_active=True,
+    )
+    async_db_session.add(p)
+    await async_db_session.commit()
+
+    # Generate export
+    gen_result = await generate_products_feed(async_db_session, company.id)
+    export_id = gen_result["export_id"]
+
+    # Mock failed upload
+    async def mock_upload_failure(self, xml_payload: str) -> bool:
+        raise RuntimeError("Network error: connection timeout")
+
+    monkeypatch.setattr(KaspiService, "upload_products_feed", mock_upload_failure)
+
+    # Upload
+    upload_result = await upload_feed_export(
+        async_db_session,
+        export_id,
+        company.id,
+        kaspi_service=KaspiService(),
+    )
+
+    assert upload_result["ok"] is False
+    assert upload_result["status"] == "failed"
+    assert upload_result["error"] is not None
+    assert "Network error" in upload_result["error"]
+
+    # Verify in DB
+    stmt = select(KaspiFeedExport).where(KaspiFeedExport.id == export_id)
+    db_result = await async_db_session.execute(stmt)
+    export = db_result.scalars().first()
+    assert export.status == "failed"
+    assert "Network error" in export.last_error


### PR DESCRIPTION
Adds KaspiFeedExport + migration, feed generation/upload services, tenant-scoped API endpoints, idempotency by checksum, and tests. Single-process pytest only (pytest-xdist unsupported).