### PR TITLE
fix(kaspi): feed upload hardening (CAS claim + stale takeover)

### DIFF
--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -976,7 +976,7 @@ async def kaspi_products_list(
 
 
 class KaspiFeedExportOut(BaseModel):
-    """Response model for feed export metadata."""
+    """Response model for feed export metadata with retry diagnostics."""
 
     id: int
     kind: str
@@ -985,6 +985,10 @@ class KaspiFeedExportOut(BaseModel):
     checksum: str
     stats_json: dict | None = None
     last_error: str | None = None
+    attempts: int = 0
+    last_attempt_at: str | None = None
+    uploaded_at: str | None = None
+    duration_ms: int | None = None
     created_at: str | None = None
     updated_at: str | None = None
 
@@ -1002,12 +1006,15 @@ class KaspiFeedGenerateOut(BaseModel):
 
 
 class KaspiFeedUploadOut(BaseModel):
-    """Response model for feed upload."""
+    """Response model for feed upload with retry diagnostics."""
 
     ok: bool
     export_id: int
     status: str
     error: str | None = None
+    is_retryable: bool | None = None
+    already_uploaded: bool = False
+    upload_in_progress: bool = False
 
 
 class KaspiFeedListOut(BaseModel):
@@ -1135,6 +1142,10 @@ async def kaspi_feeds_list(
                 checksum=e.checksum,
                 stats_json=e.stats_json,
                 last_error=e.last_error,
+                attempts=e.attempts or 0,
+                last_attempt_at=e.last_attempt_at.isoformat() if e.last_attempt_at else None,
+                uploaded_at=e.uploaded_at.isoformat() if e.uploaded_at else None,
+                duration_ms=e.duration_ms,
                 created_at=e.created_at.isoformat() if e.created_at else None,
                 updated_at=e.updated_at.isoformat() if e.updated_at else None,
             )
@@ -1197,6 +1208,10 @@ async def kaspi_feed_get(
             checksum=export.checksum,
             stats_json=export.stats_json,
             last_error=export.last_error,
+            attempts=export.attempts or 0,
+            last_attempt_at=export.last_attempt_at.isoformat() if export.last_attempt_at else None,
+            uploaded_at=export.uploaded_at.isoformat() if export.uploaded_at else None,
+            duration_ms=export.duration_ms,
             created_at=export.created_at.isoformat() if export.created_at else None,
             updated_at=export.updated_at.isoformat() if export.updated_at else None,
         )

--- a/app/models/kaspi_feed_export.py
+++ b/app/models/kaspi_feed_export.py
@@ -23,6 +23,13 @@ class KaspiFeedExport(Base):
     payload_text = Column(Text, nullable=False)  # XML content
     stats_json = Column(JSONB, nullable=True, server_default=text("NULL"))  # {total, active}
     last_error = Column(Text, nullable=True)
+    
+    # Retry and diagnostics
+    attempts = Column(Integer, nullable=False, server_default=text("0"))
+    last_attempt_at = Column(DateTime, nullable=True)
+    uploaded_at = Column(DateTime, nullable=True)
+    duration_ms = Column(Integer, nullable=True)
+    
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
 

--- a/app/services/kaspi_feed_export_service.py
+++ b/app/services/kaspi_feed_export_service.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import hashlib
+import time
 import xml.etree.ElementTree as ET
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import and_, select
+import httpx
+from sqlalchemy import and_, select, text
 from sqlalchemy.dialects.postgresql import insert
 
 from app.models import KaspiCatalogProduct, KaspiFeedExport
@@ -134,6 +136,32 @@ async def generate_products_feed(
     }
 
 
+def _classify_error(error: Exception) -> tuple[str, bool]:
+    """
+    Classify an error as retryable or not.
+
+    Returns: (error_message, is_retryable)
+    - Retryable: timeouts, network errors, 5xx server errors
+    - Non-retryable: 4xx client errors, validation errors
+    """
+    error_str = str(error)
+    error_type = type(error).__name__
+
+    # Retryable errors
+    if isinstance(error, httpx.TimeoutException | httpx.NetworkError | httpx.ConnectError):
+        return f"{error_type}: {error_str}", True
+
+    if isinstance(error, httpx.HTTPStatusError):
+        status_code = error.response.status_code
+        if 500 <= status_code < 600:
+            return f"HTTP {status_code}: {error_str}", True
+        elif 400 <= status_code < 500:
+            return f"HTTP {status_code}: {error_str}", False
+
+    # Default: treat unknown errors as non-retryable
+    return f"{error_type}: {error_str}", False
+
+
 async def upload_feed_export(
     session: AsyncSession,
     export_id: int,
@@ -141,14 +169,13 @@ async def upload_feed_export(
     kaspi_service: KaspiService | None = None,
 ) -> dict:
     """
-    Upload a feed export to Kaspi.
+    Upload a feed export to Kaspi with concurrency protection and retry tracking.
 
-    1. Load export scoped by company_id
-    2. Update status to "uploading"
-    3. Call KaspiService.upload_products_feed(payload)
-    4. On success: status="uploaded", last_error=None
-    5. On failure: status="failed", last_error=str(error)
-    6. Return summary {ok, export_id, status, error (if any)}
+    Uses PostgreSQL advisory lock to prevent concurrent uploads.
+    Tracks attempts, timestamps, and duration.
+    Classifies errors as retryable or non-retryable.
+
+    Returns: {ok, export_id, status, error, is_retryable, already_uploaded, upload_in_progress}
     """
     if kaspi_service is None:
         kaspi_service = KaspiService()
@@ -170,31 +197,97 @@ async def upload_feed_export(
             "export_id": export_id,
             "status": None,
             "error": "Export not found or access denied",
+            "is_retryable": False,
+            "already_uploaded": False,
+            "upload_in_progress": False,
         }
 
-    # Update status to uploading
+    # Idempotency: if already uploaded, return existing state
+    if export.status == "uploaded":
+        return {
+            "ok": True,
+            "export_id": export_id,
+            "status": "uploaded",
+            "error": None,
+            "is_retryable": False,
+            "already_uploaded": True,
+            "upload_in_progress": False,
+        }
+
+    # Try to acquire advisory lock (key: export_id)
+    # pg_try_advisory_lock returns true if lock acquired, false if already locked
+    lock_key = export_id
+    lock_result = await session.execute(text("SELECT pg_try_advisory_xact_lock(:key)"), {"key": lock_key})
+    lock_acquired = lock_result.scalar()
+
+    if not lock_acquired:
+        # Another process is uploading this export
+        return {
+            "ok": False,
+            "export_id": export_id,
+            "status": export.status,
+            "error": "Upload already in progress",
+            "is_retryable": True,
+            "already_uploaded": False,
+            "upload_in_progress": True,
+        }
+
+    # Lock acquired, proceed with upload
+    start_time = time.perf_counter()
+
+    # Update attempts and status
+    export.attempts = (export.attempts or 0) + 1
+    export.last_attempt_at = datetime.utcnow()
     export.status = "uploading"
     export.updated_at = datetime.utcnow()
     await session.flush()
 
     try:
-        # Call kaspi service stub
+        # Call kaspi service
         await kaspi_service.upload_products_feed(export.payload_text)
 
         # Success
+        end_time = time.perf_counter()
+        duration_ms = int((end_time - start_time) * 1000)
+
         export.status = "uploaded"
+        export.uploaded_at = datetime.utcnow()
+        export.duration_ms = duration_ms
         export.last_error = None
+        export.updated_at = datetime.utcnow()
+
+        await session.commit()
+
+        return {
+            "ok": True,
+            "export_id": export_id,
+            "status": "uploaded",
+            "error": None,
+            "is_retryable": False,
+            "already_uploaded": False,
+            "upload_in_progress": False,
+        }
+
     except Exception as e:
         # Failure
+        end_time = time.perf_counter()
+        duration_ms = int((end_time - start_time) * 1000)
+
+        error_message, is_retryable = _classify_error(e)
+
         export.status = "failed"
-        export.last_error = str(e)
+        export.last_error = error_message
+        export.duration_ms = duration_ms
+        export.updated_at = datetime.utcnow()
 
-    export.updated_at = datetime.utcnow()
-    await session.commit()
+        await session.commit()
 
-    return {
-        "ok": export.status == "uploaded",
-        "export_id": export_id,
-        "status": export.status,
-        "error": export.last_error,
-    }
+        return {
+            "ok": False,
+            "export_id": export_id,
+            "status": "failed",
+            "error": error_message,
+            "is_retryable": is_retryable,
+            "already_uploaded": False,
+            "upload_in_progress": False,
+        }

--- a/app/services/kaspi_feed_export_service.py
+++ b/app/services/kaspi_feed_export_service.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import hashlib
 import time
 import xml.etree.ElementTree as ET
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 import httpx
-from sqlalchemy import and_, select, text
+import sqlalchemy as sa
+from sqlalchemy import and_, or_, select, update
 from sqlalchemy.dialects.postgresql import insert
 
 from app.models import KaspiCatalogProduct, KaspiFeedExport
@@ -17,6 +18,10 @@ from app.services.kaspi_service import KaspiService
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
+
+
+STALE_UPLOAD_TIMEOUT = timedelta(minutes=15)
+MAX_ERROR_LENGTH = 1024
 
 
 async def generate_products_feed(
@@ -171,16 +176,15 @@ async def upload_feed_export(
     """
     Upload a feed export to Kaspi with concurrency protection and retry tracking.
 
-    Uses PostgreSQL advisory lock to prevent concurrent uploads.
-    Tracks attempts, timestamps, and duration.
-    Classifies errors as retryable or non-retryable.
+    Concurrency is enforced via a short CAS update (no long-running transactions).
+    Network upload is executed outside of any database transaction.
 
     Returns: {ok, export_id, status, error, is_retryable, already_uploaded, upload_in_progress}
     """
     if kaspi_service is None:
         kaspi_service = KaspiService()
 
-    # Load export
+    # Load export for initial checks/payload
     stmt = select(KaspiFeedExport).where(
         and_(
             KaspiFeedExport.id == export_id,
@@ -202,7 +206,6 @@ async def upload_feed_export(
             "upload_in_progress": False,
         }
 
-    # Idempotency: if already uploaded, return existing state
     if export.status == "uploaded":
         return {
             "ok": True,
@@ -214,48 +217,126 @@ async def upload_feed_export(
             "upload_in_progress": False,
         }
 
-    # Try to acquire advisory lock (key: export_id)
-    # pg_try_advisory_lock returns true if lock acquired, false if already locked
-    lock_key = export_id
-    lock_result = await session.execute(text("SELECT pg_try_advisory_xact_lock(:key)"), {"key": lock_key})
-    lock_acquired = lock_result.scalar()
+    now = datetime.utcnow()
+    stale_cutoff = now - STALE_UPLOAD_TIMEOUT
 
-    if not lock_acquired:
-        # Another process is uploading this export
+    # Short transaction: attempt to claim the upload slot via CAS update
+    claim_stmt = (
+        update(KaspiFeedExport)
+        .where(
+            and_(
+                KaspiFeedExport.id == export_id,
+                KaspiFeedExport.company_id == company_id,
+                or_(
+                    KaspiFeedExport.status.in_(("generated", "failed")),
+                    and_(
+                        KaspiFeedExport.status == "uploading",
+                        or_(
+                            KaspiFeedExport.last_attempt_at.is_(None),
+                            KaspiFeedExport.last_attempt_at < stale_cutoff,
+                        ),
+                    ),
+                ),
+            )
+        )
+        .values(
+            status="uploading",
+            attempts=sa.func.coalesce(KaspiFeedExport.attempts, 0) + 1,
+            last_attempt_at=now,
+            last_error=None,
+            updated_at=now,
+        )
+        .returning(
+            KaspiFeedExport.attempts,
+            KaspiFeedExport.payload_text,
+        )
+    )
+
+    claim_result = await session.execute(claim_stmt)
+    claimed_row = claim_result.first()
+    await session.commit()
+
+    if not claimed_row:
+        reread_stmt = (
+            select(
+                KaspiFeedExport.status,
+                KaspiFeedExport.last_attempt_at,
+                KaspiFeedExport.attempts,
+                KaspiFeedExport.uploaded_at,
+            )
+            .where(
+                and_(
+                    KaspiFeedExport.id == export_id,
+                    KaspiFeedExport.company_id == company_id,
+                )
+            )
+            .limit(1)
+        )
+        reread_result = await session.execute(reread_stmt)
+        current = reread_result.first()
+
+        if current and current.status == "uploaded":
+            return {
+                "ok": True,
+                "export_id": export_id,
+                "status": "uploaded",
+                "error": None,
+                "is_retryable": False,
+                "already_uploaded": True,
+                "upload_in_progress": False,
+            }
+
+        if (
+            current
+            and current.status == "uploading"
+            and current.last_attempt_at
+            and current.last_attempt_at >= stale_cutoff
+        ):
+            return {
+                "ok": False,
+                "export_id": export_id,
+                "status": current.status,
+                "error": "Upload already in progress",
+                "is_retryable": True,
+                "already_uploaded": False,
+                "upload_in_progress": True,
+            }
+
         return {
             "ok": False,
             "export_id": export_id,
-            "status": export.status,
-            "error": "Upload already in progress",
+            "status": current.status if current else export.status,
+            "error": "Upload not claimable",
             "is_retryable": True,
             "already_uploaded": False,
-            "upload_in_progress": True,
+            "upload_in_progress": False,
         }
 
-    # Lock acquired, proceed with upload
+    payload_text = claimed_row.payload_text
+
     start_time = time.perf_counter()
 
-    # Update attempts and status
-    export.attempts = (export.attempts or 0) + 1
-    export.last_attempt_at = datetime.utcnow()
-    export.status = "uploading"
-    export.updated_at = datetime.utcnow()
-    await session.flush()
-
     try:
-        # Call kaspi service
-        await kaspi_service.upload_products_feed(export.payload_text)
+        await kaspi_service.upload_products_feed(payload_text)
 
-        # Success
-        end_time = time.perf_counter()
-        duration_ms = int((end_time - start_time) * 1000)
+        duration_ms = max(1, int((time.perf_counter() - start_time) * 1000))
+        now_success = datetime.utcnow()
 
-        export.status = "uploaded"
-        export.uploaded_at = datetime.utcnow()
-        export.duration_ms = duration_ms
-        export.last_error = None
-        export.updated_at = datetime.utcnow()
-
+        await session.execute(
+            update(KaspiFeedExport)
+            .where(
+                and_(
+                    KaspiFeedExport.id == export_id,
+                    KaspiFeedExport.company_id == company_id,
+                )
+            )
+            .values(
+                status="uploaded",
+                uploaded_at=now_success,
+                duration_ms=duration_ms,
+                updated_at=now_success,
+            )
+        )
         await session.commit()
 
         return {
@@ -269,17 +350,26 @@ async def upload_feed_export(
         }
 
     except Exception as e:
-        # Failure
-        end_time = time.perf_counter()
-        duration_ms = int((end_time - start_time) * 1000)
-
+        duration_ms = max(1, int((time.perf_counter() - start_time) * 1000))
         error_message, is_retryable = _classify_error(e)
+        error_message = error_message[:MAX_ERROR_LENGTH]
+        now_fail = datetime.utcnow()
 
-        export.status = "failed"
-        export.last_error = error_message
-        export.duration_ms = duration_ms
-        export.updated_at = datetime.utcnow()
-
+        await session.execute(
+            update(KaspiFeedExport)
+            .where(
+                and_(
+                    KaspiFeedExport.id == export_id,
+                    KaspiFeedExport.company_id == company_id,
+                )
+            )
+            .values(
+                status="failed",
+                last_error=error_message,
+                duration_ms=duration_ms,
+                updated_at=now_fail,
+            )
+        )
         await session.commit()
 
         return {

--- a/migrations/versions/20260114_kaspi_feed_hardening.py
+++ b/migrations/versions/20260114_kaspi_feed_hardening.py
@@ -1,0 +1,34 @@
+"""feat(kaspi): add retry and diagnostics fields to feed exports
+
+Revision ID: 20260114_kaspi_feed_hardening
+Revises: 20260114_kaspi_feed_exports
+Create Date: 2026-01-14 12:45:00.000000+00:00
+
+"""
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260114_kaspi_feed_hardening"
+down_revision: Union[str, Sequence[str], None] = "20260114_kaspi_feed_exports"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add retry and diagnostics fields to kaspi_feed_exports."""
+    op.add_column("kaspi_feed_exports", sa.Column("attempts", sa.Integer(), nullable=False, server_default=sa.text("0")))
+    op.add_column("kaspi_feed_exports", sa.Column("last_attempt_at", sa.DateTime(), nullable=True))
+    op.add_column("kaspi_feed_exports", sa.Column("uploaded_at", sa.DateTime(), nullable=True))
+    op.add_column("kaspi_feed_exports", sa.Column("duration_ms", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove retry and diagnostics fields from kaspi_feed_exports."""
+    op.drop_column("kaspi_feed_exports", "duration_ms")
+    op.drop_column("kaspi_feed_exports", "uploaded_at")
+    op.drop_column("kaspi_feed_exports", "last_attempt_at")
+    op.drop_column("kaspi_feed_exports", "attempts")

--- a/tests/test_kaspi_feed_exports.py
+++ b/tests/test_kaspi_feed_exports.py
@@ -321,3 +321,318 @@ async def test_upload_sets_status_failed_on_mock_error(
     export = db_result.scalars().first()
     assert export.status == "failed"
     assert "Network error" in export.last_error
+
+
+# ========================================
+# Hardening Tests
+# ========================================
+
+
+@pytest.mark.asyncio
+async def test_upload_idempotent_when_already_uploaded(
+    monkeypatch,
+    async_db_session,
+):
+    """Test that uploading an already-uploaded export returns early without re-uploading."""
+    from app.models.company import Company
+    from app.services.kaspi_feed_export_service import generate_products_feed, upload_feed_export
+
+    # Create company and product
+    company = Company(name="TestCo")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    p = KaspiCatalogProduct(
+        company_id=company.id,
+        offer_id="OFFER001",
+        name="Product A",
+        sku="SKU-A",
+        price=100.00,
+        qty=10,
+        is_active=True,
+    )
+    async_db_session.add(p)
+    await async_db_session.commit()
+
+    # Generate export
+    gen_result = await generate_products_feed(async_db_session, company.id)
+    export_id = gen_result["export_id"]
+
+    # Mock successful upload
+    upload_count = 0
+
+    async def mock_upload_success(self, xml_payload: str) -> bool:
+        nonlocal upload_count
+        upload_count += 1
+        return True
+
+    monkeypatch.setattr(KaspiService, "upload_products_feed", mock_upload_success)
+
+    # First upload
+    result1 = await upload_feed_export(
+        async_db_session,
+        export_id,
+        company.id,
+        kaspi_service=KaspiService(),
+    )
+
+    assert result1["ok"] is True
+    assert result1["status"] == "uploaded"
+    assert result1["already_uploaded"] is False
+    assert upload_count == 1
+
+    # Second upload (should be idempotent)
+    result2 = await upload_feed_export(
+        async_db_session,
+        export_id,
+        company.id,
+        kaspi_service=KaspiService(),
+    )
+
+    assert result2["ok"] is True
+    assert result2["status"] == "uploaded"
+    assert result2["already_uploaded"] is True  # key assertion
+    assert upload_count == 1  # no second upload
+
+
+@pytest.mark.asyncio
+async def test_upload_increments_attempts_and_sets_timestamps(
+    monkeypatch,
+    async_db_session,
+):
+    """Test that upload tracks attempts, last_attempt_at, and duration_ms."""
+    from app.models.company import Company
+    from app.services.kaspi_feed_export_service import generate_products_feed, upload_feed_export
+
+    company = Company(name="TestCo")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    p = KaspiCatalogProduct(
+        company_id=company.id,
+        offer_id="OFFER001",
+        name="Product A",
+        sku="SKU-A",
+        price=100.00,
+        qty=10,
+        is_active=True,
+    )
+    async_db_session.add(p)
+    await async_db_session.commit()
+
+    # Generate export
+    gen_result = await generate_products_feed(async_db_session, company.id)
+    export_id = gen_result["export_id"]
+
+    # Mock successful upload
+    async def mock_upload_success(self, xml_payload: str) -> bool:
+        return True
+
+    monkeypatch.setattr(KaspiService, "upload_products_feed", mock_upload_success)
+
+    # Upload
+    upload_result = await upload_feed_export(
+        async_db_session,
+        export_id,
+        company.id,
+        kaspi_service=KaspiService(),
+    )
+
+    assert upload_result["ok"] is True
+    assert upload_result["status"] == "uploaded"
+
+    # Verify DB fields
+    stmt = select(KaspiFeedExport).where(KaspiFeedExport.id == export_id)
+    db_result = await async_db_session.execute(stmt)
+    export = db_result.scalars().first()
+
+    assert export.attempts == 1
+    assert export.last_attempt_at is not None
+    assert export.uploaded_at is not None
+    assert export.duration_ms is not None
+    assert export.duration_ms > 0
+
+
+@pytest.mark.asyncio
+async def test_upload_classifies_retryable_errors(
+    monkeypatch,
+    async_db_session,
+):
+    """Test that network/timeout/5xx errors are classified as retryable."""
+    import httpx
+
+    from app.models.company import Company
+    from app.services.kaspi_feed_export_service import generate_products_feed, upload_feed_export
+
+    company = Company(name="TestCo")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    p = KaspiCatalogProduct(
+        company_id=company.id,
+        offer_id="OFFER001",
+        name="Product A",
+        sku="SKU-A",
+        price=100.00,
+        qty=10,
+        is_active=True,
+    )
+    async_db_session.add(p)
+    await async_db_session.commit()
+
+    # Generate export
+    gen_result = await generate_products_feed(async_db_session, company.id)
+    export_id = gen_result["export_id"]
+
+    # Test 1: Timeout error (retryable)
+    async def mock_timeout_error(self, xml_payload: str) -> bool:
+        raise httpx.TimeoutException("Request timeout")
+
+    monkeypatch.setattr(KaspiService, "upload_products_feed", mock_timeout_error)
+
+    result = await upload_feed_export(
+        async_db_session,
+        export_id,
+        company.id,
+        kaspi_service=KaspiService(),
+    )
+
+    assert result["ok"] is False
+    assert result["is_retryable"] is True  # key assertion
+    assert "TimeoutException" in result["error"]
+
+    # Test 2: 503 Service Unavailable (retryable)
+    async def mock_5xx_error(self, xml_payload: str) -> bool:
+        # Create a mock response
+        mock_request = httpx.Request("POST", "https://api.kaspi.kz")
+        mock_response = httpx.Response(503, request=mock_request)
+        raise httpx.HTTPStatusError("Service unavailable", request=mock_request, response=mock_response)
+
+    monkeypatch.setattr(KaspiService, "upload_products_feed", mock_5xx_error)
+
+    result = await upload_feed_export(
+        async_db_session,
+        export_id,
+        company.id,
+        kaspi_service=KaspiService(),
+    )
+
+    assert result["ok"] is False
+    assert result["is_retryable"] is True  # 5xx is retryable
+
+
+@pytest.mark.asyncio
+async def test_upload_classifies_non_retryable_errors(
+    monkeypatch,
+    async_db_session,
+):
+    """Test that 4xx client errors are classified as non-retryable."""
+    import httpx
+
+    from app.models.company import Company
+    from app.services.kaspi_feed_export_service import generate_products_feed, upload_feed_export
+
+    company = Company(name="TestCo")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    p = KaspiCatalogProduct(
+        company_id=company.id,
+        offer_id="OFFER001",
+        name="Product A",
+        sku="SKU-A",
+        price=100.00,
+        qty=10,
+        is_active=True,
+    )
+    async_db_session.add(p)
+    await async_db_session.commit()
+
+    # Generate export
+    gen_result = await generate_products_feed(async_db_session, company.id)
+    export_id = gen_result["export_id"]
+
+    # Mock 400 Bad Request (non-retryable)
+    async def mock_4xx_error(self, xml_payload: str) -> bool:
+        mock_request = httpx.Request("POST", "https://api.kaspi.kz")
+        mock_response = httpx.Response(400, request=mock_request)
+        raise httpx.HTTPStatusError("Bad request", request=mock_request, response=mock_response)
+
+    monkeypatch.setattr(KaspiService, "upload_products_feed", mock_4xx_error)
+
+    result = await upload_feed_export(
+        async_db_session,
+        export_id,
+        company.id,
+        kaspi_service=KaspiService(),
+    )
+
+    assert result["ok"] is False
+    assert result["is_retryable"] is False  # 4xx is non-retryable
+    assert "HTTP 400" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_upload_protection_with_advisory_lock(
+    monkeypatch,
+    async_db_session,
+):
+    """
+    Test that concurrent uploads are prevented via advisory lock.
+
+    This test simulates the lock being busy by mocking the pg_try_advisory_xact_lock result.
+    """
+    from unittest.mock import AsyncMock
+
+    from sqlalchemy.engine import Result
+
+    from app.models.company import Company
+    from app.services.kaspi_feed_export_service import generate_products_feed, upload_feed_export
+
+    company = Company(name="TestCo")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    p = KaspiCatalogProduct(
+        company_id=company.id,
+        offer_id="OFFER001",
+        name="Product A",
+        sku="SKU-A",
+        price=100.00,
+        qty=10,
+        is_active=True,
+    )
+    async_db_session.add(p)
+    await async_db_session.commit()
+
+    # Generate export
+    gen_result = await generate_products_feed(async_db_session, company.id)
+    export_id = gen_result["export_id"]
+
+    # Mock the session.execute to return False for advisory lock (lock busy)
+    original_execute = async_db_session.execute
+
+    async def mock_execute(stmt, *args, **kwargs):
+        # Check if this is the advisory lock query
+        if hasattr(stmt, "text") and "pg_try_advisory_xact_lock" in str(stmt):
+            # Return False to simulate lock busy
+            mock_result = AsyncMock(spec=Result)
+            mock_result.scalar.return_value = False
+            return mock_result
+        # Otherwise, call the original
+        return await original_execute(stmt, *args, **kwargs)
+
+    monkeypatch.setattr(async_db_session, "execute", mock_execute)
+
+    # Attempt upload (should fail due to lock busy)
+    upload_result = await upload_feed_export(
+        async_db_session,
+        export_id,
+        company.id,
+        kaspi_service=KaspiService(),
+    )
+
+    assert upload_result["ok"] is False
+    assert upload_result["upload_in_progress"] is True  # key assertion
+    assert "already in progress" in upload_result["error"].lower()
+    assert upload_result["is_retryable"] is True

--- a/tests/test_kaspi_feed_exports.py
+++ b/tests/test_kaspi_feed_exports.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
+
 import pytest
 import sqlalchemy as sa
 from sqlalchemy import select
@@ -573,19 +575,11 @@ async def test_upload_classifies_non_retryable_errors(
 
 
 @pytest.mark.asyncio
-async def test_concurrent_upload_protection_with_advisory_lock(
+async def test_concurrent_upload_protection_when_recently_uploading(
     monkeypatch,
     async_db_session,
 ):
-    """
-    Test that concurrent uploads are prevented via advisory lock.
-
-    This test simulates the lock being busy by mocking the pg_try_advisory_xact_lock result.
-    """
-    from unittest.mock import AsyncMock
-
-    from sqlalchemy.engine import Result
-
+    """If status is uploading with a fresh attempt, service must not re-upload."""
     from app.models.company import Company
     from app.services.kaspi_feed_export_service import generate_products_feed, upload_feed_export
 
@@ -605,26 +599,24 @@ async def test_concurrent_upload_protection_with_advisory_lock(
     async_db_session.add(p)
     await async_db_session.commit()
 
-    # Generate export
     gen_result = await generate_products_feed(async_db_session, company.id)
     export_id = gen_result["export_id"]
 
-    # Mock the session.execute to return False for advisory lock (lock busy)
-    original_execute = async_db_session.execute
+    # Mark as uploading recently
+    now = datetime.utcnow()
+    await async_db_session.execute(
+        sa.update(KaspiFeedExport)
+        .where(KaspiFeedExport.id == export_id)
+        .values(status="uploading", last_attempt_at=now, attempts=1)
+    )
+    await async_db_session.commit()
 
-    async def mock_execute(stmt, *args, **kwargs):
-        # Check if this is the advisory lock query
-        if hasattr(stmt, "text") and "pg_try_advisory_xact_lock" in str(stmt):
-            # Return False to simulate lock busy
-            mock_result = AsyncMock(spec=Result)
-            mock_result.scalar.return_value = False
-            return mock_result
-        # Otherwise, call the original
-        return await original_execute(stmt, *args, **kwargs)
+    # Ensure upload is NOT called
+    async def mock_upload_should_not_run(self, xml_payload: str) -> bool:
+        raise AssertionError("Upload should not be invoked when another upload is in progress")
 
-    monkeypatch.setattr(async_db_session, "execute", mock_execute)
+    monkeypatch.setattr(KaspiService, "upload_products_feed", mock_upload_should_not_run)
 
-    # Attempt upload (should fail due to lock busy)
     upload_result = await upload_feed_export(
         async_db_session,
         export_id,
@@ -633,6 +625,148 @@ async def test_concurrent_upload_protection_with_advisory_lock(
     )
 
     assert upload_result["ok"] is False
-    assert upload_result["upload_in_progress"] is True  # key assertion
-    assert "already in progress" in upload_result["error"].lower()
+    assert upload_result["upload_in_progress"] is True
     assert upload_result["is_retryable"] is True
+    assert upload_result["already_uploaded"] is False
+
+    # attempts should remain unchanged when we fail to acquire
+    stmt = select(KaspiFeedExport).where(KaspiFeedExport.id == export_id)
+    db_result = await async_db_session.execute(stmt)
+    export = db_result.scalars().first()
+    assert export.attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_stale_upload_takeover(monkeypatch, async_db_session):
+    """If upload is stale (>15m), new upload should take over and succeed."""
+    from app.models.company import Company
+    from app.services.kaspi_feed_export_service import generate_products_feed, upload_feed_export
+
+    company = Company(name="TestCo")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    p = KaspiCatalogProduct(
+        company_id=company.id,
+        offer_id="OFFER001",
+        name="Product A",
+        sku="SKU-A",
+        price=100.00,
+        qty=10,
+        is_active=True,
+    )
+    async_db_session.add(p)
+    await async_db_session.commit()
+
+    gen_result = await generate_products_feed(async_db_session, company.id)
+    export_id = gen_result["export_id"]
+
+    stale_time = datetime.utcnow() - timedelta(minutes=20)
+    await async_db_session.execute(
+        sa.update(KaspiFeedExport)
+        .where(KaspiFeedExport.id == export_id)
+        .values(status="uploading", last_attempt_at=stale_time, attempts=1)
+    )
+    await async_db_session.commit()
+
+    upload_called = False
+
+    async def mock_upload_success(self, xml_payload: str) -> bool:
+        nonlocal upload_called
+        upload_called = True
+        return True
+
+    monkeypatch.setattr(KaspiService, "upload_products_feed", mock_upload_success)
+
+    result = await upload_feed_export(
+        async_db_session,
+        export_id,
+        company.id,
+        kaspi_service=KaspiService(),
+    )
+
+    assert result["ok"] is True
+    assert result["upload_in_progress"] is False
+    assert upload_called is True
+
+    stmt = select(KaspiFeedExport).where(KaspiFeedExport.id == export_id)
+    db_result = await async_db_session.execute(stmt)
+    export = db_result.scalars().first()
+    assert export.status == "uploaded"
+    assert export.attempts == 2  # previous attempt + takeover
+    assert export.last_attempt_at is not None
+    assert export.uploaded_at is not None
+    assert export.duration_ms is not None
+
+
+@pytest.mark.asyncio
+async def test_claim_fail_then_already_uploaded(monkeypatch, async_db_session):
+    """If claim fails but row becomes uploaded, return already_uploaded without calling upload."""
+    from app.models.company import Company
+    from app.services.kaspi_feed_export_service import generate_products_feed, upload_feed_export
+
+    company = Company(name="TestCo")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    p = KaspiCatalogProduct(
+        company_id=company.id,
+        offer_id="OFFER001",
+        name="Product A",
+        sku="SKU-A",
+        price=100.00,
+        qty=10,
+        is_active=True,
+    )
+    async_db_session.add(p)
+    await async_db_session.commit()
+
+    gen_result = await generate_products_feed(async_db_session, company.id)
+    export_id = gen_result["export_id"]
+
+    # Put into uploading recent so CAS will fail, and flip to uploaded during claim attempt
+    now = datetime.utcnow()
+    await async_db_session.execute(
+        sa.update(KaspiFeedExport)
+        .where(KaspiFeedExport.id == export_id)
+        .values(status="uploading", last_attempt_at=now, attempts=1)
+    )
+    await async_db_session.commit()
+
+    original_execute = async_db_session.execute
+
+    async def mock_execute(stmt, *args, **kwargs):
+        # On claim attempt, switch row to uploaded and return no rows to simulate another worker
+        if isinstance(stmt, sa.sql.dml.Update) and getattr(stmt.table, "name", "") == KaspiFeedExport.__tablename__:
+            await original_execute(
+                sa.update(KaspiFeedExport)
+                .where(KaspiFeedExport.id == export_id)
+                .values(status="uploaded", uploaded_at=datetime.utcnow())
+            )
+            await async_db_session.commit()
+
+            class _Empty:
+                def first(self_inner):
+                    return None
+
+            return _Empty()
+        return await original_execute(stmt, *args, **kwargs)
+
+    monkeypatch.setattr(async_db_session, "execute", mock_execute)
+
+    async def mock_upload_should_not_run(self, xml_payload: str) -> bool:
+        raise AssertionError("Upload should not be called when already uploaded is detected")
+
+    monkeypatch.setattr(KaspiService, "upload_products_feed", mock_upload_should_not_run)
+
+    result = await upload_feed_export(
+        async_db_session,
+        export_id,
+        company.id,
+        kaspi_service=KaspiService(),
+    )
+
+    assert result["ok"] is True
+    assert result["already_uploaded"] is True
+    assert result["upload_in_progress"] is False
+    assert result["is_retryable"] is False


### PR DESCRIPTION
Production-grade concurrency for feed upload: short CAS claim transaction (no long DB tx), network upload outside tx, precise claim-fail states (already_uploaded / in-progress / not-claimable), stale takeover, regression tests. ruff + full pytest OK locally.