### PR TITLE
feat(kaspi): status endpoint (tenant-scoped)

### DIFF
--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -46,6 +46,7 @@ from app.integrations.kaspi_adapter import KaspiAdapter, KaspiAdapterError
 from app.models import Product
 from app.models.company import Company
 from app.models.kaspi_catalog_product import KaspiCatalogProduct
+from app.models.kaspi_feed_export import KaspiFeedExport
 from app.models.kaspi_order_sync_state import KaspiOrderSyncState
 from app.models.marketplace import KaspiStoreToken
 from app.models.user import User
@@ -71,6 +72,7 @@ router = APIRouter(prefix="/api/v1/kaspi", tags=["kaspi"])
 
 MASK_HEX_LEN = 10
 MASK_CHAR = "..."
+STATUS_LAST_ERROR_MAX_LEN = 500
 
 
 def normalize_name(name: str) -> str:
@@ -1026,6 +1028,55 @@ class KaspiFeedListOut(BaseModel):
     offset: int
 
 
+class KaspiStatusFeedOut(BaseModel):
+    """Status summary for the latest products feed."""
+
+    id: int
+    status: str
+    attempts: int = 0
+    last_attempt_at: str | None = None
+    uploaded_at: str | None = None
+    duration_ms: int | None = None
+    last_error: str | None = None
+    created_at: str | None = None
+
+
+class KaspiStatusFeedsOut(BaseModel):
+    products_latest: KaspiStatusFeedOut | None = None
+
+
+class KaspiCatalogStatusOut(BaseModel):
+    total: int
+    active: int
+    last_updated_at: str | None = None
+
+
+class KaspiOrdersSyncStatusOut(BaseModel):
+    last_synced_at: str | None = None
+    last_external_order_id: str | None = None
+    last_attempt_at: str | None = None
+    last_duration_ms: int | None = None
+    last_result: str | None = None
+    last_fetched: int | None = None
+    last_inserted: int | None = None
+    last_updated: int | None = None
+    last_error_at: str | None = None
+    last_error_code: str | None = None
+    last_error_message: str | None = None
+    updated_at: str | None = None
+
+
+class KaspiHealthStatusOut(BaseModel):
+    has_kaspi_token_configured: bool
+
+
+class KaspiStatusOut(BaseModel):
+    feeds: KaspiStatusFeedsOut
+    catalog: KaspiCatalogStatusOut
+    orders_sync: KaspiOrdersSyncStatusOut | None = None
+    health: KaspiHealthStatusOut
+
+
 @router.post(
     "/feeds/products/generate",
     summary="Сгенерировать фид продуктов для Kaspi",
@@ -1272,4 +1323,147 @@ async def kaspi_feed_get_payload(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve payload",
+        )
+
+
+# ============================= STATUS (операционная панель) =============================
+
+
+@router.get(
+    "/status",
+    summary="Статус интеграции Kaspi по компании",
+    response_model=KaspiStatusOut,
+)
+async def kaspi_status(
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    """
+    Возвращает срез состояния интеграции по компании: фиды, каталог, синк заказов, health.
+    Без сетевых вызовов, только чтение из БД.
+    """
+
+    company_id = _resolve_company_id(current_user)
+
+    try:
+        company = (await session.execute(sa.select(Company).where(Company.id == company_id))).scalars().first()
+        if not company:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+
+        # Latest products feed
+        feed_stmt = (
+            sa.select(
+                KaspiFeedExport.id,
+                KaspiFeedExport.status,
+                KaspiFeedExport.attempts,
+                KaspiFeedExport.last_attempt_at,
+                KaspiFeedExport.uploaded_at,
+                KaspiFeedExport.duration_ms,
+                KaspiFeedExport.last_error,
+                KaspiFeedExport.created_at,
+            )
+            .where(
+                sa.and_(
+                    KaspiFeedExport.company_id == company_id,
+                    KaspiFeedExport.kind == "products",
+                )
+            )
+            .order_by(KaspiFeedExport.created_at.desc())
+            .limit(1)
+        )
+
+        feed_row = await session.execute(feed_stmt)
+        feed_row = feed_row.first()
+
+        products_latest = None
+        if feed_row:
+            last_error = feed_row.last_error[:STATUS_LAST_ERROR_MAX_LEN] if feed_row.last_error else None
+            products_latest = KaspiStatusFeedOut(
+                id=feed_row.id,
+                status=feed_row.status,
+                attempts=feed_row.attempts or 0,
+                last_attempt_at=feed_row.last_attempt_at.isoformat() if feed_row.last_attempt_at else None,
+                uploaded_at=feed_row.uploaded_at.isoformat() if feed_row.uploaded_at else None,
+                duration_ms=feed_row.duration_ms,
+                last_error=last_error,
+                created_at=feed_row.created_at.isoformat() if feed_row.created_at else None,
+            )
+
+        # Catalog aggregates
+        catalog_stmt = (
+            sa.select(
+                sa.func.count(KaspiCatalogProduct.id),
+                sa.func.count().filter(KaspiCatalogProduct.is_active.is_(True)),
+                sa.func.max(KaspiCatalogProduct.updated_at),
+            )
+            .where(KaspiCatalogProduct.company_id == company_id)
+            .limit(1)
+        )
+        catalog_row = await session.execute(catalog_stmt)
+        catalog_row = catalog_row.first()
+        catalog_total = catalog_row[0] or 0 if catalog_row else 0
+        catalog_active = catalog_row[1] or 0 if catalog_row else 0
+        catalog_last_updated = catalog_row[2].isoformat() if catalog_row and catalog_row[2] else None
+
+        catalog = KaspiCatalogStatusOut(
+            total=int(catalog_total),
+            active=int(catalog_active),
+            last_updated_at=catalog_last_updated,
+        )
+
+        # Orders sync state
+        orders_sync_row = (
+            (
+                await session.execute(
+                    sa.select(KaspiOrderSyncState).where(KaspiOrderSyncState.company_id == company_id).limit(1)
+                )
+            )
+            .scalars()
+            .first()
+        )
+
+        orders_sync = None
+        if orders_sync_row:
+            orders_sync = KaspiOrdersSyncStatusOut(
+                last_synced_at=orders_sync_row.last_synced_at.isoformat() if orders_sync_row.last_synced_at else None,
+                last_external_order_id=orders_sync_row.last_external_order_id,
+                last_attempt_at=orders_sync_row.last_attempt_at.isoformat()
+                if orders_sync_row.last_attempt_at
+                else None,
+                last_duration_ms=orders_sync_row.last_duration_ms,
+                last_result=orders_sync_row.last_result,
+                last_fetched=orders_sync_row.last_fetched,
+                last_inserted=orders_sync_row.last_inserted,
+                last_updated=orders_sync_row.last_updated,
+                last_error_at=orders_sync_row.last_error_at.isoformat() if orders_sync_row.last_error_at else None,
+                last_error_code=orders_sync_row.last_error_code,
+                last_error_message=orders_sync_row.last_error_message,
+                updated_at=orders_sync_row.updated_at.isoformat() if orders_sync_row.updated_at else None,
+            )
+
+        # Health: token presence (no secrets)
+        has_token = False
+        store_name = company.kaspi_store_id
+        if store_name:
+            token_count = await session.execute(
+                sa.select(sa.func.count())
+                .select_from(KaspiStoreToken)
+                .where(sa.func.lower(KaspiStoreToken.store_name) == sa.func.lower(sa.literal(store_name)))
+            )
+            has_token = (token_count.scalar() or 0) > 0
+
+        return KaspiStatusOut(
+            feeds=KaspiStatusFeedsOut(products_latest=products_latest),
+            catalog=catalog,
+            orders_sync=orders_sync,
+            health=KaspiHealthStatusOut(has_kaspi_token_configured=has_token),
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Kaspi status failed: company_id=%s error=%s", company_id, e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to load Kaspi status",
         )

--- a/app/models/kaspi_feed_export.py
+++ b/app/models/kaspi_feed_export.py
@@ -23,13 +23,13 @@ class KaspiFeedExport(Base):
     payload_text = Column(Text, nullable=False)  # XML content
     stats_json = Column(JSONB, nullable=True, server_default=text("NULL"))  # {total, active}
     last_error = Column(Text, nullable=True)
-    
+
     # Retry and diagnostics
     attempts = Column(Integer, nullable=False, server_default=text("0"))
     last_attempt_at = Column(DateTime, nullable=True)
     uploaded_at = Column(DateTime, nullable=True)
     duration_ms = Column(Integer, nullable=True)
-    
+
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
 

--- a/tests/test_kaspi_status_api.py
+++ b/tests/test_kaspi_status_api.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+import sqlalchemy as sa
+
+from app.models.company import Company
+from app.models.kaspi_catalog_product import KaspiCatalogProduct
+from app.models.kaspi_feed_export import KaspiFeedExport
+from app.models.kaspi_order_sync_state import KaspiOrderSyncState
+from app.models.marketplace import KaspiStoreToken
+
+
+@pytest.mark.asyncio
+async def test_kaspi_status_returns_latest_feed_and_counts(
+    async_client,
+    async_db_session,
+    company_a_admin_headers,
+):
+    """Status endpoint returns latest feed, catalog aggregates, orders sync, and health for tenant."""
+
+    company_id = 1001
+    store_name = "store-status-a"
+
+    # Clean previous data for this company
+    await async_db_session.execute(sa.delete(KaspiFeedExport).where(KaspiFeedExport.company_id == company_id))
+    await async_db_session.execute(sa.delete(KaspiCatalogProduct).where(KaspiCatalogProduct.company_id == company_id))
+    await async_db_session.execute(sa.delete(KaspiOrderSyncState).where(KaspiOrderSyncState.company_id == company_id))
+    await async_db_session.execute(sa.delete(KaspiStoreToken).where(KaspiStoreToken.store_name == store_name))
+
+    # Configure company
+    company = (await async_db_session.execute(sa.select(Company).where(Company.id == company_id))).scalars().first()
+    company.kaspi_store_id = store_name
+
+    # Token (masked/boolean only)
+    async_db_session.add(KaspiStoreToken(store_name=store_name, token_ciphertext=b"secret"))
+
+    # Feed export (latest)
+    now = datetime.utcnow()
+    long_error = "E" * 600
+    feed = KaspiFeedExport(
+        company_id=company_id,
+        kind="products",
+        format="xml",
+        status="uploaded",
+        checksum="status-feed-chk-1",
+        payload_text="<products></products>",
+        attempts=2,
+        last_attempt_at=now - timedelta(minutes=5),
+        uploaded_at=now,
+        duration_ms=123,
+        last_error=long_error,
+        created_at=now - timedelta(minutes=10),
+    )
+    async_db_session.add(feed)
+
+    # Catalog products
+    prod1 = KaspiCatalogProduct(
+        company_id=company_id,
+        offer_id="OFFER-STAT-1",
+        name="Status Product 1",
+        sku="SKU-STAT-1",
+        price=100,
+        qty=5,
+        is_active=True,
+        updated_at=now,
+    )
+    prod2 = KaspiCatalogProduct(
+        company_id=company_id,
+        offer_id="OFFER-STAT-2",
+        name="Status Product 2",
+        sku="SKU-STAT-2",
+        price=50,
+        qty=0,
+        is_active=False,
+        updated_at=now - timedelta(minutes=1),
+    )
+    async_db_session.add_all([prod1, prod2])
+
+    # Orders sync state
+    sync_state = KaspiOrderSyncState(
+        company_id=company_id,
+        last_synced_at=now - timedelta(hours=1),
+        last_external_order_id="ord-123",
+        last_attempt_at=now - timedelta(minutes=2),
+        last_duration_ms=456,
+        last_result="ok",
+        last_fetched=3,
+        last_inserted=2,
+        last_updated=1,
+        last_error_at=None,
+        last_error_code=None,
+        last_error_message=None,
+        updated_at=now - timedelta(minutes=2),
+    )
+    async_db_session.add(sync_state)
+
+    await async_db_session.commit()
+
+    resp = await async_client.get("/api/v1/kaspi/status", headers=company_a_admin_headers)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    feed_data = data["feeds"]["products_latest"]
+    assert feed_data["id"] == feed.id
+    assert feed_data["attempts"] == 2
+    assert feed_data["status"] == "uploaded"
+    assert len(feed_data["last_error"]) <= 500
+    assert feed_data["last_error"].startswith("E")
+
+    catalog = data["catalog"]
+    assert catalog["total"] == 2
+    assert catalog["active"] == 1
+    assert catalog["last_updated_at"] is not None
+
+    orders_sync = data["orders_sync"]
+    assert orders_sync["last_result"] == "ok"
+    assert orders_sync["last_fetched"] == 3
+
+    health = data["health"]
+    assert health["has_kaspi_token_configured"] is True
+
+
+@pytest.mark.asyncio
+async def test_kaspi_status_is_tenant_isolated_and_null_when_no_feed(
+    async_client,
+    async_db_session,
+    company_b_admin_headers,
+):
+    """Tenant B should not see company A data and gets nulls when no records exist."""
+
+    company_id_b = 2001
+
+    # Cleanup B data
+    await async_db_session.execute(sa.delete(KaspiFeedExport).where(KaspiFeedExport.company_id == company_id_b))
+    await async_db_session.execute(sa.delete(KaspiCatalogProduct).where(KaspiCatalogProduct.company_id == company_id_b))
+    await async_db_session.execute(sa.delete(KaspiOrderSyncState).where(KaspiOrderSyncState.company_id == company_id_b))
+
+    company_b = (await async_db_session.execute(sa.select(Company).where(Company.id == company_id_b))).scalars().first()
+    company_b.kaspi_store_id = None
+
+    await async_db_session.commit()
+
+    resp = await async_client.get("/api/v1/kaspi/status", headers=company_b_admin_headers)
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()
+    assert data["feeds"]["products_latest"] is None
+    assert data["catalog"]["total"] == 0
+    assert data["catalog"]["active"] == 0
+    assert data["catalog"]["last_updated_at"] is None
+    assert data["orders_sync"] is None
+    assert data["health"]["has_kaspi_token_configured"] is False


### PR DESCRIPTION
Adds GET /api/v1/kaspi/status aggregated status (feed/catalog/orders-sync/token) without external calls + API tests. Local ruff+pytest OK.