### PR TITLE
feat(auth): invitations + password reset tokens; employee role; OTP TTL; anti-reuse locks

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -42,29 +42,44 @@ from app.core.dependencies import (
     get_otp_service,
     otp_rate_limit,
 )
-from app.core.exceptions import AuthenticationError, ConflictError, SmartSellValidationError
+from app.core.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    ConflictError,
+    ExternalServiceError,
+    SmartSellValidationError,
+)
 from app.core.logging import audit_logger
 from app.core.security import (
     create_access_token,
     create_refresh_token,
     get_password_hash,
+    require_company_admin,
+    resolve_tenant_company_id,
     verify_password,
 )
 from app.integrations.ports.otp import OtpProvider
 from app.models.company import Company
+from app.models.invitation import InvitationToken, PasswordResetToken
 from app.models.otp import OtpAttempt  # таблица otp_codes и enterprise-OTP попытки
 from app.models.user import User, UserSession
 from app.schemas.base import SuccessResponse
 from app.schemas.user import (
+    InvitationAccept,
+    InvitationCreate,
     OTPRequest,
     OTPVerify,
     PasswordReset,
+    PasswordResetConfirm,
+    PasswordResetRequest,
     RefreshTokenRequest,
     TokenResponse,
     UserCreate,
     UserLogin,
 )
+from app.services.messaging import MessagingConfigError, send_email
 from app.utils.otp import create_otp_attempt, verify_otp_code
+from app.utils.tokens import generate_token, hash_token
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])
 
@@ -159,6 +174,15 @@ def _should_return_provider_info() -> bool:
         return False
     is_test_env = bool(os.getenv("PYTEST_CURRENT_TEST")) or bool(getattr(settings, "TESTING", False))
     return is_test_env or (env != "production")
+
+
+def _is_production() -> bool:
+    env = str(os.getenv("ENVIRONMENT") or getattr(settings, "ENVIRONMENT", "production") or "production").lower()
+    return env == "production"
+
+
+def _public_url() -> str:
+    return str(getattr(settings, "PUBLIC_URL", os.getenv("PUBLIC_URL", "http://localhost:8000")) or "").rstrip("/")
 
 
 # =============================================================================
@@ -745,6 +769,125 @@ async def verify_otp(otp_verify: OTPVerify, db: AsyncSession = Depends(get_async
 
 
 # =============================================================================
+# Invitations
+# =============================================================================
+
+
+@router.post(
+    "/invitations",
+    response_model=SuccessResponse,
+    dependencies=[Depends(auth_rate_limit)],
+)
+async def create_invitation(
+    payload: InvitationCreate,
+    current_user: User = Depends(require_company_admin),
+    db: AsyncSession = Depends(get_async_db),
+):
+    company_id = resolve_tenant_company_id(current_user)
+    res_company = await db.execute(select(Company).where(Company.id == company_id))
+    company = res_company.scalars().first()
+    is_owner = bool(company and company.owner_id and company.owner_id == current_user.id)
+    email = (payload.email or "").strip().lower()
+    phone = _normalize_phone(payload.phone)
+    variants = _phone_variants(phone)
+    role = (payload.role or "employee").strip().lower()
+    if role not in {"admin", "employee"}:
+        raise SmartSellValidationError("Invalid role", "INVALID_ROLE")
+    if not is_owner and role == "admin":
+        raise AuthorizationError("Only owner can invite admins", "OWNER_REQUIRED")
+
+    # Ensure no existing user for this company (phone/email uniqueness assumed global)
+    res = await db.execute(select(User).where(User.phone.in_(variants)))
+    if res.scalars().first():
+        raise SmartSellValidationError("User with this phone already exists", "USER_EXISTS")
+    if email:
+        res_e = await db.execute(select(User).where(User.email == email))
+        if res_e.scalars().first():
+            raise SmartSellValidationError("User with this email already exists", "USER_EXISTS")
+
+    token = generate_token()
+    token_hash = hash_token(token, secret=getattr(settings, "INVITE_TOKEN_SECRET", None))
+    invite = InvitationToken.build(
+        company_id=company_id,
+        role=role,
+        phone=phone,
+        email=email,
+        display_name=payload.display_name,
+        token_hash=token_hash,
+        ttl_hours=72,
+        created_by_user_id=current_user.id,
+    )
+    db.add(invite)
+    await db.commit()
+    await db.refresh(invite)
+
+    data = {"invitation_id": invite.id, "expires_at": invite.expires_at}
+
+    return SuccessResponse(message="Invitation created", data=data)
+
+
+@router.post(
+    "/invitations/accept",
+    response_model=TokenResponse,
+    dependencies=[Depends(auth_rate_limit)],
+)
+async def accept_invitation(payload: InvitationAccept, db: AsyncSession = Depends(get_async_db)):
+    token_hash = hash_token(payload.token, secret=getattr(settings, "INVITE_TOKEN_SECRET", None))
+    async with db.begin():
+        res = await db.execute(
+            select(InvitationToken).where(InvitationToken.token_hash == token_hash).with_for_update()
+        )
+        invite = res.scalars().first()
+
+        if not invite or invite.used_at or invite.expires_at <= _utcnow_naive():
+            raise SmartSellValidationError("Invitation is invalid or expired", "INVITATION_INVALID")
+
+        # Guard against duplicate user creation
+        if invite.phone:
+            res_u = await db.execute(select(User).where(User.phone.in_(_phone_variants(invite.phone))))
+            if res_u.scalars().first():
+                raise SmartSellValidationError("User already exists", "USER_EXISTS")
+        if invite.email:
+            res_e = await db.execute(select(User).where(User.email == invite.email))
+            if res_e.scalars().first():
+                raise SmartSellValidationError("User already exists", "USER_EXISTS")
+
+        user = User(
+            company_id=invite.company_id,
+            phone=invite.phone,
+            email=invite.email,
+            full_name=invite.display_name,
+            role=invite.role,
+            is_active=True,
+            is_verified=False,
+            hashed_password=get_password_hash(payload.password),
+        )
+        db.add(user)
+        invite.used_at = _utcnow_naive()
+
+    await db.refresh(user)
+
+    access_token, refresh_token = _issue_tokens_for_user(user.id)
+    session = UserSession(
+        user_id=user.id,
+        refresh_token=hashlib.sha256(refresh_token.encode()).hexdigest(),
+        ip_address="",
+        user_agent="",
+        expires_at=_utcnow_naive() + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS),
+        is_active=True,
+    )
+    db.add(session)
+    await db.commit()
+
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_type="bearer",
+        expires_in=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+    )
+
+
+# =============================================================================
 # Password reset
 # =============================================================================
 
@@ -783,6 +926,106 @@ async def reset_password(reset_data: PasswordReset, db: AsyncSession = Depends(g
     )
 
     return SuccessResponse(message="Password reset successfully")
+
+
+# =============================================================================
+# Password reset (token-based)
+# =============================================================================
+
+
+@router.post(
+    "/password/reset/request",
+    response_model=SuccessResponse,
+    dependencies=[Depends(auth_rate_limit)],
+)
+async def password_reset_request(
+    payload: PasswordResetRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_async_db),
+):
+    identifier = (payload.identifier or "").strip()
+    phone = _normalize_phone(identifier)
+    email = (identifier or "").strip().lower()
+    client_info = get_client_info(request)
+
+    user = None
+    if phone:
+        res = await db.execute(select(User).where(User.phone.in_(_phone_variants(phone))))
+        user = res.scalars().first()
+    if not user and email:
+        res_e = await db.execute(select(User).where(User.email == email))
+        user = res_e.scalars().first()
+
+    # Always return success to avoid leaking existence
+    if not user or not user.email or not user.is_active:
+        return SuccessResponse(message="If the account exists, reset instructions were sent")
+
+    token = generate_token()
+    token_hash = hash_token(token, secret=getattr(settings, "RESET_TOKEN_SECRET", None))
+    reset_obj = PasswordResetToken.build(
+        user_id=user.id,
+        token_hash=token_hash,
+        ttl_minutes=10,
+        requested_ip=client_info.get("ip_address"),
+        user_agent=client_info.get("user_agent"),
+    )
+    db.add(reset_obj)
+    await db.commit()
+
+    reset_url = f"{_public_url()}/reset-password?token={token}"
+    try:
+        await send_email(
+            to=user.email,
+            subject="Password reset",
+            body=f"Reset your password: {reset_url}",
+            meta={"user_id": user.id},
+        )
+    except MessagingConfigError:
+        if _is_production():
+            raise ExternalServiceError(
+                "Email provider not configured",
+                "EMAIL_PROVIDER_NOT_CONFIGURED",
+                http_status=503,
+            )
+        # In non-prod: log-only via send_email, ignore
+
+    data = {}
+    if not _is_production():
+        data["reset_url"] = reset_url
+
+    return SuccessResponse(message="If the account exists, reset instructions were sent", data=data)
+
+
+@router.post(
+    "/password/reset/confirm",
+    response_model=SuccessResponse,
+    dependencies=[Depends(auth_rate_limit)],
+)
+async def password_reset_confirm(
+    payload: PasswordResetConfirm,
+    db: AsyncSession = Depends(get_async_db),
+):
+    token_hash = hash_token(payload.token, secret=getattr(settings, "RESET_TOKEN_SECRET", None))
+    async with db.begin():
+        res = await db.execute(
+            select(PasswordResetToken).where(PasswordResetToken.token_hash == token_hash).with_for_update()
+        )
+        reset_obj = res.scalars().first()
+
+        if not reset_obj or reset_obj.used_at or reset_obj.expires_at <= _utcnow_naive():
+            raise SmartSellValidationError("Invalid or expired token", "RESET_TOKEN_INVALID")
+
+        user = await db.get(User, reset_obj.user_id)
+        if not user:
+            raise SmartSellValidationError("Invalid or expired token", "RESET_TOKEN_INVALID")
+
+        user.hashed_password = get_password_hash(payload.new_password)
+        user.failed_login_attempts = 0
+        user.locked_until = None
+        reset_obj.used_at = _utcnow_naive()
+        await db.execute(update(UserSession).where(UserSession.user_id == user.id).values(is_active=False))
+
+    return SuccessResponse(message="Password reset successful")
 
 
 # =============================================================================

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -168,6 +168,8 @@ _LAZY_MODELS: dict[str, tuple[str, str]] = {
     # OTP / 2FA (строго в app.models.otp)
     "OTPCode": ("app.models.otp", "OTPCode"),
     "OtpAttempt": ("app.models.otp", "OtpAttempt"),
+    "InvitationToken": ("app.models.invitation", "InvitationToken"),
+    "PasswordResetToken": ("app.models.invitation", "PasswordResetToken"),
     # склад/инвентарь
     "Warehouse": ("app.models.warehouse", "Warehouse"),
     "ProductStock": ("app.models.warehouse", "ProductStock"),
@@ -194,6 +196,7 @@ _DOMAIN_MODULES: tuple[str, ...] = (
     "app.models.campaign",
     "app.models.company",
     "app.models.customer",
+    "app.models.invitation",
     "app.models.order",
     "app.models.payment",
     "app.models.product",
@@ -335,6 +338,9 @@ __all__ = [
     # OTP
     "OTPCode",
     "OtpAttempt",
+    # Invitations / Password reset
+    "InvitationToken",
+    "PasswordResetToken",
     # Компания, клиенты, склад
     "Company",
     "Customer",

--- a/app/models/invitation.py
+++ b/app/models/invitation.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from sqlalchemy import CheckConstraint, Column, DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import validates
+
+from app.models.base import Base
+
+
+def utc_now() -> datetime:
+    return datetime.utcnow()
+
+
+def _normalize_phone(v: str | None) -> str:
+    return "".join(ch for ch in (v or "") if ch.isdigit() or ch == "+").strip()
+
+
+def _normalize_email(v: str | None) -> str:
+    vv = (v or "").strip().lower()
+    return vv
+
+
+class InvitationToken(Base):
+    __tablename__ = "invitation_tokens"
+    __table_args__ = (
+        UniqueConstraint("token_hash", name="uq_invitation_tokens_token_hash"),
+        Index("ix_invitation_tokens_expires_at", "expires_at"),
+        Index("ix_invitation_tokens_token_hash", "token_hash"),
+        Index("ix_invitation_tokens_company_id", "company_id"),
+        CheckConstraint("role in ('admin','employee')", name="ck_invitation_role"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    company_id = Column(Integer, ForeignKey("companies.id", ondelete="CASCADE"), nullable=False)
+    role = Column(String(32), nullable=False, default="employee")
+    email = Column(String(255), nullable=True)
+    phone = Column(String(32), nullable=False)
+    display_name = Column(String(255), nullable=True)
+    token_hash = Column(String(128), nullable=False)
+    expires_at = Column(DateTime, nullable=False)
+    used_at = Column(DateTime, nullable=True)
+    created_by_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    created_at = Column(DateTime, nullable=False, default=utc_now)
+    meta = Column(JSONB, nullable=True)
+
+    @validates("email")
+    def _v_email(self, _k: str, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return _normalize_email(v)
+
+    @validates("phone")
+    def _v_phone(self, _k: str, v: str) -> str:
+        return _normalize_phone(v)
+
+    @validates("role")
+    def _v_role(self, _k: str, v: str) -> str:
+        return (v or "employee").strip().lower()
+
+    def mark_used(self) -> None:
+        self.used_at = utc_now()
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        company_id: int,
+        role: str,
+        phone: str,
+        token_hash: str,
+        email: Optional[str] = None,
+        display_name: Optional[str] = None,
+        ttl_hours: int = 72,
+        created_by_user_id: Optional[int] = None,
+        meta: Optional[str] = None,
+    ) -> InvitationToken:
+        now = utc_now()
+        return cls(
+            company_id=company_id,
+            role=(role or "employee").strip().lower(),
+            email=_normalize_email(email),
+            phone=_normalize_phone(phone),
+            display_name=display_name.strip() if display_name else None,
+            token_hash=token_hash,
+            expires_at=now + timedelta(hours=max(ttl_hours, 1)),
+            created_at=now,
+            created_by_user_id=created_by_user_id,
+            meta=meta,
+        )
+
+    def is_used(self) -> bool:
+        return self.used_at is not None
+
+    def is_expired(self, now: Optional[datetime] = None) -> bool:
+        now = now or utc_now()
+        return self.expires_at <= now
+
+
+class PasswordResetToken(Base):
+    __tablename__ = "password_reset_tokens"
+    __table_args__ = (
+        UniqueConstraint("token_hash", name="uq_password_reset_tokens_token_hash"),
+        Index("ix_password_reset_tokens_expires_at", "expires_at"),
+        Index("ix_password_reset_tokens_token_hash", "token_hash"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    token_hash = Column(String(128), nullable=False)
+    expires_at = Column(DateTime, nullable=False)
+    used_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=utc_now)
+    requested_ip = Column(String(45), nullable=True)
+    user_agent = Column(String(255), nullable=True)
+
+    def mark_used(self) -> None:
+        self.used_at = utc_now()
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        user_id: int,
+        token_hash: str,
+        ttl_minutes: int = 10,
+        requested_ip: Optional[str] = None,
+        user_agent: Optional[str] = None,
+    ) -> PasswordResetToken:
+        now = utc_now()
+        return cls(
+            user_id=user_id,
+            token_hash=token_hash,
+            expires_at=now + timedelta(minutes=max(ttl_minutes, 1)),
+            created_at=now,
+            requested_ip=requested_ip,
+            user_agent=user_agent,
+        )
+
+    def is_used(self) -> bool:
+        return self.used_at is not None
+
+    def is_expired(self, now: Optional[datetime] = None) -> bool:
+        now = now or utc_now()
+        return self.expires_at <= now

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -138,7 +138,7 @@ from app.models.base import (  # async helpers (опциональны, но а�
 # ======================================================================================
 # Constants & Policies
 # ======================================================================================
-ALLOWED_ROLES = {"admin", "manager", "storekeeper", "analyst", "platform_admin"}
+ALLOWED_ROLES = {"admin", "employee", "manager", "storekeeper", "analyst", "platform_admin"}
 EMAIL_REGEX = re.compile(r"^[^@]+@[^@]+\.[^@]+$")
 PHONE_REGEX = re.compile(r"^\+?\d{10,15}$")
 

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -33,6 +33,11 @@ __all__ = [
     "UserUpdate",
     "TokenResponse",
     "RefreshTokenRequest",
+    "InvitationCreate",
+    "InvitationAccept",
+    "InvitationStatus",
+    "PasswordResetRequest",
+    "PasswordResetConfirm",
     "OTPRequest",
     "OTPVerify",
     "PasswordReset",
@@ -231,6 +236,55 @@ class RefreshTokenRequest(BaseSchema):
     """Schema for refresh token request."""
 
     refresh_token: str = Field(..., description="Refresh token")
+
+
+# -----------------------------------------------------------------------------
+# Invitations / Password reset
+# -----------------------------------------------------------------------------
+
+
+class InvitationCreate(BaseSchema):
+    email: EmailStr = Field(..., description="Invitee email")
+    phone: str = Field(..., description="Invitee phone")
+    role: Literal["admin", "employee"] = Field("employee", description="Role for invitee")
+    display_name: str | None = Field(None, max_length=255)
+
+    @field_validator("phone", mode="before")
+    @classmethod
+    def _normalize_invite_phone(cls, v: str) -> str:
+        digits = _normalize_phone(v)
+        _validate_phone_digits(digits)
+        return digits
+
+
+class InvitationAccept(BaseSchema):
+    token: str = Field(..., min_length=16, description="Invitation token")
+    password: str = Field(..., min_length=8, description="Initial password")
+
+    @field_validator("password")
+    @classmethod
+    def _validate_password_strength(cls, v: str) -> str:
+        _password_strength_check(v)
+        return v
+
+
+class InvitationStatus(BaseSchema):
+    token: str = Field(..., min_length=16, description="Invitation token")
+
+
+class PasswordResetRequest(BaseSchema):
+    identifier: str = Field(..., description="Email or phone")
+
+
+class PasswordResetConfirm(BaseSchema):
+    token: str = Field(..., min_length=16)
+    new_password: str = Field(..., min_length=8)
+
+    @field_validator("new_password")
+    @classmethod
+    def _validate_reset_password_strength(cls, v: str) -> str:
+        _password_strength_check(v)
+        return v
 
 
 # -----------------------------------------------------------------------------

--- a/app/services/messaging.py
+++ b/app/services/messaging.py
@@ -1,0 +1,57 @@
+"""Messaging utilities (email)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+try:
+    from app.core.config import settings  # type: ignore
+except Exception:  # pragma: no cover
+
+    class _Settings:  # type: ignore
+        ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+        EMAIL_PROVIDER = os.getenv("EMAIL_PROVIDER", "")
+        PUBLIC_URL = os.getenv("PUBLIC_URL", "http://localhost:8000")
+
+    settings = _Settings()  # type: ignore
+
+try:
+    from app.core.logging import get_logger  # type: ignore
+except Exception:  # pragma: no cover
+
+    def get_logger(_name: str):
+        class _L:
+            def info(self, *a, **k):
+                ...
+
+            def warning(self, *a, **k):
+                ...
+
+        return _L()
+
+
+log = get_logger(__name__)
+
+
+class MessagingConfigError(RuntimeError):
+    pass
+
+
+def _env() -> str:
+    return str(os.getenv("ENVIRONMENT") or getattr(settings, "ENVIRONMENT", "production") or "production").lower()
+
+
+def _provider_name() -> str:
+    return str(getattr(settings, "EMAIL_PROVIDER", "") or os.getenv("EMAIL_PROVIDER", "")).strip()
+
+
+async def send_email(*, to: str, subject: str, body: str, meta: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Send email via configured provider. In dev, logs; in prod without provider, raises."""
+
+    provider = _provider_name()
+    if _env() == "production" and not provider:
+        raise MessagingConfigError("Email provider is not configured")
+
+    log.info("email.send", to=to, subject=subject, provider=provider or "noop", meta=meta or {})
+    return {"success": True, "provider": provider or "noop"}

--- a/app/utils/otp.py
+++ b/app/utils/otp.py
@@ -17,6 +17,8 @@ from app.models import OtpAttempt
 
 logger = get_logger(__name__)
 
+DEFAULT_OTP_TTL_MINUTES = 5
+
 
 def generate_otp_code(length: int = 6) -> str:
     """Generate random OTP code"""
@@ -49,7 +51,7 @@ async def create_otp_attempt(
     db: AsyncSession,
     phone: str,
     purpose: str = "login",
-    expires_minutes: int = 5,
+    expires_minutes: int = DEFAULT_OTP_TTL_MINUTES,
     attempts_left: int | None = None,
     code: str | None = None,
     user_id: int | None = None,

--- a/app/utils/tokens.py
+++ b/app/utils/tokens.py
@@ -1,0 +1,43 @@
+"""Secure token utilities for invitation and password reset flows."""
+
+from __future__ import annotations
+
+import hmac
+import os
+import secrets
+from hashlib import sha256
+from typing import Optional
+
+try:
+    from app.core.config import settings  # type: ignore
+except Exception:  # pragma: no cover
+
+    class _Settings:  # type: ignore
+        SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret")
+        INVITE_TOKEN_SECRET = os.getenv("INVITE_TOKEN_SECRET")
+        RESET_TOKEN_SECRET = os.getenv("RESET_TOKEN_SECRET")
+
+    settings = _Settings()  # type: ignore
+
+
+def _default_secret(preferred: Optional[str] = None) -> str:
+    return preferred or getattr(settings, "SECRET_KEY", "dev-secret")
+
+
+def generate_token(length: int = 32) -> str:
+    """Generate URL-safe random token (>= length bytes before encoding)."""
+
+    # token_urlsafe uses base64; length argument is number of bytes.
+    return secrets.token_urlsafe(max(32, length))
+
+
+def hash_token(token: str, *, secret: Optional[str] = None) -> str:
+    """Return HMAC-SHA256 hex digest of token with the given secret."""
+
+    key = _default_secret(secret)
+    digest = hmac.new(key.encode("utf-8"), token.encode("utf-8"), sha256).hexdigest()
+    return digest
+
+
+def constant_time_compare(val1: str, val2: str) -> bool:
+    return hmac.compare_digest(val1, val2)

--- a/migrations/versions/20260115_allow_employee_role.py
+++ b/migrations/versions/20260115_allow_employee_role.py
@@ -1,0 +1,51 @@
+"""fix(auth): allow employee role in users
+
+Revision ID: 20260115_allow_employee_role
+Revises: 20260115_invite_reset
+Create Date: 2026-01-15 00:00:01.000000+00:00
+
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260115_allow_employee_role"
+down_revision = "20260115_invite_reset"
+branch_labels = None
+depends_on = None
+
+NEW_ALLOWED_ROLES = (
+    "admin",
+    "employee",
+    "manager",
+    "storekeeper",
+    "analyst",
+    "platform_admin",
+)
+
+OLD_ALLOWED_ROLES = (
+    "admin",
+    "manager",
+    "storekeeper",
+    "analyst",
+    "platform_admin",
+)
+
+
+def upgrade() -> None:
+    op.drop_constraint(op.f("ck__users__ck_user_role_allowed"), "users", type_="check")
+    op.create_check_constraint(
+        op.f("ck__users__ck_user_role_allowed"),
+        "users",
+        sa.text("role IN ('" + "','".join(NEW_ALLOWED_ROLES) + "')"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(op.f("ck__users__ck_user_role_allowed"), "users", type_="check")
+    op.create_check_constraint(
+        op.f("ck__users__ck_user_role_allowed"),
+        "users",
+        sa.text("role IN ('" + "','".join(OLD_ALLOWED_ROLES) + "')"),
+    )

--- a/migrations/versions/20260115_invitation_password_reset_tokens.py
+++ b/migrations/versions/20260115_invitation_password_reset_tokens.py
@@ -1,0 +1,73 @@
+"""feat(auth): invitation and password reset tokens
+
+Revision ID: 20260115_invite_reset
+Revises: 20260114_kaspi_feed_hardening
+Create Date: 2026-01-15 00:00:00.000000+00:00
+
+"""
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260115_invite_reset"
+down_revision: Union[str, Sequence[str], None] = "20260114_kaspi_feed_hardening"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "invitation_tokens",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("company_id", sa.Integer(), sa.ForeignKey("companies.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("role", sa.String(length=32), nullable=False, server_default="employee"),
+        sa.Column("email", sa.String(length=255), nullable=True),
+        sa.Column("phone", sa.String(length=32), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=True),
+        sa.Column("token_hash", sa.String(length=128), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("used_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "created_by_user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")),
+        sa.Column("meta", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.CheckConstraint("role in ('admin','employee')", name="ck_invitation_role"),
+        sa.UniqueConstraint("token_hash", name="uq_invitation_tokens_token_hash"),
+    )
+    op.create_index("ix_invitation_tokens_token_hash", "invitation_tokens", ["token_hash"], unique=True)
+    op.create_index("ix_invitation_tokens_expires_at", "invitation_tokens", ["expires_at"], unique=False)
+    op.create_index("ix_invitation_tokens_company_id", "invitation_tokens", ["company_id"], unique=False)
+
+    op.create_table(
+        "password_reset_tokens",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("token_hash", sa.String(length=128), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("used_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")),
+        sa.Column("requested_ip", sa.String(length=45), nullable=True),
+        sa.Column("user_agent", sa.String(length=255), nullable=True),
+        sa.UniqueConstraint("token_hash", name="uq_password_reset_tokens_token_hash"),
+    )
+    op.create_index("ix_password_reset_tokens_token_hash", "password_reset_tokens", ["token_hash"], unique=True)
+    op.create_index("ix_password_reset_tokens_expires_at", "password_reset_tokens", ["expires_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_password_reset_tokens_expires_at", table_name="password_reset_tokens")
+    op.drop_index("ix_password_reset_tokens_token_hash", table_name="password_reset_tokens")
+    op.drop_table("password_reset_tokens")
+
+    op.drop_index("ix_invitation_tokens_company_id", table_name="invitation_tokens")
+    op.drop_index("ix_invitation_tokens_expires_at", table_name="invitation_tokens")
+    op.drop_index("ix_invitation_tokens_token_hash", table_name="invitation_tokens")
+    op.drop_table("invitation_tokens")

--- a/tests/app/test_invitations_password_reset.py
+++ b/tests/app/test_invitations_password_reset.py
@@ -1,0 +1,271 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import get_password_hash
+from app.models import Company, InvitationToken, PasswordResetToken, User
+from app.utils.tokens import hash_token
+
+
+@pytest.mark.asyncio
+async def test_invitation_create_requires_admin(async_client: AsyncClient, company_a_manager_headers):
+    resp = await async_client.post(
+        "/api/v1/auth/invitations",
+        headers=company_a_manager_headers,
+        json={"email": "inv@example.com", "phone": "77001112233", "role": "employee"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_invitation_owner_can_invite_admin(
+    async_client: AsyncClient, async_db_session: AsyncSession, monkeypatch
+):
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    company = Company(name="Owner Invite Co")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    owner = User(
+        company_id=company.id,
+        phone="77001112211",
+        email="owner@example.com",
+        hashed_password=get_password_hash("Password123!"),
+        role="admin",
+        is_active=True,
+        is_verified=True,
+    )
+    async_db_session.add(owner)
+    await async_db_session.commit()
+    company.owner_id = owner.id
+    await async_db_session.commit()
+
+    from app.core.security import create_access_token
+
+    token = create_access_token(subject=owner.id, extra={"company_id": company.id, "role": owner.role})
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = await async_client.post(
+        "/api/v1/auth/invitations",
+        headers=headers,
+        json={"email": "admin-invite@example.com", "phone": "77001112212", "role": "admin"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_invitation_admin_cannot_invite_admin(async_client: AsyncClient, company_a_admin_headers, monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    resp = await async_client.post(
+        "/api/v1/auth/invitations",
+        headers=company_a_admin_headers,
+        json={"email": "admin2@example.com", "phone": "77001112234", "role": "admin"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_invitation_admin_can_invite_employee(async_client: AsyncClient, company_a_admin_headers, monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    resp = await async_client.post(
+        "/api/v1/auth/invitations",
+        headers=company_a_admin_headers,
+        json={"email": "employee1@example.com", "phone": "77001112235", "role": "employee"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_invitation_employee_cannot_invite(
+    async_client: AsyncClient, async_db_session: AsyncSession, monkeypatch
+):
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    company = Company(name="Employee Invite Co")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    employee = User(
+        company_id=company.id,
+        phone="77001112236",
+        email="employee@example.com",
+        hashed_password=get_password_hash("Password123!"),
+        role="employee",
+        is_active=True,
+        is_verified=True,
+    )
+    async_db_session.add(employee)
+    await async_db_session.commit()
+
+    from app.core.security import create_access_token
+
+    token = create_access_token(subject=employee.id, extra={"company_id": company.id, "role": employee.role})
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = await async_client.post(
+        "/api/v1/auth/invitations",
+        headers=headers,
+        json={"email": "other@example.com", "phone": "77001112237", "role": "employee"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_invitation_accept_creates_user_without_otp(
+    async_client: AsyncClient, async_db_session: AsyncSession, company_a_admin_headers, monkeypatch
+):
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    resp = await async_client.post(
+        "/api/v1/auth/invitations",
+        headers=company_a_admin_headers,
+        json={"email": "newuser@example.com", "phone": "77001112233", "role": "employee"},
+    )
+    assert resp.status_code == 200, resp.text
+    rows = await async_db_session.execute(select(InvitationToken).order_by(InvitationToken.id.desc()))
+    invite = rows.scalars().first()
+    assert invite is not None
+    token = "invitation-token-123456"
+    invite.token_hash = hash_token(token)
+    await async_db_session.commit()
+
+    accept = await async_client.post(
+        "/api/v1/auth/invitations/accept",
+        json={"token": token, "password": "Password123!"},
+    )
+    assert accept.status_code == 200, accept.text
+    body = accept.json()
+    assert body.get("access_token")
+
+    await async_db_session.rollback()
+    res = await async_db_session.execute(select(User).where(User.phone == "77001112233"))
+    user = res.scalars().first()
+    assert user is not None
+    assert user.company_id is not None
+    assert user.is_verified is False
+
+
+@pytest.mark.asyncio
+async def test_invitation_expired_rejected(async_client: AsyncClient, async_db_session: AsyncSession):
+    company = Company(name="Invite Co")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    token = "expired-token"
+    inv = InvitationToken.build(
+        company_id=company.id,
+        role="employee",
+        phone="77009990000",
+        email="exp@example.com",
+        token_hash=hash_token(token),
+        ttl_hours=72,
+    )
+    inv.expires_at = inv.expires_at.replace(year=2000)
+    async_db_session.add(inv)
+    await async_db_session.commit()
+
+    resp = await async_client.post(
+        "/api/v1/auth/invitations/accept",
+        json={"token": token, "password": "Password123!"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_invitation_used_rejected(async_client: AsyncClient, async_db_session: AsyncSession):
+    company = Company(name="Invite Used Co")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    token = "used-token"
+    inv = InvitationToken.build(
+        company_id=company.id,
+        role="employee",
+        phone="77009990001",
+        email="used@example.com",
+        token_hash=hash_token(token),
+        ttl_hours=72,
+    )
+    inv.used_at = inv.created_at
+    async_db_session.add(inv)
+    await async_db_session.commit()
+
+    resp = await async_client.post(
+        "/api/v1/auth/invitations/accept",
+        json={"token": token, "password": "Password123!"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_password_reset_request_does_not_leak_user_existence(
+    async_client: AsyncClient, async_db_session: AsyncSession, monkeypatch
+):
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    resp = await async_client.post(
+        "/api/v1/auth/password/reset/request",
+        json={"identifier": "unknown@example.com"},
+    )
+    assert resp.status_code == 200
+
+    company = Company(name="Reset Co")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    user = User(
+        company_id=company.id,
+        phone="77007770000",
+        email="reset@example.com",
+        hashed_password=get_password_hash("Password123!"),
+        role="admin",
+        is_active=True,
+        is_verified=True,
+    )
+    async_db_session.add(user)
+    await async_db_session.commit()
+
+    resp2 = await async_client.post(
+        "/api/v1/auth/password/reset/request",
+        json={"identifier": "reset@example.com"},
+    )
+    assert resp2.status_code == 200
+
+    await async_db_session.rollback()
+    rows = await async_db_session.execute(select(PasswordResetToken).where(PasswordResetToken.user_id == user.id))
+    token_row = rows.scalars().first()
+    assert token_row is not None
+
+
+@pytest.mark.asyncio
+async def test_password_reset_confirm_works_and_is_one_time(async_client: AsyncClient, async_db_session: AsyncSession):
+    company = Company(name="Reset Confirm Co")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    user = User(
+        company_id=company.id,
+        phone="77007770001",
+        email="reset-confirm@example.com",
+        hashed_password=get_password_hash("Password123!"),
+        role="admin",
+        is_active=True,
+        is_verified=True,
+    )
+    async_db_session.add(user)
+    await async_db_session.commit()
+
+    token = "reset-token-123456"
+    reset = PasswordResetToken.build(user_id=user.id, token_hash=hash_token(token), ttl_minutes=10)
+    async_db_session.add(reset)
+    await async_db_session.commit()
+
+    resp = await async_client.post(
+        "/api/v1/auth/password/reset/confirm",
+        json={"token": token, "new_password": "NewPassword123!"},
+    )
+    assert resp.status_code == 200
+
+    resp2 = await async_client.post(
+        "/api/v1/auth/password/reset/confirm",
+        json={"token": token, "new_password": "AnotherPassword123!"},
+    )
+    assert resp2.status_code == 422

--- a/tests/app/test_otp_expiry.py
+++ b/tests/app/test_otp_expiry.py
@@ -1,0 +1,30 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import OtpAttempt
+from app.utils.otp import generate_otp_code, hash_otp_code
+
+
+@pytest.mark.asyncio
+async def test_otp_expired_code_rejected(async_client: AsyncClient, async_db_session: AsyncSession):
+    phone = "77009998877"
+    code = generate_otp_code()
+    code_hash = hash_otp_code(code)
+
+    attempt = OtpAttempt.create_new(
+        phone=phone,
+        code_hash=code_hash,
+        purpose="login",
+        expires_minutes=1,
+        attempts_left=3,
+    )
+    attempt.expires_at = attempt.expires_at.replace(year=2000)
+    async_db_session.add(attempt)
+    await async_db_session.commit()
+
+    resp = await async_client.post(
+        "/api/v1/auth/verify-otp",
+        json={"phone": phone, "purpose": "login", "code": code},
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
Adds invitation and password-reset token flows (hashed tokens, TTL, one-time use with FOR UPDATE), adds employee role + constraint migration, sets OTP TTL constant and tests. Local checks: ruff + pytest passed.