### PR TITLE
fix(security): remove debug leaks (OTP/DB/config); dev-only debug/reset URLs; ban prints via ruff

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -332,7 +332,8 @@ def mount_v1(target: Target, base_prefix: str = "/api/v1") -> None:
     Также монтирует диагностические эндпоинты под /api/v1.
     """
     current_settings = config.get_settings()
-    debug_enabled = bool(current_settings.DEBUG) or str(getattr(current_settings, "ENVIRONMENT", "")).lower() == "local"
+    env = str(getattr(current_settings, "ENVIRONMENT", "") or "").lower()
+    debug_enabled = bool(current_settings.DEBUG) or env in {"development", "dev", "local"}
 
     for name, router, is_absolute in V1_ROUTERS:
         if name == "debug_db" and not debug_enabled:

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -49,7 +49,7 @@ from app.core.exceptions import (
     ExternalServiceError,
     SmartSellValidationError,
 )
-from app.core.logging import audit_logger
+from app.core.logging import audit_logger, get_logger
 from app.core.security import (
     create_access_token,
     create_refresh_token,
@@ -72,6 +72,8 @@ from app.schemas.user import (
     PasswordReset,
     PasswordResetConfirm,
     PasswordResetRequest,
+    PhoneChangeConfirm,
+    PhoneChangeRequest,
     RefreshTokenRequest,
     TokenResponse,
     UserCreate,
@@ -82,6 +84,7 @@ from app.utils.otp import create_otp_attempt, verify_otp_code
 from app.utils.tokens import generate_token, hash_token
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])
+logger = get_logger(__name__)
 
 # =============================================================================
 # Конфигурация/политики (с дефолтами)
@@ -101,6 +104,7 @@ LOGIN_LOCK_MINUTES: int = int(_conf("LOGIN_LOCK_MINUTES", 15))
 PROJECT_NAME: str = str(_conf("PROJECT_NAME", "SmartSell"))
 DEBUG_MODE: bool = bool(_conf("DEBUG", False))
 DEBUG_OTP_CODE: str | None = getattr(settings, "DEBUG_OTP_CODE", None)
+DEBUG_OTP_LOGGING: bool = bool(_conf("DEBUG_OTP_LOGGING", False))
 AUTH_REGISTER_ISSUE_TOKENS: bool = str(_conf("AUTH_REGISTER_ISSUE_TOKENS", "1")) in (
     "1",
     "true",
@@ -148,6 +152,11 @@ def _normalize_email(v: str | None) -> str | None:
     return vv or None
 
 
+def _looks_like_email(value: str) -> bool:
+    v = (value or "").strip()
+    return bool(re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", v))
+
+
 def _normalize_purpose(v: str | None) -> str:
     return (v or "").strip().lower() or "login"
 
@@ -163,6 +172,15 @@ def _issue_tokens_for_user(user_id: int) -> tuple[str, str]:
 def _sms_text_for_otp(code: str, purpose: str) -> str:
     p = purpose or "login"
     return f"{PROJECT_NAME}: код подтверждения {code} для {p}. Никому не сообщайте."
+
+
+def _mask_phone(value: str) -> str:
+    digits = re.sub(r"\D", "", value or "")
+    if not digits:
+        return ""
+    if len(digits) <= 4:
+        return "*" * len(digits)
+    return "*" * (len(digits) - 2) + digits[-2:]
 
 
 def _should_return_provider_info() -> bool:
@@ -401,22 +419,27 @@ async def register(user_data: UserCreate, request: Request, db: AsyncSession = D
 async def login(login_data: UserLogin, request: Request, db: AsyncSession = Depends(get_async_db)):
     """Аутентификация по телефону и паролю. Возвращает access/refresh токены."""
     client_info = get_client_info(request)
-    phone = _normalize_phone(login_data.phone)
+    identifier = (login_data.identifier or "").strip()
+    is_email = _looks_like_email(identifier)
+    phone = _normalize_phone(identifier) if not is_email else ""
+    email = identifier.lower() if is_email else ""
     otp_code = (login_data.otp_code or "").strip()
     via_otp = bool(otp_code)
 
-    user = await _get_user_by_phone(db, phone)
+    user = await (_get_user_by_email(db, email) if is_email else _get_user_by_phone(db, phone))
 
     # Блокировка по неудачным попыткам
     if user and user.locked_until and user.locked_until > _utcnow_naive():
         audit_logger.log_auth_failure(
-            username=phone,
+            username=identifier,
             ip_address=client_info["ip_address"],
             reason="Account locked",
         )
         raise AuthenticationError("Account is temporarily locked", "ACCOUNT_LOCKED")
 
     if via_otp:
+        if is_email:
+            raise AuthenticationError("Invalid OTP code", "INVALID_OTP")
         if not user:
             raise AuthenticationError("Invalid OTP code", "INVALID_OTP")
 
@@ -433,15 +456,15 @@ async def login(login_data: UserLogin, request: Request, db: AsyncSession = Depe
                 await db.commit()
 
             audit_logger.log_auth_failure(
-                username=phone,
+                username=identifier,
                 ip_address=client_info["ip_address"],
                 reason="Invalid credentials",
             )
-            raise AuthenticationError("Invalid phone number or password", "INVALID_CREDENTIALS")
+            raise AuthenticationError("Invalid credentials", "INVALID_CREDENTIALS")
 
     if not user.is_active:
         audit_logger.log_auth_failure(
-            username=phone,
+            username=identifier,
             ip_address=client_info["ip_address"],
             reason="Inactive account",
         )
@@ -692,8 +715,9 @@ async def request_otp(
         },
     )
 
-    if DEBUG_MODE:
-        print(f"[DEBUG] OTP for {phone}: {code}")
+    env = str(os.getenv("ENVIRONMENT") or getattr(settings, "ENVIRONMENT", "production") or "production").lower()
+    if DEBUG_OTP_LOGGING and env == "development":
+        logger.info("OTP issued for phone=%s purpose=%s", _mask_phone(phone), purpose)
 
     data = {
         "expires_in": otp_attempt.seconds_left,
@@ -926,6 +950,134 @@ async def reset_password(reset_data: PasswordReset, db: AsyncSession = Depends(g
     )
 
     return SuccessResponse(message="Password reset successfully")
+
+
+# =============================================================================
+# Phone change
+# =============================================================================
+
+
+@router.post(
+    "/phone/change/request",
+    response_model=SuccessResponse,
+    dependencies=[Depends(auth_rate_limit), Depends(otp_rate_limit)],
+)
+async def phone_change_request(
+    payload: PhoneChangeRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+    otp_service: OtpProvider = Depends(get_otp_service),
+):
+    phone = _normalize_phone(payload.new_phone)
+    variants = _phone_variants(phone)
+
+    if any(v == current_user.phone for v in variants):
+        raise SmartSellValidationError("Phone is unchanged", "PHONE_UNCHANGED")
+
+    res = await db.execute(select(User).where(User.phone.in_(variants), User.id != current_user.id))
+    if res.scalars().first():
+        raise ConflictError("Phone number already in use", "PHONE_IN_USE")
+
+    code, otp_attempt = await create_otp_attempt(
+        db,
+        phone=phone,
+        purpose="phone_change",
+        expires_minutes=OTP_TTL_MINUTES,
+        attempts_left=OTP_MAX_ATTEMPTS,
+        user_id=current_user.id,
+    )
+
+    text = _sms_text_for_otp(code, "phone_change")
+    send_result: dict[str, Any] | None = None
+    provider_name: str | None = None
+    provider_version: int | None = None
+
+    try:
+        send_result = await otp_service.send_otp(
+            phone=phone,
+            code=code,
+            ttl_seconds=int(timedelta(minutes=OTP_TTL_MINUTES).total_seconds()),
+            metadata={"purpose": "phone_change", "text": text},
+        )
+        provider_name = (send_result or {}).get("provider") or getattr(otp_service, "name", None)
+        provider_version = (send_result or {}).get("version") or getattr(otp_service, "version", None)
+    except Exception as exc:
+        provider_name = getattr(otp_service, "name", None) or "noop"
+        provider_version = getattr(otp_service, "version", None)
+        audit_logger.log_system_event(
+            level="warning",
+            event="otp_send_failed",
+            message=str(exc),
+            meta={"phone": phone, "purpose": "phone_change", "provider": provider_name},
+        )
+
+    audit_logger.log_system_event(
+        level="info",
+        event="otp_requested",
+        message="OTP issued",
+        meta={
+            "phone": phone,
+            "purpose": "phone_change",
+            "provider": provider_name or (send_result or {}).get("provider", "none"),
+            "provider_version": provider_version,
+        },
+    )
+
+    data: dict[str, Any] = {
+        "expires_in": otp_attempt.seconds_left,
+        "provider_success": (send_result or {}).get("success") if send_result else None,
+        "provider_status": (send_result or {}).get("status") if send_result else None,
+    }
+
+    if _should_return_provider_info():
+        data["provider"] = provider_name
+        data["provider_version"] = provider_version
+
+    env = str(os.getenv("ENVIRONMENT") or getattr(settings, "ENVIRONMENT", "production") or "production").lower()
+    if env != "production" and (provider_name or "noop").startswith("noop"):
+        data["dev_code"] = code
+
+    return SuccessResponse(message="OTP code sent successfully", data=data)
+
+
+@router.post(
+    "/phone/change/confirm",
+    response_model=SuccessResponse,
+    dependencies=[Depends(auth_rate_limit)],
+)
+async def phone_change_confirm(
+    payload: PhoneChangeConfirm,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+):
+    phone = _normalize_phone(payload.new_phone)
+    variants = _phone_variants(phone)
+
+    verified = await verify_otp_code(db, phone, payload.code or "", "phone_change")
+    if not verified:
+        raise SmartSellValidationError("Invalid or expired OTP code", "INVALID_OTP")
+
+    res = await db.execute(select(User).where(User.phone.in_(variants), User.id != current_user.id))
+    if res.scalars().first():
+        raise ConflictError("Phone number already in use", "PHONE_IN_USE")
+
+    user = await db.get(User, current_user.id)
+    if not user:
+        raise AuthenticationError("User not found", "USER_NOT_FOUND")
+
+    user.phone = phone
+    user.is_verified = True
+    await db.commit()
+
+    audit_logger.log_data_change(
+        user_id=user.id,
+        action="update",
+        resource_type="user",
+        resource_id=str(user.id),
+        changes={"phone": phone, "is_verified": True},
+    )
+
+    return SuccessResponse(message="Phone updated successfully")
 
 
 # =============================================================================

--- a/app/api/v1/debug_db.py
+++ b/app/api/v1/debug_db.py
@@ -35,7 +35,7 @@ async def debug_db() -> dict[str, Any]:
     url = settings.DATABASE_URL or ""
     parts = _url_parts(url)
 
-    fp = config.db_connection_fingerprint(url, include_password=True)
+    fp = config.db_connection_fingerprint(url, include_password=False)
     fp_no_pw = config.db_connection_fingerprint(url, include_password=False)
     source = settings.db_url_source() if hasattr(settings, "db_url_source") else "unknown"
 

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -6,26 +6,23 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, Path, Query
-from sqlalchemy import func, or_, select, update
+from fastapi import APIRouter, Body, Depends, Path, Query
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_async_db
-from app.core.dependencies import (
-    Pagination,
-    api_rate_limit,
-    get_current_user,
-    get_current_verified_user,
-    get_pagination,
-)
-from app.core.exceptions import AuthenticationError, NotFoundError, SmartSellValidationError
+from app.core.dependencies import api_rate_limit, get_current_user, get_current_verified_user
+from app.core.exceptions import AuthenticationError, AuthorizationError, NotFoundError, SmartSellValidationError
 from app.core.logging import audit_logger
-from app.core.security import get_password_hash, verify_password
+from app.core.security import get_password_hash, resolve_tenant_company_id, verify_password
+from app.models.company import Company
 from app.models.user import User, UserSession
-from app.schemas.base import PaginatedResponse, SuccessResponse
+from app.schemas.base import SuccessResponse
 from app.schemas.user import UserResponse, UserUpdate
+from app.schemas.users import UserPublicOut, UserRoleUpdate, UsersListOut
+from app.schemas.users import UserUpdate as CompanyUserUpdate
 
-router = APIRouter(prefix="/users", tags=["Users"], dependencies=[Depends(api_rate_limit)])
+router = APIRouter(prefix="/users", tags=["users"], dependencies=[Depends(api_rate_limit)])
 
 
 # ---------------------------------------------------------------------------
@@ -33,46 +30,231 @@ router = APIRouter(prefix="/users", tags=["Users"], dependencies=[Depends(api_ra
 # ---------------------------------------------------------------------------
 
 
-def _is_admin(user: User) -> bool:
-    # Поддерживаем обе возможные модели флага
-    return bool(getattr(user, "is_superuser", False) or getattr(user, "is_admin", False))
+async def _get_company_and_owner(db: AsyncSession, company_id: int) -> Company | None:
+    res = await db.execute(select(Company).where(Company.id == company_id))
+    return res.scalars().first()
 
 
-def _apply_user_filters(stmt, search: str | None, is_active: bool | None):
-    if is_active is not None:
-        stmt = stmt.where(User.is_active == is_active)
-
-    if search:
-        s = f"%{search}%"
-        stmt = stmt.where(
-            or_(
-                User.full_name.ilike(s),
-                User.phone.ilike(s),
-                User.email.ilike(s),
-            )
-        )
-    return stmt
-
-
-_ALLOWED_SORT_FIELDS = {
-    "id": User.id,
-    "full_name": User.full_name,
-    "phone": User.phone,
-    "email": User.email,
-    "created_at": getattr(User, "created_at", User.id),
-    "updated_at": getattr(User, "updated_at", User.id),
-    "last_login_at": getattr(User, "last_login_at", User.id),
-}
-
-
-def _apply_sorting(stmt, sort_by: str, sort_order: str):
-    col = _ALLOWED_SORT_FIELDS.get(sort_by, _ALLOWED_SORT_FIELDS["created_at"])
-    return stmt.order_by(col.asc() if sort_order.lower() == "asc" else col.desc())
+def _require_owner_or_admin(*, current_user: User, company: Company | None) -> bool:
+    is_owner = bool(company and company.owner_id == current_user.id)
+    role = (getattr(current_user, "role", "") or "").lower()
+    if is_owner or role == "admin":
+        return is_owner
+    raise AuthorizationError("Insufficient permissions", "FORBIDDEN")
 
 
 # ---------------------------------------------------------------------------
 # Me
 # ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=UsersListOut)
+async def list_company_users(
+    active_only: bool | None = Query(None),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+):
+    company_id = resolve_tenant_company_id(current_user)
+    company = await _get_company_and_owner(db, company_id)
+    _require_owner_or_admin(current_user=current_user, company=company)
+
+    stmt = select(User).where(User.company_id == company_id)
+    if active_only:
+        stmt = stmt.where(User.is_active.is_(True))
+    res = await db.execute(stmt.order_by(User.id.asc()))
+    users = res.scalars().all()
+
+    items = [
+        UserPublicOut(
+            id=u.id,
+            phone=u.phone,
+            email=u.email,
+            full_name=getattr(u, "full_name", None),
+            role=getattr(u, "role", None),
+            is_active=bool(getattr(u, "is_active", True)),
+            is_verified=bool(getattr(u, "is_verified", False)),
+            created_at=getattr(u, "created_at", None),
+        )
+        for u in users
+    ]
+    return UsersListOut(items=items)
+
+
+@router.patch("/{user_id}", response_model=UserPublicOut)
+async def update_company_user(
+    user_id: int = Path(...),
+    payload: CompanyUserUpdate = Body(...),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+):
+    company_id = resolve_tenant_company_id(current_user)
+    company = await _get_company_and_owner(db, company_id)
+    _require_owner_or_admin(current_user=current_user, company=company)
+
+    res = await db.execute(select(User).where(User.id == user_id, User.company_id == company_id))
+    user = res.scalars().first()
+    if not user:
+        raise NotFoundError("User not found", "USER_NOT_FOUND")
+
+    data = payload.model_dump(exclude_unset=True)
+    if "full_name" in data:
+        user.full_name = data["full_name"]
+        await db.commit()
+
+    if "full_name" in data:
+        audit_logger.log_data_change(
+            user_id=current_user.id,
+            action="update",
+            resource_type="user",
+            resource_id=str(user_id),
+            changes={"full_name": data.get("full_name")},
+        )
+
+    return UserPublicOut(
+        id=user.id,
+        phone=user.phone,
+        email=user.email,
+        full_name=user.full_name,
+        role=user.role,
+        is_active=user.is_active,
+        is_verified=user.is_verified,
+        created_at=getattr(user, "created_at", None),
+    )
+
+
+def _is_owner(company: Company | None, user: User) -> bool:
+    return bool(company and company.owner_id == user.id)
+
+
+def _is_admin(user: User) -> bool:
+    return (getattr(user, "role", "") or "").lower() == "admin"
+
+
+@router.post("/{user_id}/deactivate", response_model=SuccessResponse)
+async def deactivate_user(
+    user_id: int = Path(...),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+):
+    company_id = resolve_tenant_company_id(current_user)
+    company = await _get_company_and_owner(db, company_id)
+    is_owner = _is_owner(company, current_user)
+    is_admin = _is_admin(current_user)
+    if not (is_owner or is_admin):
+        raise AuthorizationError("Insufficient permissions", "FORBIDDEN")
+
+    if current_user.id == user_id:
+        raise SmartSellValidationError("Cannot deactivate self", "SELF_ACTION_FORBIDDEN")
+
+    res = await db.execute(select(User).where(User.id == user_id, User.company_id == company_id))
+    user = res.scalars().first()
+    if not user:
+        raise NotFoundError("User not found", "USER_NOT_FOUND")
+
+    if company and company.owner_id == user.id:
+        raise AuthorizationError("Cannot deactivate owner", "OWNER_PROTECTED")
+
+    target_role = (getattr(user, "role", "") or "").lower()
+    if is_admin and not is_owner and target_role != "employee":
+        raise AuthorizationError("Admin can deactivate only employees", "FORBIDDEN")
+
+    user.is_active = False
+    await db.execute(update(UserSession).where(UserSession.user_id == user.id).values(is_active=False))
+    await db.commit()
+
+    audit_logger.log_data_change(
+        user_id=current_user.id,
+        action="deactivate",
+        resource_type="user",
+        resource_id=str(user_id),
+        changes={"is_active": False},
+    )
+    return SuccessResponse(message="User deactivated")
+
+
+@router.post("/{user_id}/activate", response_model=SuccessResponse)
+async def activate_user(
+    user_id: int = Path(...),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+):
+    company_id = resolve_tenant_company_id(current_user)
+    company = await _get_company_and_owner(db, company_id)
+    is_owner = _is_owner(company, current_user)
+    is_admin = _is_admin(current_user)
+    if not (is_owner or is_admin):
+        raise AuthorizationError("Insufficient permissions", "FORBIDDEN")
+
+    if current_user.id == user_id:
+        raise SmartSellValidationError("Cannot activate self", "SELF_ACTION_FORBIDDEN")
+
+    res = await db.execute(select(User).where(User.id == user_id, User.company_id == company_id))
+    user = res.scalars().first()
+    if not user:
+        raise NotFoundError("User not found", "USER_NOT_FOUND")
+
+    if company and company.owner_id == user.id:
+        raise AuthorizationError("Cannot modify owner", "OWNER_PROTECTED")
+
+    target_role = (getattr(user, "role", "") or "").lower()
+    if is_admin and not is_owner and target_role != "employee":
+        raise AuthorizationError("Admin can activate only employees", "FORBIDDEN")
+
+    user.is_active = True
+    await db.commit()
+
+    audit_logger.log_data_change(
+        user_id=current_user.id,
+        action="activate",
+        resource_type="user",
+        resource_id=str(user_id),
+        changes={"is_active": True},
+    )
+    return SuccessResponse(message="User activated")
+
+
+@router.post("/{user_id}/role", response_model=SuccessResponse)
+async def change_user_role(
+    user_id: int = Path(...),
+    payload: UserRoleUpdate = Body(...),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+):
+    company_id = resolve_tenant_company_id(current_user)
+    company = await _get_company_and_owner(db, company_id)
+    is_owner = _is_owner(company, current_user)
+    is_admin = _is_admin(current_user)
+    if not (is_owner or is_admin):
+        raise AuthorizationError("Insufficient permissions", "FORBIDDEN")
+
+    if current_user.id == user_id:
+        raise SmartSellValidationError("Cannot change own role", "SELF_ACTION_FORBIDDEN")
+
+    res = await db.execute(select(User).where(User.id == user_id, User.company_id == company_id))
+    user = res.scalars().first()
+    if not user:
+        raise NotFoundError("User not found", "USER_NOT_FOUND")
+
+    if company and company.owner_id == user.id:
+        raise AuthorizationError("Cannot change owner role", "OWNER_PROTECTED")
+
+    target_role = (payload.role or "").lower()
+    if target_role == "admin" and not is_owner:
+        raise AuthorizationError("Only owner can assign admin", "OWNER_REQUIRED")
+    if is_admin and not is_owner and target_role in {"admin", "platform_admin"}:
+        raise AuthorizationError("Admin cannot assign this role", "FORBIDDEN")
+
+    user.role = target_role
+    await db.commit()
+
+    audit_logger.log_data_change(
+        user_id=current_user.id,
+        action="role_change",
+        resource_type="user",
+        resource_id=str(user_id),
+        changes={"role": payload.role},
+    )
+    return SuccessResponse(message="Role updated")
 
 
 @router.get("/me", response_model=UserResponse)
@@ -313,7 +495,7 @@ async def revoke_all_my_sessions(
 
 
 # ---------------------------------------------------------------------------
-# Public profiles & admin listing
+# Public profiles
 # ---------------------------------------------------------------------------
 
 
@@ -331,39 +513,6 @@ async def get_user_public_profile(
     if not user:
         raise NotFoundError("User not found", "USER_NOT_FOUND")
     return user
-
-
-@router.get("", response_model=PaginatedResponse[UserResponse])
-async def list_users(
-    pagination: Pagination = Depends(get_pagination),
-    sort_by: str = Query("created_at"),
-    sort_order: str = Query("desc", pattern="^(?i)(asc|desc)$"),
-    search: str | None = Query(None),
-    is_active: bool | None = Query(None),
-    current_user: User = Depends(get_current_verified_user),
-    db: AsyncSession = Depends(get_async_db),
-):
-    """
-    List users with filters (admin-only if флаг админа присутствует).
-    Если в модели нет флага админа — допускаем только самого пользователя (вернём 1 запись — его).
-    """
-    if hasattr(User, "is_superuser") or hasattr(User, "is_admin"):
-        if not _is_admin(current_user):
-            # Не админ — ограничим только собой
-            total = 1
-            items = [current_user]
-            return PaginatedResponse.create(
-                items=items, total=total, page=pagination.page, per_page=pagination.per_page
-            )
-
-    stmt = select(User)
-    stmt = _apply_user_filters(stmt, search, is_active)
-    total_stmt = select(func.count()).select_from(stmt.subquery())
-    total = int((await db.execute(total_stmt)).scalar_one())
-    items_stmt = _apply_sorting(stmt, sort_by, sort_order).offset(pagination.offset).limit(pagination.limit)
-    users = (await db.execute(items_stmt)).scalars().all()
-
-    return PaginatedResponse.create(items=users, total=total, page=pagination.page, per_page=pagination.per_page)
 
 
 # ---------------------------------------------------------------------------

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -411,6 +411,12 @@ class Settings(BaseSettings):
     DEBUG: bool = Field(default=False, description="Debug mode", validation_alias="DEBUG")
     ENVIRONMENT: str = Field(default="development", description="Environment", validation_alias="ENVIRONMENT")
     TESTING: bool = Field(default=False, description="Testing mode", validation_alias="TESTING")
+    DEBUG_OTP_LOGGING: bool = Field(
+        default=False, description="Allow masked OTP debug logging in development", validation_alias="DEBUG_OTP_LOGGING"
+    )
+    DEBUG_CONFIG_DUMP: bool = Field(
+        default=False, description="Allow masked config dumps", validation_alias="DEBUG_CONFIG_DUMP"
+    )
     API_V1_STR: str = Field(default="/api/v1", description="API v1 prefix")
     HOST: str = Field(default="127.0.0.1", description="Server host", validation_alias="HOST")
     PORT: int = Field(default=8000, description="Server port", validation_alias="PORT")
@@ -1466,9 +1472,9 @@ class Settings(BaseSettings):
         return result
 
     def dump_settings(self) -> None:
-        import pprint
-
-        pprint.pprint(self.model_dump())
+        if not self.DEBUG_CONFIG_DUMP:
+            return
+        logging.getLogger(__name__).info("Settings dump: %s", self.dump_settings_safe())
 
     def dump_settings_safe(self) -> dict:
         raw = self.model_dump()

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -41,6 +41,8 @@ __all__ = [
     "OTPRequest",
     "OTPVerify",
     "PasswordReset",
+    "PhoneChangeConfirm",
+    "PhoneChangeRequest",
 ]
 
 # -----------------------------------------------------------------------------
@@ -174,16 +176,14 @@ class UserCreate(UserBase):
 class UserLogin(BaseSchema):
     """Schema for user login (password or OTP)."""
 
-    phone: str = Field(..., description="Phone number")
+    identifier: str = Field(..., description="Phone or email")
     password: str | None = Field(None, description="Password (required if no OTP)")
     otp_code: str | None = Field(None, description="One-time password code")
 
-    @field_validator("phone", mode="before")
+    @field_validator("identifier", mode="before")
     @classmethod
-    def _normalize_and_validate_phone(cls, v: str) -> str:
-        digits = _normalize_phone(v)
-        _validate_phone_digits(digits)
-        return digits
+    def _normalize_identifier(cls, v: str) -> str:
+        return (v or "").strip()
 
     @model_validator(mode="after")
     def _require_password_or_otp(self) -> UserLogin:
@@ -285,6 +285,34 @@ class PasswordResetConfirm(BaseSchema):
     def _validate_reset_password_strength(cls, v: str) -> str:
         _password_strength_check(v)
         return v
+
+
+# -----------------------------------------------------------------------------
+# Phone change
+# -----------------------------------------------------------------------------
+
+
+class PhoneChangeRequest(BaseSchema):
+    new_phone: str = Field(..., description="New phone number")
+
+    @field_validator("new_phone", mode="before")
+    @classmethod
+    def _normalize_new_phone(cls, v: str) -> str:
+        digits = _normalize_phone(v)
+        _validate_phone_digits(digits)
+        return digits
+
+
+class PhoneChangeConfirm(BaseSchema):
+    new_phone: str = Field(..., description="New phone number")
+    code: str = Field(..., min_length=4, max_length=6, description="OTP code")
+
+    @field_validator("new_phone", mode="before")
+    @classmethod
+    def _normalize_new_phone_confirm(cls, v: str) -> str:
+        digits = _normalize_phone(v)
+        _validate_phone_digits(digits)
+        return digits
 
 
 # -----------------------------------------------------------------------------

--- a/app/schemas/users.py
+++ b/app/schemas/users.py
@@ -1,0 +1,42 @@
+"""Schemas for company users management."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import Field, field_validator
+
+from app.schemas.base import BaseSchema
+
+_ALLOWED_ROLES = {"admin", "employee", "manager", "storekeeper", "analyst", "platform_admin"}
+
+
+class UserPublicOut(BaseSchema):
+    id: int
+    phone: str | None = None
+    email: str | None = None
+    full_name: str | None = None
+    role: str | None = None
+    is_active: bool = True
+    is_verified: bool = False
+    created_at: datetime | None = None
+
+
+class UsersListOut(BaseSchema):
+    items: list[UserPublicOut]
+
+
+class UserUpdate(BaseSchema):
+    full_name: str | None = Field(None, max_length=255)
+
+
+class UserRoleUpdate(BaseSchema):
+    role: Literal["admin", "employee", "manager", "storekeeper", "analyst", "platform_admin"]
+
+    @field_validator("role")
+    @classmethod
+    def _validate_role(cls, v: str) -> str:
+        if v not in _ALLOWED_ROLES:
+            raise ValueError("Invalid role")
+        return v

--- a/app/services/background_tasks.py
+++ b/app/services/background_tasks.py
@@ -2,12 +2,32 @@
 Background task services using Celery for async operations.
 """
 
+from __future__ import annotations
+
+import os
+import re
+
 from celery import Celery
 
 from app.core.config import settings
 from app.core.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+def _mask_phone(value: str) -> str:
+    digits = re.sub(r"\D", "", value or "")
+    if not digits:
+        return ""
+    if len(digits) <= 4:
+        return "*" * len(digits)
+    return "*" * (len(digits) - 2) + digits[-2:]
+
+
+def _should_log_otp_debug() -> bool:
+    env = str(os.getenv("ENVIRONMENT") or getattr(settings, "ENVIRONMENT", "production") or "production").lower()
+    return bool(getattr(settings, "DEBUG_OTP_LOGGING", False)) and env == "development"
+
 
 # Initialize Celery
 celery_app = Celery(
@@ -35,16 +55,15 @@ def send_sms_otp(phone: str, code: str) -> bool:
     """Send SMS OTP code using Mobizon API."""
     try:
         # TODO: Implement actual Mobizon API call
-        logger.info(f"Sending OTP {code} to {phone}")
+        logger.info(f"Sending OTP to {_mask_phone(phone)}")
 
         # Simulate API call delay
         import time
 
         time.sleep(1)
 
-        # For now, just log the OTP (remove in production)
-        if settings.DEBUG:
-            print(f"SMS OTP for {phone}: {code}")
+        if _should_log_otp_debug():
+            logger.info(f"OTP requested for phone {_mask_phone(phone)}")
 
         return True
     except Exception as e:

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,7 +2,7 @@
 target-version = "py311"
 
 [lint]
-select = ["E","F","I","B","UP","C4"]
+select = ["E","F","I","B","UP","C4","T20"]
 ignore = ["B904","E402","C401","C408","C416","B009","B010","UP007","E501"]  # временно, E501 handled by formatter
 
 exclude = [
@@ -27,3 +27,4 @@ exclude = [
 "app/main.py"            = ["B008"]
 "app/core/dependencies.py" = ["B008"]
 "app/core/security.py"     = ["B008"]
+"tools/**/*.py"          = ["T201"]

--- a/tests/app/test_auth.py
+++ b/tests/app/test_auth.py
@@ -7,6 +7,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.v1 import auth as auth_mod
 from app.core.security import get_password_hash
 from app.models import Company, OtpAttempt, User
 from app.utils.otp import hash_otp_code
@@ -156,7 +157,7 @@ class TestAuth:
         await async_db_session.commit()
 
         # Login
-        login_data = {"phone": "+77001234567", "password": "password123"}
+        login_data = {"identifier": "+77001234567", "password": "password123"}
 
         response = await async_client.post("/api/auth/login", json=login_data)
 
@@ -185,7 +186,7 @@ class TestAuth:
         await async_db_session.commit()
 
         # Login with wrong password
-        login_data = {"phone": "+77001234567", "password": "wrongpassword"}
+        login_data = {"identifier": "+77001234567", "password": "wrongpassword"}
 
         response = await async_client.post("/api/auth/login", json=login_data)
 
@@ -210,7 +211,7 @@ class TestAuth:
         await async_db_session.commit()
 
         # Login with OTP
-        login_data = {"phone": "+77001234567", "otp_code": otp_code}
+        login_data = {"identifier": "+77001234567", "otp_code": otp_code}
 
         response = await async_client.post("/api/auth/login", json=login_data)
 
@@ -219,6 +220,148 @@ class TestAuth:
 
         assert "access_token" in data
         assert "refresh_token" in data
+
+    @pytest.mark.asyncio
+    async def test_login_with_email(self, async_client: AsyncClient, async_db_session: AsyncSession):
+        company = Company(name="Email Login Co")
+        async_db_session.add(company)
+        await async_db_session.flush()
+
+        user = User(
+            company_id=company.id,
+            phone="+77001112222",
+            email="user@example.com",
+            hashed_password=get_password_hash("password123"),
+            role="admin",
+        )
+        async_db_session.add(user)
+        await async_db_session.commit()
+
+        login_data = {"identifier": "user@example.com", "password": "password123"}
+        response = await async_client.post("/api/auth/login", json=login_data)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert "access_token" in data
+        assert "refresh_token" in data
+
+        @pytest.mark.asyncio
+        async def test_password_reset_request_reset_url_dev_only(
+            self,
+            async_client: AsyncClient,
+            async_db_session: AsyncSession,
+            monkeypatch,
+        ):
+            company = Company(name="Reset URL Co")
+            async_db_session.add(company)
+            await async_db_session.flush()
+
+            user = User(
+                company_id=company.id,
+                phone="77001119999",
+                email="reset-url@example.com",
+                hashed_password=get_password_hash("Password123!"),
+                role="admin",
+                is_active=True,
+                is_verified=True,
+            )
+            async_db_session.add(user)
+            await async_db_session.commit()
+
+            async def _noop_send_email(*args, **kwargs):
+                return True
+
+            monkeypatch.setattr(auth_mod, "send_email", _noop_send_email)
+
+            monkeypatch.setenv("ENVIRONMENT", "development")
+            resp_dev = await async_client.post(
+                "/api/v1/auth/password/reset/request",
+                json={"identifier": "reset-url@example.com"},
+            )
+            assert resp_dev.status_code == 200
+            dev_data = resp_dev.json().get("data") or {}
+            assert "reset_url" in dev_data
+
+            monkeypatch.setenv("ENVIRONMENT", "production")
+            resp_prod = await async_client.post(
+                "/api/v1/auth/password/reset/request",
+                json={"identifier": "reset-url@example.com"},
+            )
+            assert resp_prod.status_code == 200
+            prod_data = resp_prod.json().get("data") or {}
+            assert "reset_url" not in prod_data
+
+    @pytest.mark.asyncio
+    async def test_phone_change_happy_path(
+        self, async_client: AsyncClient, async_db_session: AsyncSession, company_a_admin_headers
+    ):
+        new_phone = "77009991122"
+        otp_code = "123456"
+        await async_db_session.rollback()
+        res_user = await async_db_session.execute(select(User).where(User.phone.in_(["70000010001", "+70000010001"])))
+        existing = res_user.scalars().first()
+        assert existing is not None
+        user_id = existing.id
+        otp_attempt = OtpAttempt.create_new(
+            phone=new_phone,
+            code_hash=hash_otp_code(otp_code),
+            purpose="phone_change",
+        )
+        async_db_session.add(otp_attempt)
+        await async_db_session.commit()
+
+        resp = await async_client.post(
+            "/api/v1/auth/phone/change/confirm",
+            headers=company_a_admin_headers,
+            json={"new_phone": new_phone, "code": otp_code},
+        )
+        assert resp.status_code == 200, resp.text
+
+        await async_db_session.rollback()
+        async_db_session.expire_all()
+        refreshed = await async_db_session.get(User, user_id)
+        assert refreshed is not None
+        assert refreshed.phone == new_phone
+        assert refreshed.is_verified is True
+
+    @pytest.mark.asyncio
+    async def test_phone_change_uniqueness_rejected(
+        self, async_client: AsyncClient, async_db_session: AsyncSession, company_a_admin_headers
+    ):
+        company = Company(name="Phone Change Co")
+        async_db_session.add(company)
+        await async_db_session.flush()
+
+        taken = User(
+            company_id=company.id,
+            phone="77008887766",
+            hashed_password=get_password_hash("Secret123!"),
+            role="admin",
+            is_active=True,
+            is_verified=True,
+        )
+        async_db_session.add(taken)
+        await async_db_session.commit()
+
+        resp = await async_client.post(
+            "/api/v1/auth/phone/change/request",
+            headers=company_a_admin_headers,
+            json={"new_phone": "77008887766"},
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_phone_change_request_no_dev_code_in_production(
+        self, async_client: AsyncClient, company_a_admin_headers, monkeypatch
+    ):
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        resp = await async_client.post(
+            "/api/v1/auth/phone/change/request",
+            headers=company_a_admin_headers,
+            json={"new_phone": "77007776655"},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json().get("data") or {}
+        assert "dev_code" not in data
 
     @pytest.mark.asyncio
     async def test_send_otp(self, async_client: AsyncClient):
@@ -283,7 +426,7 @@ class TestAuth:
         await async_db_session.commit()
 
         # Login to get tokens
-        login_data = {"phone": "+77001234567", "password": "password123"}
+        login_data = {"identifier": "+77001234567", "password": "password123"}
 
         login_response = await async_client.post("/api/auth/login", json=login_data)
         assert login_response.status_code == 200, login_response.text
@@ -320,7 +463,7 @@ class TestAuth:
         await async_db_session.commit()
 
         # Login to get token
-        login_data = {"phone": "+77001234567", "password": "password123"}
+        login_data = {"identifier": "+77001234567", "password": "password123"}
 
         login_response = await async_client.post("/api/auth/login", json=login_data)
         assert login_response.status_code == 200, login_response.text
@@ -357,7 +500,7 @@ class TestAuth:
         await async_db_session.commit()
 
         # Login to get token
-        login_data = {"phone": "+77001234567", "password": "oldpassword"}
+        login_data = {"identifier": "+77001234567", "password": "oldpassword"}
 
         login_response = await async_client.post("/api/auth/login", json=login_data)
         assert login_response.status_code == 200, login_response.text
@@ -375,7 +518,7 @@ class TestAuth:
         assert response.status_code == 200, response.text
 
         # Verify new password works
-        login_data = {"phone": "+77001234567", "password": "newpassword123"}
+        login_data = {"identifier": "+77001234567", "password": "newpassword123"}
 
         response = await async_client.post("/api/auth/login", json=login_data)
 

--- a/tests/app/test_users_mgmt.py
+++ b/tests/app/test_users_mgmt.py
@@ -1,0 +1,157 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, get_password_hash
+from app.models import Company, User, UserSession
+
+
+async def _make_user(
+    async_db_session: AsyncSession,
+    *,
+    company: Company,
+    phone: str,
+    role: str,
+    email: str | None = None,
+    is_active: bool = True,
+) -> User:
+    user = User(
+        company_id=company.id,
+        phone=phone,
+        email=email,
+        hashed_password=get_password_hash("Secret123!"),
+        role=role,
+        is_active=is_active,
+        is_verified=True,
+    )
+    async_db_session.add(user)
+    await async_db_session.commit()
+    await async_db_session.refresh(user)
+    return user
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token(subject=user.id, extra={"company_id": user.company_id, "role": user.role})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_list_users_owner_and_admin_allowed_employee_forbidden(
+    async_client: AsyncClient, async_db_session: AsyncSession
+):
+    company = Company(name="Users Co")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    owner = await _make_user(async_db_session, company=company, phone="77000011111", role="admin")
+    company.owner_id = owner.id
+    await async_db_session.commit()
+
+    admin = await _make_user(async_db_session, company=company, phone="77000011112", role="admin")
+    employee = await _make_user(async_db_session, company=company, phone="77000011113", role="employee")
+
+    resp_owner = await async_client.get("/api/v1/users", headers=_auth_headers(owner))
+    assert resp_owner.status_code == 200
+    assert len(resp_owner.json().get("items") or []) >= 3
+
+    resp_admin = await async_client.get("/api/v1/users", headers=_auth_headers(admin))
+    assert resp_admin.status_code == 200
+
+    resp_emp = await async_client.get("/api/v1/users", headers=_auth_headers(employee))
+    assert resp_emp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_deactivate_rules_and_session_invalidation(async_client: AsyncClient, async_db_session: AsyncSession):
+    company = Company(name="Deactivate Co")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    owner = await _make_user(async_db_session, company=company, phone="77000022221", role="admin")
+    company.owner_id = owner.id
+    await async_db_session.commit()
+
+    admin = await _make_user(async_db_session, company=company, phone="77000022222", role="admin")
+    employee = await _make_user(async_db_session, company=company, phone="77000022223", role="employee")
+    admin_peer = await _make_user(async_db_session, company=company, phone="77000022224", role="admin")
+    admin_id = admin.id
+    employee_id = employee.id
+    admin_peer_id = admin_peer.id
+    owner_id = owner.id
+    admin_headers = _auth_headers(admin)
+    owner_headers = _auth_headers(owner)
+
+    session = UserSession(user_id=employee_id, refresh_token="x", is_active=True)
+    async_db_session.add(session)
+    await async_db_session.commit()
+
+    resp_admin = await async_client.post(f"/api/v1/users/{employee_id}/deactivate", headers=admin_headers)
+    assert resp_admin.status_code == 200
+
+    resp_owner = await async_client.post(f"/api/v1/users/{admin_id}/deactivate", headers=owner_headers)
+    assert resp_owner.status_code == 200
+
+    resp_activate = await async_client.post(f"/api/v1/users/{admin_id}/activate", headers=owner_headers)
+    assert resp_activate.status_code == 200
+
+    await async_db_session.rollback()
+    res_admin = await async_db_session.execute(select(User).where(User.id == admin_id))
+    admin_refreshed = res_admin.scalars().first()
+    assert admin_refreshed is not None and admin_refreshed.is_active is True
+
+    await async_db_session.rollback()
+    res_session = await async_db_session.execute(select(UserSession).where(UserSession.user_id == employee_id))
+    sess = res_session.scalars().first()
+    assert sess is not None and sess.is_active is False
+
+    resp_admin_bad = await async_client.post(f"/api/v1/users/{admin_peer_id}/deactivate", headers=admin_headers)
+    assert resp_admin_bad.status_code == 403
+
+    resp_owner_bad = await async_client.post(f"/api/v1/users/{owner_id}/deactivate", headers=owner_headers)
+    assert resp_owner_bad.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_role_change_rules_and_tenant_isolation(async_client: AsyncClient, async_db_session: AsyncSession):
+    company_a = Company(name="Roles A")
+    company_b = Company(name="Roles B")
+    async_db_session.add(company_a)
+    async_db_session.add(company_b)
+    await async_db_session.flush()
+
+    owner = await _make_user(async_db_session, company=company_a, phone="77000033331", role="admin")
+    company_a.owner_id = owner.id
+    await async_db_session.commit()
+
+    admin = await _make_user(async_db_session, company=company_a, phone="77000033332", role="admin")
+    employee = await _make_user(async_db_session, company=company_a, phone="77000033333", role="employee")
+    other_company_user = await _make_user(async_db_session, company=company_b, phone="77000033334", role="employee")
+
+    resp_owner = await async_client.post(
+        f"/api/v1/users/{employee.id}/role",
+        headers=_auth_headers(owner),
+        json={"role": "admin"},
+    )
+    assert resp_owner.status_code == 200
+
+    resp_admin = await async_client.post(
+        f"/api/v1/users/{employee.id}/role",
+        headers=_auth_headers(admin),
+        json={"role": "admin"},
+    )
+    assert resp_admin.status_code == 403
+
+    resp_self = await async_client.post(
+        f"/api/v1/users/{admin.id}/role",
+        headers=_auth_headers(admin),
+        json={"role": "manager"},
+    )
+    assert resp_self.status_code == 422
+
+    resp_other = await async_client.post(
+        f"/api/v1/users/{other_company_user.id}/role",
+        headers=_auth_headers(owner),
+        json={"role": "employee"},
+    )
+    assert resp_other.status_code == 404

--- a/tests/test_debug_db_endpoint.py
+++ b/tests/test_debug_db_endpoint.py
@@ -133,7 +133,7 @@ def test_debug_routes_disabled_in_non_local_without_debug(monkeypatch):
     env = {
         "TESTING": "1",
         "TEST_DATABASE_URL": "postgresql://user:pass@host:5432/db",
-        "ENVIRONMENT": "development",
+        "ENVIRONMENT": "production",
         "DEBUG": "0",
     }
 


### PR DESCRIPTION
Removes OTP prints/logging, makes debug DB fingerprint password-safe, restricts debug routes to dev/DEBUG, guards config dumps behind DEBUG_CONFIG_DUMP, enforces print ban via Ruff (T201). Local checks: ruff + pytest passed.