### PR TITLE
feat(kaspi): product catalog sync (tenant token + pagination) MVP

### DIFF
--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -883,6 +883,12 @@ async def kaspi_products_sync(
     try:
         result = await sync_kaspi_catalog_products(session, company_id)
         return KaspiProductSyncOut(**result)
+    except ValueError as e:
+        detail = str(e) or "kaspi_sync_not_configured"
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=detail,
+        )
     except Exception as e:
         logger.error("Kaspi products sync failed: company_id=%s error=%s", company_id, e)
         raise HTTPException(

--- a/app/services/kaspi_products_sync_service.py
+++ b/app/services/kaspi_products_sync_service.py
@@ -14,8 +14,11 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.logging import get_logger
+from app.models.company import Company
 from app.models.kaspi_catalog_product import KaspiCatalogProduct
+from app.models.marketplace import KaspiStoreToken
 from app.services.kaspi_service import KaspiService
 
 logger = get_logger(__name__)
@@ -25,6 +28,9 @@ async def sync_kaspi_catalog_products(
     session: AsyncSession,
     company_id: int,
     kaspi: KaspiService | None = None,
+    *,
+    page_size: int = 100,
+    max_pages: int = 100,
 ) -> dict[str, Any]:
     """
     Synchronize Kaspi catalog products to local database.
@@ -37,8 +43,21 @@ async def sync_kaspi_catalog_products(
     Returns:
         Summary dict with keys: ok, company_id, fetched, inserted, updated
     """
+    res_company = await session.execute(select(Company).where(Company.id == company_id))
+    company = res_company.scalars().first()
+    if not company:
+        raise ValueError("company_not_found")
+
+    store_name = (company.kaspi_store_id or "").strip()
+    if not store_name:
+        raise ValueError("kaspi_store_not_configured")
+
+    token = await KaspiStoreToken.get_token(session, store_name)
+    if not token:
+        raise ValueError("kaspi_token_not_found")
+
     if kaspi is None:
-        kaspi = KaspiService()
+        kaspi = KaspiService(api_key=token, base_url=settings.KASPI_API_URL)
 
     fetched = 0
     inserted = 0
@@ -47,71 +66,76 @@ async def sync_kaspi_catalog_products(
     logger.info("Kaspi catalog sync start: company_id=%s", company_id)
 
     try:
-        # Fetch products from Kaspi API (page 1, default page_size)
-        items = await kaspi.get_products(page=1, page_size=100)
-        fetched = len(items)
+        # Fetch products from Kaspi API with pagination
+        for page in range(1, max_pages + 1):
+            items = await kaspi.get_products(page=page, page_size=page_size)
+            if not items:
+                break
 
-        logger.info("Kaspi catalog sync: company_id=%s fetched=%s", company_id, fetched)
+            fetched += len(items)
 
-        # Process each product item
-        for item in items:
-            # Extract offer_id (priority: offer_id, then id)
-            offer_id = item.get("offer_id") or item.get("id")
-            if not offer_id:
-                logger.warning("Kaspi catalog sync: skipping item without offer_id/id")
-                continue
+            # Process each product item
+            for item in items:
+                # Extract offer_id (priority: offer_id, then id)
+                offer_id = item.get("offer_id") or item.get("id")
+                if not offer_id:
+                    logger.warning("Kaspi catalog sync: skipping item without offer_id/id")
+                    continue
 
-            # Check if product already exists
-            check_stmt = select(KaspiCatalogProduct.id).where(
-                KaspiCatalogProduct.company_id == company_id,
-                KaspiCatalogProduct.offer_id == str(offer_id),
-            )
-            result_check = await session.execute(check_stmt)
-            exists = result_check.scalar_one_or_none()
-
-            # Extract fields
-            name = item.get("name") or item.get("title")
-            sku = item.get("sku") or item.get("code")
-            price = item.get("price")
-            qty = item.get("qty") or item.get("quantity") or item.get("stock")
-            is_active = item.get("is_active", True)
-
-            # Build upsert statement (ON CONFLICT DO UPDATE)
-            stmt = (
-                insert(KaspiCatalogProduct)
-                .values(
-                    company_id=company_id,
-                    offer_id=str(offer_id),
-                    name=str(name) if name else None,
-                    sku=str(sku) if sku else None,
-                    price=float(price) if price is not None else None,
-                    qty=int(qty) if qty is not None else None,
-                    is_active=bool(is_active),
-                    raw=item,
-                    created_at=datetime.utcnow(),
-                    updated_at=datetime.utcnow(),
+                # Check if product already exists
+                check_stmt = select(KaspiCatalogProduct.id).where(
+                    KaspiCatalogProduct.company_id == company_id,
+                    KaspiCatalogProduct.offer_id == str(offer_id),
                 )
-                .on_conflict_do_update(
-                    index_elements=["company_id", "offer_id"],
-                    set_={
-                        "name": str(name) if name else None,
-                        "sku": str(sku) if sku else None,
-                        "price": float(price) if price is not None else None,
-                        "qty": int(qty) if qty is not None else None,
-                        "is_active": bool(is_active),
-                        "raw": item,
-                        "updated_at": datetime.utcnow(),
-                    },
+                result_check = await session.execute(check_stmt)
+                exists = result_check.scalar_one_or_none()
+
+                # Extract fields
+                name = item.get("name") or item.get("title")
+                sku = item.get("sku") or item.get("code")
+                price = item.get("price")
+                qty = item.get("qty") or item.get("quantity") or item.get("stock")
+                is_active = item.get("is_active", True)
+
+                # Build upsert statement (ON CONFLICT DO UPDATE)
+                stmt = (
+                    insert(KaspiCatalogProduct)
+                    .values(
+                        company_id=company_id,
+                        offer_id=str(offer_id),
+                        name=str(name) if name else None,
+                        sku=str(sku) if sku else None,
+                        price=float(price) if price is not None else None,
+                        qty=int(qty) if qty is not None else None,
+                        is_active=bool(is_active),
+                        raw=item,
+                        created_at=datetime.utcnow(),
+                        updated_at=datetime.utcnow(),
+                    )
+                    .on_conflict_do_update(
+                        index_elements=["company_id", "offer_id"],
+                        set_={
+                            "name": str(name) if name else None,
+                            "sku": str(sku) if sku else None,
+                            "price": float(price) if price is not None else None,
+                            "qty": int(qty) if qty is not None else None,
+                            "is_active": bool(is_active),
+                            "raw": item,
+                            "updated_at": datetime.utcnow(),
+                        },
+                    )
                 )
-            )
 
-            await session.execute(stmt)
+                await session.execute(stmt)
 
-            # Track insert vs update
-            if exists:
-                updated += 1
-            else:
-                inserted += 1
+                # Track insert vs update
+                if exists:
+                    updated += 1
+                else:
+                    inserted += 1
+
+            if len(items) < page_size:
+                break
 
         # Commit transaction
         await session.commit()

--- a/tests/app/test_kaspi_products_sync.py
+++ b/tests/app/test_kaspi_products_sync.py
@@ -1,0 +1,109 @@
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.company import Company
+from app.models.kaspi_catalog_product import KaspiCatalogProduct
+from app.models.marketplace import KaspiStoreToken
+from app.services.kaspi_products_sync_service import sync_kaspi_catalog_products
+
+
+class _DummyKaspiService:
+    def __init__(self, pages: dict[int, list[dict]]):
+        self._pages = pages
+        self.calls: list[tuple[int, int]] = []
+
+    async def get_products(self, *, page: int = 1, page_size: int = 100) -> list[dict]:
+        self.calls.append((page, page_size))
+        return self._pages.get(page, [])
+
+
+@pytest.mark.asyncio
+async def test_kaspi_products_sync_pagination_and_upsert(async_db_session: AsyncSession, monkeypatch):
+    company_a = Company(name="Kaspi A", kaspi_store_id="store-a")
+    company_b = Company(name="Kaspi B", kaspi_store_id="store-b")
+    async_db_session.add(company_a)
+    async_db_session.add(company_b)
+    await async_db_session.commit()
+
+    async def _get_token(session: AsyncSession, store_name: str):
+        return "token-a" if store_name == "store-a" else "token-b"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    pages_run1 = {
+        1: [
+            {"offer_id": "1", "name": "Item 1", "price": 10.0, "qty": 5, "is_active": True},
+            {"offer_id": "2", "name": "Item 2", "price": 20.0, "qty": 2, "is_active": True},
+        ],
+        2: [{"offer_id": "3", "name": "Item 3", "price": 30.0, "qty": 1, "is_active": False}],
+        3: [],
+    }
+
+    kaspi = _DummyKaspiService(pages_run1)
+    result1 = await sync_kaspi_catalog_products(async_db_session, company_a.id, kaspi=kaspi, page_size=2, max_pages=5)
+    assert result1["fetched"] == 3
+    assert result1["inserted"] == 3
+    assert result1["updated"] == 0
+
+    rows_a = await async_db_session.execute(
+        select(KaspiCatalogProduct).where(KaspiCatalogProduct.company_id == company_a.id)
+    )
+    items_a = rows_a.scalars().all()
+    assert len(items_a) == 3
+
+    rows_b = await async_db_session.execute(
+        select(KaspiCatalogProduct).where(KaspiCatalogProduct.company_id == company_b.id)
+    )
+    items_b = rows_b.scalars().all()
+    assert len(items_b) == 0
+
+    pages_run2 = {
+        1: [
+            {"offer_id": "1", "name": "Item 1", "price": 11.5, "qty": 7, "is_active": True},
+            {"offer_id": "2", "name": "Item 2", "price": 20.0, "qty": 2, "is_active": True},
+        ],
+        2: [{"offer_id": "3", "name": "Item 3", "price": 30.0, "qty": 1, "is_active": False}],
+    }
+
+    kaspi2 = _DummyKaspiService(pages_run2)
+    result2 = await sync_kaspi_catalog_products(async_db_session, company_a.id, kaspi=kaspi2, page_size=2, max_pages=5)
+    assert result2["fetched"] == 3
+    assert result2["updated"] >= 1
+
+    await async_db_session.rollback()
+    updated_row = await async_db_session.execute(
+        select(KaspiCatalogProduct)
+        .where(
+            KaspiCatalogProduct.company_id == company_a.id,
+            KaspiCatalogProduct.offer_id == "1",
+        )
+        .execution_options(populate_existing=True)
+    )
+    updated_item = updated_row.scalars().first()
+    assert updated_item is not None
+    assert float(updated_item.price or 0) == 11.5
+    assert updated_item.qty == 7
+
+
+@pytest.mark.asyncio
+async def test_kaspi_products_sync_requires_store_and_token(async_db_session: AsyncSession, monkeypatch):
+    company = Company(name="Kaspi Missing")
+    async_db_session.add(company)
+    await async_db_session.commit()
+
+    with pytest.raises(ValueError) as exc:
+        await sync_kaspi_catalog_products(async_db_session, company.id, kaspi=_DummyKaspiService({}))
+    assert "kaspi_store_not_configured" in str(exc.value)
+
+    company.kaspi_store_id = "store-missing-token"
+    await async_db_session.commit()
+
+    async def _missing_token(session: AsyncSession, store_name: str):
+        return None
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _missing_token)
+
+    with pytest.raises(ValueError) as exc2:
+        await sync_kaspi_catalog_products(async_db_session, company.id, kaspi=_DummyKaspiService({}))
+    assert "kaspi_token_not_found" in str(exc2.value)

--- a/tests/test_kaspi_products_catalog_sync.py
+++ b/tests/test_kaspi_products_catalog_sync.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import pytest
 import sqlalchemy as sa
 
+from app.models.company import Company
 from app.models.kaspi_catalog_product import KaspiCatalogProduct
+from app.models.marketplace import KaspiStoreToken
 
 
 def _fake_products_payload() -> list[dict]:
@@ -39,6 +41,16 @@ def _fake_products_payload() -> list[dict]:
     ]
 
 
+async def _ensure_company_store(async_db_session, company_id: int, store_id: str) -> None:
+    company = await async_db_session.get(Company, company_id)
+    if not company:
+        company = Company(id=company_id, name=f"Company {company_id}", kaspi_store_id=store_id)
+        async_db_session.add(company)
+    else:
+        company.kaspi_store_id = store_id
+    await async_db_session.commit()
+
+
 @pytest.mark.asyncio
 async def test_kaspi_products_sync_creates_and_lists(
     monkeypatch,
@@ -57,6 +69,13 @@ async def test_kaspi_products_sync_creates_and_lists(
     5. Verify: 2 products returned with correct fields
     """
     from app.services.kaspi_service import KaspiService
+
+    await _ensure_company_store(async_db_session, 1001, "store-a")
+
+    async def _get_token(session, store_name: str):
+        return "token-a" if store_name == "store-a" else None
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
 
     # Mock get_products
     async def fake_get_products(self, *, page=1, page_size=100):  # noqa: ARG001
@@ -110,6 +129,13 @@ async def test_kaspi_products_sync_idempotent(
     """
     from app.services.kaspi_service import KaspiService
 
+    await _ensure_company_store(async_db_session, 1001, "store-a")
+
+    async def _get_token(session, store_name: str):
+        return "token-a" if store_name == "store-a" else None
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
     # Mock get_products
     async def fake_get_products(self, *, page=1, page_size=100):  # noqa: ARG001
         return _fake_products_payload()
@@ -156,6 +182,14 @@ async def test_kaspi_products_tenant_isolation(
     4. List products for company B: should see only B's products
     """
     from app.services.kaspi_service import KaspiService
+
+    await _ensure_company_store(async_db_session, 1001, "store-a")
+    await _ensure_company_store(async_db_session, 2001, "store-b")
+
+    async def _get_token(session, store_name: str):
+        return "token-a" if store_name == "store-a" else "token-b"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
 
     # Mock get_products to return different data based on call count
     call_count = [0]


### PR DESCRIPTION
Tenant-scoped product sync: uses Company.kaspi_store_id -> KaspiStoreToken.get_token. KaspiService instantiated per-store with KASPI_API_URL. Added pagination with safety max pages. Missing store/token mapped to 409 Conflict. Tests: ruff + pytest passed (324 passed).