### PR TITLE
fix(kaspi): tenant token selftest for orders+goods

### DIFF
--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -28,9 +28,10 @@ app/api/v1/kaspi.py — Полный, боевой роутер интеграц
 
 import inspect
 import json
-import logging
+from datetime import datetime, timedelta
 from typing import Any
 
+import httpx
 import sqlalchemy as sa
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field
@@ -47,12 +48,10 @@ from app.models import Product
 from app.models.company import Company
 from app.models.kaspi_catalog_product import KaspiCatalogProduct
 from app.models.kaspi_feed_export import KaspiFeedExport
+from app.models.kaspi_goods_import import KaspiGoodsImport
 from app.models.kaspi_order_sync_state import KaspiOrderSyncState
 from app.models.marketplace import KaspiStoreToken
 from app.models.user import User
-
-logger = get_logger(__name__)
-
 from app.schemas.kaspi import (
     ImportRequest,
     ImportStatusQuery,
@@ -62,9 +61,10 @@ from app.schemas.kaspi import (
     KaspiTokenOut,
     OrdersQuery,
 )
+from app.services.kaspi_goods_client import KaspiGoodsClient, KaspiNotAuthenticated
 from app.services.kaspi_service import KaspiService, KaspiSyncAlreadyRunning
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 router = APIRouter(prefix="/api/v1/kaspi", tags=["kaspi"])
 
 
@@ -91,6 +91,34 @@ async def _auth_user(current_user: User = Depends(get_current_user)) -> User:
 
 def _resolve_company_id(current_user: User) -> int:
     return resolve_tenant_company_id(current_user, not_found_detail="Company not set")
+
+
+async def _resolve_kaspi_token(session: AsyncSession, company_id: int) -> tuple[str, str]:
+    company = (await session.execute(sa.select(Company).where(Company.id == company_id))).scalars().first()
+    if not company:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+    store_name = (company.kaspi_store_id or "").strip()
+    if not store_name:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="kaspi_store_not_configured")
+    token = await KaspiStoreToken.get_token(session, store_name)
+    if not token:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="kaspi_token_not_found")
+    return store_name, token
+
+
+def _extract_import_code(payload: dict) -> str | None:
+    return payload.get("importCode") or payload.get("import_code") or payload.get("code") or payload.get("id")
+
+
+def _product_to_goods_payload(product: Product) -> dict[str, Any]:
+    sku = product.sku or f"PID-{product.id}"
+    return {
+        "sku": sku,
+        "name": product.name or sku,
+        "price": float(product.price) if product.price is not None else None,
+        "quantity": int(product.stock_quantity or 0),
+        "isActive": bool(product.is_active),
+    }
 
 
 # ------------------------------- Локальные схемы (deprecated - use app/schemas/kaspi.py) ------
@@ -862,6 +890,45 @@ class KaspiProductListOut(BaseModel):
     offset: int
 
 
+class KaspiGoodsImportIn(BaseModel):
+    product_ids: list[int] | None = None
+    payload: list[dict[str, Any]] | None = None
+    content_type: str | None = None
+
+
+class KaspiGoodsImportOut(BaseModel):
+    ok: bool
+    import_code: str
+    status: str
+
+
+class KaspiGoodsStatusOut(BaseModel):
+    import_code: str
+    status: str
+    payload: dict[str, Any] | None = None
+
+
+class KaspiGoodsResultOut(BaseModel):
+    import_code: str
+    status: str
+    payload: dict[str, Any] | None = None
+
+
+class KaspiTokenHealthOut(BaseModel):
+    ok: bool
+    orders_http: int
+    goods_http: int
+    cause: str | None = None
+
+
+class KaspiTokenSelftestOut(BaseModel):
+    orders_http: int
+    goods_schema_http: int
+    goods_categories_http: int
+    goods_access: str | None = None
+    orders_error: str | None = None
+
+
 @router.post(
     "/products/sync",
     summary="Синхронизировать каталог Kaspi в локальную БД",
@@ -895,6 +962,319 @@ async def kaspi_products_sync(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Failed to sync products from Kaspi",
         )
+
+
+# ============================= GOODS API ==============================
+
+
+@router.get(
+    "/goods/schema",
+    summary="Kaspi goods import schema",
+)
+async def kaspi_goods_schema(
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    company_id = _resolve_company_id(current_user)
+    _, token = await _resolve_kaspi_token(session, company_id)
+    client = KaspiGoodsClient(token=token, base_url="https://kaspi.kz")
+    try:
+        return await client.get_schema()
+    except KaspiNotAuthenticated as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="NOT_AUTHENTICATED") from exc
+
+
+@router.get(
+    "/goods/categories",
+    summary="Kaspi goods categories",
+)
+async def kaspi_goods_categories(
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    company_id = _resolve_company_id(current_user)
+    _, token = await _resolve_kaspi_token(session, company_id)
+    client = KaspiGoodsClient(token=token, base_url="https://kaspi.kz")
+    try:
+        return await client.get_categories()
+    except KaspiNotAuthenticated as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="NOT_AUTHENTICATED") from exc
+
+
+@router.get(
+    "/goods/attributes",
+    summary="Kaspi goods attributes for category",
+)
+async def kaspi_goods_attributes(
+    category: str,
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    company_id = _resolve_company_id(current_user)
+    _, token = await _resolve_kaspi_token(session, company_id)
+    client = KaspiGoodsClient(token=token, base_url="https://kaspi.kz")
+    try:
+        return await client.get_attributes(category_code=category)
+    except KaspiNotAuthenticated as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="NOT_AUTHENTICATED") from exc
+
+
+@router.get(
+    "/goods/attribute-values",
+    summary="Kaspi goods attribute values",
+)
+async def kaspi_goods_attribute_values(
+    category: str,
+    attribute: str,
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    company_id = _resolve_company_id(current_user)
+    _, token = await _resolve_kaspi_token(session, company_id)
+    client = KaspiGoodsClient(token=token, base_url="https://kaspi.kz")
+    try:
+        return await client.get_attribute_values(category_code=category, attribute_code=attribute)
+    except KaspiNotAuthenticated as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="NOT_AUTHENTICATED") from exc
+
+
+@router.post(
+    "/goods/import",
+    summary="Kaspi goods import",
+    response_model=KaspiGoodsImportOut,
+)
+async def kaspi_goods_import(
+    body: KaspiGoodsImportIn,
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    company_id = _resolve_company_id(current_user)
+    _, token = await _resolve_kaspi_token(session, company_id)
+
+    payload: list[dict[str, Any]]
+    if body.payload:
+        payload = body.payload
+    elif body.product_ids:
+        res = await session.execute(
+            sa.select(Product).where(sa.and_(Product.company_id == company_id, Product.id.in_(body.product_ids)))
+        )
+        products = res.scalars().all()
+        if not products:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="products_not_found")
+        payload = [_product_to_goods_payload(p) for p in products]
+    else:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="payload_or_product_ids_required")
+
+    client = KaspiGoodsClient(token=token, base_url="https://kaspi.kz")
+    try:
+        response = await client.post_import(payload, content_type=body.content_type)
+    except KaspiNotAuthenticated as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="NOT_AUTHENTICATED") from exc
+
+    import_code = _extract_import_code(response)
+    if not import_code:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_import_code_missing")
+
+    status_value = response.get("status") or "submitted"
+
+    record = KaspiGoodsImport(
+        company_id=company_id,
+        created_by_user_id=current_user.id,
+        import_code=str(import_code),
+        status=str(status_value),
+        request_payload=payload,
+        result_payload=None,
+        last_error=None,
+    )
+    session.add(record)
+    await session.commit()
+
+    return KaspiGoodsImportOut(ok=True, import_code=str(import_code), status=str(status_value))
+
+
+@router.get(
+    "/goods/import/{code}",
+    summary="Kaspi goods import status",
+    response_model=KaspiGoodsStatusOut,
+)
+async def kaspi_goods_import_status(
+    code: str,
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    company_id = _resolve_company_id(current_user)
+    _, token = await _resolve_kaspi_token(session, company_id)
+    client = KaspiGoodsClient(token=token, base_url="https://kaspi.kz")
+    try:
+        response = await client.get_import_status(import_code=code)
+    except KaspiNotAuthenticated as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="NOT_AUTHENTICATED") from exc
+
+    status_value = response.get("status") or "unknown"
+
+    res = await session.execute(
+        sa.select(KaspiGoodsImport).where(
+            sa.and_(KaspiGoodsImport.company_id == company_id, KaspiGoodsImport.import_code == code)
+        )
+    )
+    record = res.scalars().first()
+    if record:
+        record.status = str(status_value)
+        record.result_payload = response
+        await session.commit()
+
+    return KaspiGoodsStatusOut(import_code=code, status=str(status_value), payload=response)
+
+
+@router.get(
+    "/goods/import/{code}/result",
+    summary="Kaspi goods import result",
+    response_model=KaspiGoodsResultOut,
+)
+async def kaspi_goods_import_result(
+    code: str,
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    company_id = _resolve_company_id(current_user)
+    _, token = await _resolve_kaspi_token(session, company_id)
+    client = KaspiGoodsClient(token=token, base_url="https://kaspi.kz")
+    try:
+        response = await client.get_import_result(import_code=code)
+    except KaspiNotAuthenticated as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="NOT_AUTHENTICATED") from exc
+
+    status_value = response.get("status") or "unknown"
+
+    res = await session.execute(
+        sa.select(KaspiGoodsImport).where(
+            sa.and_(KaspiGoodsImport.company_id == company_id, KaspiGoodsImport.import_code == code)
+        )
+    )
+    record = res.scalars().first()
+    if record:
+        record.status = str(status_value)
+        record.result_payload = response
+        await session.commit()
+
+    return KaspiGoodsResultOut(import_code=code, status=str(status_value), payload=response)
+
+
+@router.get(
+    "/token/health",
+    summary="Kaspi token health",
+    response_model=KaspiTokenHealthOut,
+)
+async def kaspi_token_health(
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    company_id = _resolve_company_id(current_user)
+    _, token = await _resolve_kaspi_token(session, company_id)
+
+    now = datetime.utcnow()
+    ge_ms = int((now - timedelta(days=14)).timestamp() * 1000)
+    le_ms = int(now.timestamp() * 1000)
+
+    orders_url = "https://kaspi.kz/shop/api/v2/orders"
+    orders_params = {
+        "page[number]": 0,
+        "page[size]": 1,
+        "filter[orders][creationDate][$ge]": ge_ms,
+        "filter[orders][creationDate][$le]": le_ms,
+    }
+
+    orders_headers = {
+        "X-Auth-Token": token,
+        "Accept": "application/vnd.api+json",
+    }
+
+    goods_headers = {
+        "X-Auth-Token": token,
+        "Accept": "application/json",
+    }
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        orders_resp = await client.get(orders_url, headers=orders_headers, params=orders_params)
+        goods_resp = await client.get("https://kaspi.kz/shop/api/products/import/schema", headers=goods_headers)
+
+    cause = None
+    if orders_resp.status_code == 401 or goods_resp.status_code == 401:
+        cause = "NOT_AUTHENTICATED"
+
+    return KaspiTokenHealthOut(
+        ok=cause is None,
+        orders_http=orders_resp.status_code,
+        goods_http=goods_resp.status_code,
+        cause=cause,
+    )
+
+
+@router.get(
+    "/token/selftest",
+    summary="Kaspi token self-test",
+    response_model=KaspiTokenSelftestOut,
+)
+async def kaspi_token_selftest(
+    current_user: User = Depends(_auth_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    company_id = _resolve_company_id(current_user)
+    _, token = await _resolve_kaspi_token(session, company_id)
+
+    now = datetime.utcnow()
+    ge_ms = int((now - timedelta(days=14)).timestamp() * 1000)
+    le_ms = int(now.timestamp() * 1000)
+
+    orders_url = "https://kaspi.kz/shop/api/v2/orders"
+    orders_params = {
+        "page[size]": 1,
+        "filter[orders][state]": "NEW",
+        "filter[orders][creationDate][$ge]": ge_ms,
+        "filter[orders][creationDate][$le]": le_ms,
+    }
+    orders_headers = {
+        "X-Auth-Token": token,
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+    }
+
+    goods_headers = {
+        "X-Auth-Token": token,
+        "Accept": "application/json",
+    }
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        orders_resp = await client.get(orders_url, headers=orders_headers, params=orders_params)
+        goods_schema_resp = await client.get(
+            "https://kaspi.kz/shop/api/products/import/schema",
+            headers=goods_headers,
+        )
+        goods_categories_resp = await client.get(
+            "https://kaspi.kz/shop/api/products/classification/categories",
+            headers=goods_headers,
+        )
+
+    if orders_resp.status_code == 401:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="NOT_AUTHENTICATED")
+
+    orders_error = None
+    if orders_resp.status_code >= 400:
+        orders_error = "orders_request_failed"
+
+    goods_access = None
+    if orders_resp.status_code == 200 and (
+        goods_schema_resp.status_code == 401 or goods_categories_resp.status_code == 401
+    ):
+        goods_access = "missing_or_not_enabled"
+
+    return KaspiTokenSelftestOut(
+        orders_http=orders_resp.status_code,
+        goods_schema_http=goods_schema_resp.status_code,
+        goods_categories_http=goods_categories_resp.status_code,
+        goods_access=goods_access,
+        orders_error=orders_error,
+    )
 
 
 @router.get(

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -188,6 +188,7 @@ _LAZY_MODELS: dict[str, tuple[str, str]] = {
     "KaspiOrderSyncState": ("app.models.kaspi_order_sync_state", "KaspiOrderSyncState"),
     "KaspiCatalogProduct": ("app.models.kaspi_catalog_product", "KaspiCatalogProduct"),
     "KaspiFeedExport": ("app.models.kaspi_feed_export", "KaspiFeedExport"),
+    "KaspiGoodsImport": ("app.models.kaspi_goods_import", "KaspiGoodsImport"),
 }
 
 # Поддерживаемые модули доменов для «массового» импорта (ручной whitelisting).
@@ -207,6 +208,7 @@ _DOMAIN_MODULES: tuple[str, ...] = (
     "app.models.kaspi_order_sync_state",
     "app.models.kaspi_catalog_product",
     "app.models.kaspi_feed_export",
+    "app.models.kaspi_goods_import",
     "app.models.system_integrations",
     "app.models.integration_provider",
     "app.models.integration_provider_config",

--- a/app/models/kaspi_goods_import.py
+++ b/app/models/kaspi_goods_import.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, ForeignKey, String, Text, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from app.models.base import Base
+
+
+class KaspiGoodsImport(Base):
+    __tablename__ = "kaspi_goods_imports"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    company_id = Column(ForeignKey("companies.id", ondelete="CASCADE"), nullable=False, index=True)
+    created_by_user_id = Column(ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
+    import_code = Column(String(128), nullable=False, index=True)
+    status = Column(String(64), nullable=False, server_default=text("'created'"))
+    request_payload = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
+    result_payload = Column(JSONB, nullable=True)
+    last_error = Column(Text, nullable=True)
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)

--- a/app/services/kaspi_goods_client.py
+++ b/app/services/kaspi_goods_client.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import httpx
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class KaspiNotAuthenticated(RuntimeError):
+    """Kaspi token is invalid or not authenticated."""
+
+
+class KaspiGoodsClient:
+    def __init__(self, *, token: str, base_url: str = "https://kaspi.kz"):
+        if not token:
+            raise ValueError("kaspi_token_required")
+        self._token = token
+        self._base_url = base_url.rstrip("/")
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "X-Auth-Token": self._token,
+            "Accept": "application/json",
+        }
+
+    def _url(self, path: str) -> str:
+        if not path.startswith("/"):
+            path = "/" + path
+        return f"{self._base_url}{path}"
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        json_body: object | None = None,
+        content_type: str | None = None,
+    ) -> dict:
+        headers = self._headers()
+        if content_type:
+            headers["Content-Type"] = content_type
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.request(method, self._url(path), headers=headers, params=params, json=json_body)
+        if resp.status_code == 401:
+            raise KaspiNotAuthenticated("Kaspi token is not authenticated")
+        resp.raise_for_status()
+        return resp.json() if resp.content else {}
+
+    async def get_schema(self) -> dict:
+        return await self._request("GET", "/shop/api/products/import/schema")
+
+    async def get_categories(self) -> dict:
+        return await self._request("GET", "/shop/api/products/classification/categories")
+
+    async def get_attributes(self, *, category_code: str) -> dict:
+        return await self._request(
+            "GET",
+            "/shop/api/products/classification/attributes",
+            params={"c": category_code},
+        )
+
+    async def get_attribute_values(self, *, category_code: str, attribute_code: str) -> dict:
+        return await self._request(
+            "GET",
+            "/shop/api/products/classification/attribute/values",
+            params={"c": category_code, "a": attribute_code},
+        )
+
+    async def post_import(self, payload: list[dict], *, content_type: str | None = None) -> dict:
+        return await self._request(
+            "POST",
+            "/shop/api/products/import",
+            json_body=payload,
+            content_type=content_type or "application/json",
+        )
+
+    async def get_import_status(self, *, import_code: str) -> dict:
+        return await self._request(
+            "GET",
+            "/shop/api/products/import",
+            params={"i": import_code},
+        )
+
+    async def get_import_result(self, *, import_code: str) -> dict:
+        return await self._request(
+            "GET",
+            "/shop/api/products/import/result",
+            params={"i": import_code},
+        )

--- a/migrations/versions/20260117_kaspi_goods_imports.py
+++ b/migrations/versions/20260117_kaspi_goods_imports.py
@@ -1,0 +1,63 @@
+"""feat(kaspi): add kaspi goods imports
+
+Revision ID: 20260117_kaspi_goods_imports
+Revises: 20260115_allow_employee_role
+Create Date: 2026-01-17 10:00:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260117_kaspi_goods_imports"
+down_revision: Union[str, Sequence[str], None] = "20260115_allow_employee_role"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "kaspi_goods_imports",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column(
+            "company_id",
+            sa.Integer(),
+            sa.ForeignKey("companies.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "created_by_user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column("import_code", sa.String(length=128), nullable=False, index=True),
+        sa.Column("status", sa.String(length=64), nullable=False, server_default=sa.text("'created'")),
+        sa.Column(
+            "request_payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("result_payload", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index("ix_kaspi_goods_imports_company", "kaspi_goods_imports", ["company_id"])
+    op.create_index("ix_kaspi_goods_imports_import_code", "kaspi_goods_imports", ["import_code"])
+    op.create_index("ix_kaspi_goods_imports_created_by", "kaspi_goods_imports", ["created_by_user_id"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_kaspi_goods_imports_created_by", table_name="kaspi_goods_imports")
+    op.drop_index("ix_kaspi_goods_imports_import_code", table_name="kaspi_goods_imports")
+    op.drop_index("ix_kaspi_goods_imports_company", table_name="kaspi_goods_imports")
+    op.drop_table("kaspi_goods_imports")

--- a/tests/app/test_kaspi_goods_api.py
+++ b/tests/app/test_kaspi_goods_api.py
@@ -1,0 +1,80 @@
+import pytest
+
+from app.models.company import Company
+from app.models.marketplace import KaspiStoreToken
+from app.services.kaspi_goods_client import KaspiNotAuthenticated
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+
+class _FakeAsyncClient:
+    def __init__(self, *args, **kwargs):
+        self._responses = kwargs.pop("responses", None) or []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, *args, **kwargs):
+        return self._responses.pop(0) if self._responses else _FakeResponse(200)
+
+
+@pytest.mark.asyncio
+async def test_kaspi_goods_schema_401(async_client, async_db_session, monkeypatch, company_a_admin_headers):
+    company = await async_db_session.get(Company, 1001)
+    if not company:
+        company = Company(id=1001, name="Company 1001", kaspi_store_id="store-a")
+        async_db_session.add(company)
+    else:
+        company.kaspi_store_id = "store-a"
+    await async_db_session.commit()
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    async def _raise_unauth(self):
+        raise KaspiNotAuthenticated("Kaspi token is not authenticated")
+
+    from app.services.kaspi_goods_client import KaspiGoodsClient
+
+    monkeypatch.setattr(KaspiGoodsClient, "get_schema", _raise_unauth)
+
+    resp = await async_client.get("/api/v1/kaspi/goods/schema", headers=company_a_admin_headers)
+    assert resp.status_code == 401
+    assert resp.json().get("detail") == "NOT_AUTHENTICATED"
+
+
+@pytest.mark.asyncio
+async def test_kaspi_token_health_401(async_client, async_db_session, monkeypatch, company_a_admin_headers):
+    company = await async_db_session.get(Company, 1001)
+    if not company:
+        company = Company(id=1001, name="Company 1001", kaspi_store_id="store-a")
+        async_db_session.add(company)
+    else:
+        company.kaspi_store_id = "store-a"
+    await async_db_session.commit()
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    from app.api.v1 import kaspi as kaspi_router
+
+    fake_client = _FakeAsyncClient(responses=[_FakeResponse(401), _FakeResponse(401)])
+    monkeypatch.setattr(kaspi_router.httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+
+    resp = await async_client.get("/api/v1/kaspi/token/health", headers=company_a_admin_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is False
+    assert data["cause"] == "NOT_AUTHENTICATED"
+    assert data["orders_http"] == 401
+    assert data["goods_http"] == 401

--- a/tests/app/test_kaspi_token_selftest.py
+++ b/tests/app/test_kaspi_token_selftest.py
@@ -1,0 +1,92 @@
+import pytest
+
+from app.models.company import Company
+from app.models.marketplace import KaspiStoreToken
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        self.content = b""
+
+
+class _FakeAsyncClient:
+    def __init__(self, responses: list[_FakeResponse]):
+        self._responses = responses
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, *args, **kwargs):
+        return self._responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_kaspi_token_selftest_goods_hint(async_client, async_db_session, monkeypatch, company_a_admin_headers):
+    company = await async_db_session.get(Company, 1001)
+    if not company:
+        company = Company(id=1001, name="Company 1001", kaspi_store_id="store-a")
+        async_db_session.add(company)
+    else:
+        company.kaspi_store_id = "store-a"
+    await async_db_session.commit()
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    from app.api.v1 import kaspi as kaspi_router
+
+    fake_client = _FakeAsyncClient(
+        [
+            _FakeResponse(200),
+            _FakeResponse(401),
+            _FakeResponse(401),
+        ]
+    )
+    monkeypatch.setattr(kaspi_router.httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+
+    resp = await async_client.get("/api/v1/kaspi/token/selftest", headers=company_a_admin_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["orders_http"] == 200
+    assert data["goods_schema_http"] == 401
+    assert data["goods_categories_http"] == 401
+    assert data["goods_access"] == "missing_or_not_enabled"
+
+
+@pytest.mark.asyncio
+async def test_kaspi_token_selftest_orders_unauthorized(
+    async_client, async_db_session, monkeypatch, company_a_admin_headers
+):
+    company = await async_db_session.get(Company, 1001)
+    if not company:
+        company = Company(id=1001, name="Company 1001", kaspi_store_id="store-a")
+        async_db_session.add(company)
+    else:
+        company.kaspi_store_id = "store-a"
+    await async_db_session.commit()
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    from app.api.v1 import kaspi as kaspi_router
+
+    fake_client = _FakeAsyncClient(
+        [
+            _FakeResponse(401),
+            _FakeResponse(200),
+            _FakeResponse(200),
+        ]
+    )
+    monkeypatch.setattr(kaspi_router.httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+
+    resp = await async_client.get("/api/v1/kaspi/token/selftest", headers=company_a_admin_headers)
+    assert resp.status_code == 401
+    assert resp.json().get("detail") == "NOT_AUTHENTICATED"


### PR DESCRIPTION
Adds deterministic Kaspi tenant token self-test (Orders requires state+creationDate filters; Goods schema/categories). Prevents false 401 from wrong token/request shape. Includes PS script + API endpoint + tests.