### PR TITLE
feat(kaspi): catalog import CSV (merchantUid) + offers upsert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,7 @@ _hook_test.txt
 # local state snapshots (do not commit)
 /docs/STATE_SNAPSHOT_*.md
 
+
+# local dumps
+.local/
+

--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -26,14 +26,17 @@ app/api/v1/kaspi.py — Полный, боевой роутер интеграц
 - Расширяемость: аккуратные модели ввода/вывода; готово к будущим эндпоинтам.
 """
 
+import csv
 import inspect
+import io
 import json
 from datetime import datetime, timedelta
+from hashlib import sha256
 from typing import Any
 
 import httpx
 import sqlalchemy as sa
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, Response, UploadFile, status
 from pydantic import BaseModel, Field
 from sqlalchemy import bindparam, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -45,10 +48,12 @@ from app.core.security import get_current_user, resolve_tenant_company_id
 # Доменные зависимости/схемы:
 from app.integrations.kaspi_adapter import KaspiAdapter, KaspiAdapterError
 from app.models import Product
+from app.models.catalog_import import CatalogImportBatch, CatalogImportRow
 from app.models.company import Company
 from app.models.kaspi_catalog_product import KaspiCatalogProduct
 from app.models.kaspi_feed_export import KaspiFeedExport
 from app.models.kaspi_goods_import import KaspiGoodsImport
+from app.models.kaspi_offer import KaspiOffer
 from app.models.kaspi_order_sync_state import KaspiOrderSyncState
 from app.models.marketplace import KaspiStoreToken
 from app.models.user import User
@@ -119,6 +124,64 @@ def _product_to_goods_payload(product: Product) -> dict[str, Any]:
         "quantity": int(product.stock_quantity or 0),
         "isActive": bool(product.is_active),
     }
+
+
+def _norm_header(name: str) -> str:
+    return "".join(ch if ch.isalnum() else "_" for ch in (name or "").strip().lower()).strip("_")
+
+
+_HEADER_ALIASES = {
+    "sku": {"sku", "offer_id", "offersku", "merchant_sku"},
+    "master_sku": {"master_sku", "mastersku", "merchant_uid", "merchantuid", "parent_sku"},
+    "title": {"title", "name", "product_name"},
+    "price": {"price", "price_kzt", "price_kz"},
+    "old_price": {"old_price", "oldprice", "price_old"},
+    "stock_count": {"stock", "stock_count", "qty", "quantity"},
+    "pre_order": {"pre_order", "preorder", "pre_order_flag"},
+    "stock_specified": {"stock_specified", "stockspecified", "stock_flag"},
+    "updated_at": {"updated_at", "updated", "last_update"},
+}
+
+
+def _normalize_headers(fieldnames: list[str]) -> dict[str, str]:
+    normalized = {_norm_header(name): name for name in fieldnames}
+    mapping: dict[str, str] = {}
+    for canonical, aliases in _HEADER_ALIASES.items():
+        for alias in aliases:
+            alias_norm = _norm_header(alias)
+            if alias_norm in normalized:
+                mapping[canonical] = alias_norm
+                break
+    return mapping
+
+
+def _get_mapped_value(normalized_raw: dict[str, Any], header_map: dict[str, str], key: str) -> str | None:
+    lookup = header_map.get(key)
+    return normalized_raw.get(lookup) if lookup else None
+
+
+def _parse_int(value: str | None) -> int | None:
+    if value is None:
+        return None
+    v = str(value).strip().replace(" ", "")
+    if not v:
+        return None
+    v = v.replace(",", ".")
+    try:
+        return int(float(v))
+    except ValueError:
+        return None
+
+
+def _parse_bool(value: str | None) -> bool | None:
+    if value is None:
+        return None
+    v = str(value).strip().lower()
+    if v in {"1", "true", "yes", "y", "on"}:
+        return True
+    if v in {"0", "false", "no", "n", "off"}:
+        return False
+    return None
 
 
 # ------------------------------- Локальные схемы (deprecated - use app/schemas/kaspi.py) ------
@@ -929,6 +992,15 @@ class KaspiTokenSelftestOut(BaseModel):
     orders_error: str | None = None
 
 
+class KaspiCatalogImportOut(BaseModel):
+    batch_id: str
+    status: str
+    rows_total: int
+    rows_ok: int
+    rows_failed: int
+    errors: list[dict[str, Any]]
+
+
 @router.post(
     "/products/sync",
     summary="Синхронизировать каталог Kaspi в локальную БД",
@@ -1274,6 +1346,185 @@ async def kaspi_token_selftest(
         goods_categories_http=goods_categories_resp.status_code,
         goods_access=goods_access,
         orders_error=orders_error,
+    )
+
+
+@router.post(
+    "/catalog/import",
+    summary="Kaspi catalog import (CSV)",
+    response_model=KaspiCatalogImportOut,
+)
+async def kaspi_catalog_import(
+    file: UploadFile = File(...),
+    merchant_uid: str | None = Query(None, alias="merchantUid"),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    if not (current_user.is_superuser or current_user.role == "admin"):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
+
+    if not merchant_uid or not merchant_uid.strip():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="missing_merchant_uid")
+
+    merchant_uid = merchant_uid.strip()
+
+    company_id = _resolve_company_id(current_user)
+
+    content = await file.read()
+    if not content:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="empty_file")
+
+    content_hash = sha256(content).hexdigest()
+    filename = file.filename or "catalog.csv"
+
+    try:
+        text = content.decode("utf-8-sig", errors="replace")
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid_encoding")
+
+    reader = csv.DictReader(io.StringIO(text))
+    if not reader.fieldnames:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="missing_headers")
+
+    header_map = _normalize_headers(reader.fieldnames)
+
+    batch = CatalogImportBatch(
+        company_id=company_id,
+        source="kaspi",
+        filename=filename,
+        content_hash=content_hash,
+        status="RUNNING",
+        merchant_uid=merchant_uid,
+        started_at=datetime.utcnow(),
+    )
+    session.add(batch)
+    await session.commit()
+    await session.refresh(batch)
+
+    rows_total = 0
+    rows_ok = 0
+    rows_failed = 0
+    row_errors: list[dict[str, Any]] = []
+    row_records: list[dict[str, Any]] = []
+    offer_records: list[dict[str, Any]] = []
+
+    for idx, raw in enumerate(reader, start=1):
+        rows_total += 1
+        normalized_raw = {_norm_header(k): (v.strip() if isinstance(v, str) else v) for k, v in raw.items()}
+
+        sku = _get_mapped_value(normalized_raw, header_map, "sku")
+        master_sku = _get_mapped_value(normalized_raw, header_map, "master_sku")
+        title = _get_mapped_value(normalized_raw, header_map, "title")
+        price = _parse_int(_get_mapped_value(normalized_raw, header_map, "price"))
+        old_price = _parse_int(_get_mapped_value(normalized_raw, header_map, "old_price"))
+        stock_count = _parse_int(_get_mapped_value(normalized_raw, header_map, "stock_count"))
+        pre_order = _parse_bool(_get_mapped_value(normalized_raw, header_map, "pre_order"))
+        stock_specified = _parse_bool(_get_mapped_value(normalized_raw, header_map, "stock_specified"))
+        updated_at_raw = _get_mapped_value(normalized_raw, header_map, "updated_at")
+        updated_at = None
+        if updated_at_raw:
+            try:
+                updated_at = datetime.fromisoformat(updated_at_raw.replace("Z", ""))
+            except Exception:
+                updated_at = None
+
+        error = None
+        if not sku:
+            error = "missing_sku"
+
+        row_records.append(
+            {
+                "batch_id": batch.id,
+                "company_id": company_id,
+                "row_num": idx,
+                "raw": normalized_raw,
+                "sku": sku,
+                "master_sku": master_sku,
+                "title": title,
+                "price": price,
+                "old_price": old_price,
+                "stock_count": stock_count,
+                "pre_order": pre_order,
+                "stock_specified": stock_specified,
+                "updated_at": updated_at,
+                "error": error,
+            }
+        )
+
+        if error:
+            rows_failed += 1
+            if len(row_errors) < 5:
+                row_errors.append({"row": idx, "error": error})
+            continue
+
+        rows_ok += 1
+        offer_records.append(
+            {
+                "company_id": company_id,
+                "merchant_uid": merchant_uid,
+                "sku": sku,
+                "master_sku": master_sku,
+                "title": title,
+                "price": price,
+                "old_price": old_price,
+                "stock_count": stock_count,
+                "pre_order": pre_order,
+                "stock_specified": stock_specified,
+                "raw": normalized_raw,
+                "updated_at": datetime.utcnow(),
+            }
+        )
+
+    try:
+        if row_records:
+            await session.execute(sa.insert(CatalogImportRow), row_records)
+
+        if offer_records:
+            for chunk_start in range(0, len(offer_records), 500):
+                chunk = offer_records[chunk_start : chunk_start + 500]
+                stmt = sa.dialects.postgresql.insert(KaspiOffer).values(chunk)
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["company_id", "merchant_uid", "sku"],
+                    set_={
+                        "master_sku": stmt.excluded.master_sku,
+                        "title": stmt.excluded.title,
+                        "price": stmt.excluded.price,
+                        "old_price": stmt.excluded.old_price,
+                        "stock_count": stmt.excluded.stock_count,
+                        "pre_order": stmt.excluded.pre_order,
+                        "stock_specified": stmt.excluded.stock_specified,
+                        "raw": stmt.excluded.raw,
+                        "updated_at": datetime.utcnow(),
+                    },
+                )
+                await session.execute(stmt)
+
+        batch.rows_total = rows_total
+        batch.rows_ok = rows_ok
+        batch.rows_failed = rows_failed
+        batch.status = "DONE"
+        batch.finished_at = datetime.utcnow()
+        if rows_failed:
+            batch.error_summary = "; ".join({e["error"] for e in row_errors})
+
+        await session.commit()
+    except Exception as exc:
+        await session.rollback()
+        batch = await session.get(CatalogImportBatch, batch.id)
+        if batch:
+            batch.status = "FAILED"
+            batch.finished_at = datetime.utcnow()
+            batch.error_summary = str(exc)[:500]
+            await session.commit()
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="catalog_import_failed")
+
+    return KaspiCatalogImportOut(
+        batch_id=str(batch.id),
+        status=batch.status,
+        rows_total=rows_total,
+        rows_ok=rows_ok,
+        rows_failed=rows_failed,
+        errors=row_errors,
     )
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -189,6 +189,9 @@ _LAZY_MODELS: dict[str, tuple[str, str]] = {
     "KaspiCatalogProduct": ("app.models.kaspi_catalog_product", "KaspiCatalogProduct"),
     "KaspiFeedExport": ("app.models.kaspi_feed_export", "KaspiFeedExport"),
     "KaspiGoodsImport": ("app.models.kaspi_goods_import", "KaspiGoodsImport"),
+    "CatalogImportBatch": ("app.models.catalog_import", "CatalogImportBatch"),
+    "CatalogImportRow": ("app.models.catalog_import", "CatalogImportRow"),
+    "KaspiOffer": ("app.models.kaspi_offer", "KaspiOffer"),
 }
 
 # Поддерживаемые модули доменов для «массового» импорта (ручной whitelisting).
@@ -209,6 +212,8 @@ _DOMAIN_MODULES: tuple[str, ...] = (
     "app.models.kaspi_catalog_product",
     "app.models.kaspi_feed_export",
     "app.models.kaspi_goods_import",
+    "app.models.catalog_import",
+    "app.models.kaspi_offer",
     "app.models.system_integrations",
     "app.models.integration_provider",
     "app.models.integration_provider_config",

--- a/app/models/catalog_import.py
+++ b/app/models/catalog_import.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from app.models.base import Base
+
+
+class CatalogImportBatch(Base):
+    __tablename__ = "catalog_import_batches"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    company_id = Column(ForeignKey("companies.id", ondelete="CASCADE"), nullable=False, index=True)
+    source = Column(String(32), nullable=False, server_default=text("'kaspi'"))
+    filename = Column(String(255), nullable=False)
+    content_hash = Column(String(64), nullable=False, index=True)
+    status = Column(String(16), nullable=False, server_default=text("'PENDING'"))
+    merchant_uid = Column(String(128), nullable=True)
+
+    rows_total = Column(Integer, nullable=False, server_default=text("0"))
+    rows_ok = Column(Integer, nullable=False, server_default=text("0"))
+    rows_failed = Column(Integer, nullable=False, server_default=text("0"))
+
+    started_at = Column(DateTime, nullable=True)
+    finished_at = Column(DateTime, nullable=True)
+    error_summary = Column(Text, nullable=True)
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+
+class CatalogImportRow(Base):
+    __tablename__ = "catalog_import_rows"
+
+    id = Column(Integer, primary_key=True)
+    batch_id = Column(ForeignKey("catalog_import_batches.id", ondelete="CASCADE"), nullable=False, index=True)
+    company_id = Column(ForeignKey("companies.id", ondelete="CASCADE"), nullable=False, index=True)
+    row_num = Column(Integer, nullable=False)
+    raw = Column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+
+    sku = Column(String(128), nullable=True)
+    master_sku = Column(String(128), nullable=True)
+    title = Column(String(255), nullable=True)
+    price = Column(Integer, nullable=True)
+    old_price = Column(Integer, nullable=True)
+    stock_count = Column(Integer, nullable=True)
+    pre_order = Column(Boolean, nullable=True)
+    stock_specified = Column(Boolean, nullable=True)
+    updated_at = Column(DateTime, nullable=True)
+
+    error = Column(Text, nullable=True)

--- a/app/models/kaspi_offer.py
+++ b/app/models/kaspi_offer.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, Numeric, String, UniqueConstraint, text
+from sqlalchemy.dialects.postgresql import JSONB
+
+from app.models.base import Base
+
+
+class KaspiOffer(Base):
+    __tablename__ = "kaspi_offers"
+
+    id = Column(Integer, primary_key=True)
+    company_id = Column(ForeignKey("companies.id", ondelete="CASCADE"), nullable=False, index=True)
+    merchant_uid = Column(String(128), nullable=False)
+    sku = Column(String(128), nullable=False)
+    master_sku = Column(String(128), nullable=True)
+    title = Column(String(255), nullable=True)
+    price = Column(Numeric(18, 2), nullable=True)
+    old_price = Column(Numeric(18, 2), nullable=True)
+    stock_count = Column(Integer, nullable=True)
+    pre_order = Column(Boolean, nullable=True)
+    stock_specified = Column(Boolean, nullable=True)
+    raw = Column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("company_id", "merchant_uid", "sku", name="uq_kaspi_offers_company_merchant_sku"),
+    )

--- a/migrations/versions/20260117_kaspi_catalog_import_mvp.py
+++ b/migrations/versions/20260117_kaspi_catalog_import_mvp.py
@@ -1,0 +1,133 @@
+"""feat(kaspi): add catalog import batches/rows and kaspi offers
+
+Revision ID: 20260117_kaspi_catalog_import
+Revises: 20260117_kaspi_goods_imports
+Create Date: 2026-01-17 12:00:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260117_kaspi_catalog_import"
+down_revision: Union[str, Sequence[str], None] = "20260117_kaspi_goods_imports"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "catalog_import_batches",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column(
+            "company_id",
+            sa.Integer(),
+            sa.ForeignKey("companies.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("source", sa.String(length=32), nullable=False, server_default=sa.text("'kaspi'")),
+        sa.Column("filename", sa.String(length=255), nullable=False),
+        sa.Column("content_hash", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default=sa.text("'PENDING'")),
+        sa.Column("merchant_uid", sa.String(length=128), nullable=True),
+        sa.Column("rows_total", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("rows_ok", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("rows_failed", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+        sa.Column("error_summary", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index("ix_catalog_import_batches_company", "catalog_import_batches", ["company_id"])
+    op.create_index("ix_catalog_import_batches_hash", "catalog_import_batches", ["content_hash"])
+
+    op.create_table(
+        "catalog_import_rows",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column(
+            "batch_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("catalog_import_batches.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "company_id",
+            sa.Integer(),
+            sa.ForeignKey("companies.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("row_num", sa.Integer(), nullable=False),
+        sa.Column(
+            "raw",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("sku", sa.String(length=128), nullable=True),
+        sa.Column("master_sku", sa.String(length=128), nullable=True),
+        sa.Column("title", sa.String(length=255), nullable=True),
+        sa.Column("price", sa.Integer(), nullable=True),
+        sa.Column("old_price", sa.Integer(), nullable=True),
+        sa.Column("stock_count", sa.Integer(), nullable=True),
+        sa.Column("pre_order", sa.Boolean(), nullable=True),
+        sa.Column("stock_specified", sa.Boolean(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+    )
+    op.create_index("ix_catalog_import_rows_batch", "catalog_import_rows", ["batch_id"])
+    op.create_index("ix_catalog_import_rows_company", "catalog_import_rows", ["company_id"])
+
+    op.create_table(
+        "kaspi_offers",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column(
+            "company_id",
+            sa.Integer(),
+            sa.ForeignKey("companies.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("merchant_uid", sa.String(length=128), nullable=False),
+        sa.Column("sku", sa.String(length=128), nullable=False),
+        sa.Column("master_sku", sa.String(length=128), nullable=True),
+        sa.Column("title", sa.String(length=255), nullable=True),
+        sa.Column("price", sa.Numeric(18, 2), nullable=True),
+        sa.Column("old_price", sa.Numeric(18, 2), nullable=True),
+        sa.Column("stock_count", sa.Integer(), nullable=True),
+        sa.Column("pre_order", sa.Boolean(), nullable=True),
+        sa.Column("stock_specified", sa.Boolean(), nullable=True),
+        sa.Column(
+            "raw",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("company_id", "merchant_uid", "sku", name="uq_kaspi_offers_company_merchant_sku"),
+    )
+    op.create_index("ix_kaspi_offers_company", "kaspi_offers", ["company_id"])
+    op.create_index("ix_kaspi_offers_company_sku", "kaspi_offers", ["company_id", "sku"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_kaspi_offers_company_sku", table_name="kaspi_offers")
+    op.drop_index("ix_kaspi_offers_company", table_name="kaspi_offers")
+    op.drop_table("kaspi_offers")
+
+    op.drop_index("ix_catalog_import_rows_company", table_name="catalog_import_rows")
+    op.drop_index("ix_catalog_import_rows_batch", table_name="catalog_import_rows")
+    op.drop_table("catalog_import_rows")
+
+    op.drop_index("ix_catalog_import_batches_hash", table_name="catalog_import_batches")
+    op.drop_index("ix_catalog_import_batches_company", table_name="catalog_import_batches")
+    op.drop_table("catalog_import_batches")

--- a/tests/app/test_kaspi_catalog_import.py
+++ b/tests/app/test_kaspi_catalog_import.py
@@ -1,0 +1,130 @@
+import pytest
+from sqlalchemy import select
+
+from app.models.catalog_import import CatalogImportRow
+from app.models.kaspi_offer import KaspiOffer
+
+
+def _csv_bytes(text: str) -> bytes:
+    return text.encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_kaspi_catalog_import_rbac(async_client, company_a_manager_headers):
+    csv_data = "SKU,Title,Price\nS1,Item 1,1000\n"
+    resp = await async_client.post(
+        "/api/v1/kaspi/catalog/import",
+        headers=company_a_manager_headers,
+        params={"merchantUid": "M1"},
+        files={"file": ("catalog.csv", _csv_bytes(csv_data), "text/csv")},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_kaspi_catalog_import_missing_merchant_uid(async_client, company_a_admin_headers):
+    csv_data = "SKU,Title,Price\nS1,Item 1,1000\n"
+    resp = await async_client.post(
+        "/api/v1/kaspi/catalog/import",
+        headers=company_a_admin_headers,
+        files={"file": ("catalog.csv", _csv_bytes(csv_data), "text/csv")},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "missing_merchant_uid"
+
+
+@pytest.mark.asyncio
+async def test_kaspi_catalog_import_header_aliases(async_client, async_db_session, company_a_admin_headers):
+    csv_data = "Master SKU,SKU,Title,Price,Stock,Pre Order\nMS1,S1,Item 1,1000,5,yes\n"
+    resp = await async_client.post(
+        "/api/v1/kaspi/catalog/import",
+        headers=company_a_admin_headers,
+        params={"merchantUid": "M1"},
+        files={"file": ("catalog.csv", _csv_bytes(csv_data), "text/csv")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["rows_ok"] == 1
+    assert data["rows_failed"] == 0
+
+    await async_db_session.rollback()
+    row = (await async_db_session.execute(select(CatalogImportRow))).scalars().first()
+    assert row is not None
+    assert row.sku == "S1"
+    assert row.master_sku == "MS1"
+
+    offer = (await async_db_session.execute(select(KaspiOffer))).scalars().first()
+    assert offer is not None
+    assert offer.sku == "S1"
+    assert offer.merchant_uid == "M1"
+    assert float(offer.price or 0) == 1000.0
+    assert offer.stock_count == 5
+
+
+@pytest.mark.asyncio
+async def test_kaspi_catalog_import_idempotent(async_client, async_db_session, company_a_admin_headers):
+    csv_first = "SKU,Title,Price,Stock\nS1,Item 1,1000,5\n"
+    resp1 = await async_client.post(
+        "/api/v1/kaspi/catalog/import",
+        headers=company_a_admin_headers,
+        params={"merchantUid": "M1"},
+        files={"file": ("catalog.csv", _csv_bytes(csv_first), "text/csv")},
+    )
+    assert resp1.status_code == 200
+
+    csv_second = "SKU,Title,Price,Stock\nS1,Item 1,1200,7\n"
+    resp2 = await async_client.post(
+        "/api/v1/kaspi/catalog/import",
+        headers=company_a_admin_headers,
+        params={"merchantUid": "M1"},
+        files={"file": ("catalog.csv", _csv_bytes(csv_second), "text/csv")},
+    )
+    assert resp2.status_code == 200
+
+    await async_db_session.rollback()
+    offers = (
+        await async_db_session.execute(
+            select(KaspiOffer).where(KaspiOffer.sku == "S1", KaspiOffer.merchant_uid == "M1")
+        )
+    ).scalars().all()
+    assert len(offers) == 1
+    offer = offers[0]
+    assert float(offer.price or 0) == 1200.0
+    assert offer.stock_count == 7
+
+
+@pytest.mark.asyncio
+async def test_kaspi_catalog_import_missing_sku(async_client, company_a_admin_headers):
+    csv_data = "SKU,Title,Price\n,NoSku,1000\n"
+    resp = await async_client.post(
+        "/api/v1/kaspi/catalog/import",
+        headers=company_a_admin_headers,
+        params={"merchantUid": "M1"},
+        files={"file": ("catalog.csv", _csv_bytes(csv_data), "text/csv")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["rows_failed"] == 1
+    assert data["errors"][0]["error"] == "missing_sku"
+
+
+@pytest.mark.asyncio
+async def test_kaspi_catalog_import_numeric_parsing(async_client, async_db_session, company_a_admin_headers):
+    csv_data = 'SKU,Title,Price,Stock\nS2,Item 2,"12,7",7\n'
+    resp = await async_client.post(
+        "/api/v1/kaspi/catalog/import",
+        headers=company_a_admin_headers,
+        params={"merchantUid": "M1"},
+        files={"file": ("catalog.csv", _csv_bytes(csv_data), "text/csv")},
+    )
+    assert resp.status_code == 200
+
+    await async_db_session.rollback()
+    offer = (
+        await async_db_session.execute(
+            select(KaspiOffer).where(KaspiOffer.sku == "S2", KaspiOffer.merchant_uid == "M1")
+        )
+    ).scalars().first()
+    assert offer is not None
+    assert float(offer.price or 0) == 12.0
+    assert offer.stock_count == 7


### PR DESCRIPTION
Adds catalog import batches/rows and kaspi_offers. Import requires merchantUid and upserts offers per company+merchantUid+sku. Tests green (ruff + pytest).