### PR TITLE
fix(core): migrate startup hooks to FastAPI lifespan

### DIFF
--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -23,6 +23,8 @@ SmartSell3 Core Package Initializer (enterprise-grade)
 import os
 import time
 import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 
 from fastapi import FastAPI, Request, Response
@@ -437,6 +439,41 @@ def _register_health_endpoints(app: FastAPI) -> None:
 
 
 # ------------------------------------------------------------------------------
+# Lifespan
+# ------------------------------------------------------------------------------
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # type: ignore[override]
+    log = get_logger("startup")
+
+    # tests/CI short-circuit
+    if should_disable_startup_hooks():
+        log.info("Core startup hook skipped (tests/CI)")
+    else:
+        role = getattr(settings, "PROCESS_ROLE", os.getenv("PROCESS_ROLE", "web")) or "web"
+        if role not in ("web", "migrator"):
+            log.info("Core startup hook skipped for role", extra={"role": role})
+        else:
+            # предупреждения по критичным ENV
+            issues = _critical_env_warnings()
+            if issues:
+                log.warning("Critical ENV issues", issues=issues)
+            # alembic
+            _run_alembic_migrations_if_needed()
+            # готовность ядра для /readyz прометheus-метрики
+            try:
+                if _HAS_PROM and _READY_GAUGE is not None:
+                    # после старта ещё не проверяли DB — консервативно 0; поднимется при первом /readyz
+                    _READY_GAUGE.set(0)
+            except Exception:
+                pass
+
+    try:
+        yield
+    finally:
+        pass
+
+
+# ------------------------------------------------------------------------------
 # Unified initializer
 # ------------------------------------------------------------------------------
 def init_core(app: FastAPI) -> None:
@@ -475,34 +512,8 @@ def init_core(app: FastAPI) -> None:
     # Health endpoints
     _register_health_endpoints(app)
 
-    # Startup hook: Alembic (best-effort)
-    @app.on_event("startup")
-    async def _on_startup() -> None:
-        log = get_logger("startup")
-
-        # tests/CI short-circuit
-        if should_disable_startup_hooks():
-            log.info("Core startup hook skipped (tests/CI)")
-            return
-
-        role = getattr(settings, "PROCESS_ROLE", os.getenv("PROCESS_ROLE", "web")) or "web"
-        if role not in ("web", "migrator"):
-            log.info("Core startup hook skipped for role", extra={"role": role})
-            return
-
-        # предупреждения по критичным ENV
-        issues = _critical_env_warnings()
-        if issues:
-            log.warning("Critical ENV issues", issues=issues)
-        # alembic
-        _run_alembic_migrations_if_needed()
-        # готовность ядра для /readyz прометheus-метрики
-        try:
-            if _HAS_PROM and _READY_GAUGE is not None:
-                # после старта ещё не проверяли DB — консервативно 0; поднимется при первом /readyz
-                _READY_GAUGE.set(0)
-        except Exception:
-            pass
+    # Lifespan hook: Alembic (best-effort)
+    app.router.lifespan_context = lifespan
 
     # Стартовый лог
     log = get_logger("startup")

--- a/tests/test_core_startup_hook_guards.py
+++ b/tests/test_core_startup_hook_guards.py
@@ -20,7 +20,8 @@ async def test_startup_hooks_disabled(monkeypatch):
     app = FastAPI()
     init_core(app)
 
-    await app.router.startup()  # Should not raise
+    async with app.router.lifespan_context(app):
+        pass
 
 
 @pytest.mark.asyncio
@@ -37,7 +38,8 @@ async def test_startup_skipped_for_non_web_role(monkeypatch):
     app = FastAPI()
     init_core(app)
 
-    await app.router.startup()  # Should not raise
+    async with app.router.lifespan_context(app):
+        pass
 
 
 @pytest.mark.asyncio
@@ -59,7 +61,8 @@ async def test_startup_web_role_respects_migration_flag(monkeypatch):
     app = FastAPI()
     init_core(app)
 
-    await app.router.startup()
+    async with app.router.lifespan_context(app):
+        pass
 
     # Since RUN_MIGRATIONS_ON_START is unset/false, migration callable should not increment
     assert calls["count"] == 0


### PR DESCRIPTION
Replaces deprecated @app.on_event('startup') with lifespan context (app.router.lifespan_context) and updates startup hook guard tests to use lifespan manager. Local ruff OK; tests: startup_hook_guards/lifespan (3 passed).