### PR TITLE
fix(kaspi): store merchant_uid in public feed tokens

### DIFF
--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -41,7 +41,7 @@ from xml.sax.saxutils import escape, quoteattr
 import httpx
 import sqlalchemy as sa
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, Response, UploadFile, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import bindparam, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -2442,6 +2442,9 @@ class KaspiFeedExportOut(BaseModel):
 
 
 class KaspiFeedPublicTokenIn(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    merchant_uid: str = Field(..., min_length=1, alias="merchantUid")
     comment: str | None = None
 
 
@@ -2539,7 +2542,9 @@ async def kaspi_feed_export_create(
             .order_by(KaspiOffer.updated_at.desc())
         )
         offers = result.scalars().all()
-        xml_body = _build_kaspi_offers_xml(offers)
+        company = await session.get(Company, company_id)
+        company_name = (company.name if company else None) or f"Company {company_id}"
+        xml_body = _build_kaspi_offers_xml(offers, company=company_name, merchant_id=merchant_uid)
         checksum = sha256(xml_body.encode("utf-8")).hexdigest()
         duration_ms = int((time.perf_counter() - started_perf) * 1000)
 
@@ -2674,13 +2679,16 @@ async def kaspi_feed_export_download(
 )
 async def kaspi_feed_public_token_create(
     payload: KaspiFeedPublicTokenIn,
-    merchant_uid: str | None = Query(None, alias="merchantUid"),
     current_user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_db),
 ):
     _require_admin(current_user)
     company_id = _resolve_company_id(current_user)
     env_is_dev = settings.is_development
+
+    merchant_uid = (payload.merchant_uid or "").strip()
+    if not merchant_uid:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="missing_merchant_uid")
 
     token_value = None
     token_hash = None
@@ -2704,7 +2712,7 @@ async def kaspi_feed_public_token_create(
 
     token_row = KaspiFeedPublicToken(
         company_id=company_id,
-        merchant_uid=merchant_uid.strip() if merchant_uid else None,
+        merchant_uid=merchant_uid,
         token_hash=token_hash,
         comment=payload.comment,
     )

--- a/tests/app/test_kaspi_feed_public.py
+++ b/tests/app/test_kaspi_feed_public.py
@@ -28,19 +28,18 @@ async def _create_offer(async_db_session, company_id: int, merchant_uid: str, sk
 async def test_public_feed_ok(async_client, async_db_session, company_a_admin_headers, monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "development")
     await _create_company(async_db_session, 1001)
-    await _create_offer(async_db_session, 1001, "M1", "S1")
+    await _create_offer(async_db_session, 1001, "17319385", "S1")
 
     token_resp = await async_client.post(
         "/api/v1/kaspi/feed/public-tokens",
         headers=company_a_admin_headers,
-        params={"merchantUid": "M1"},
-        json={"comment": "test"},
+        json={"merchant_uid": "17319385", "comment": "test"},
     )
     token = token_resp.json()["token"]
 
     resp = await async_client.get(
         "/api/v1/kaspi/feed/public/offers.xml",
-        params={"token": token},
+        params={"token": token, "merchantUid": "17319385"},
     )
     assert resp.status_code == 200
     assert resp.headers.get("content-type", "").startswith("application/xml")
@@ -60,8 +59,7 @@ async def test_public_feed_token_returns_in_default_dev_env(
     token_resp = await async_client.post(
         "/api/v1/kaspi/feed/public-tokens",
         headers=company_a_admin_headers,
-        params={"merchantUid": "M1"},
-        json={"comment": "test"},
+        json={"merchant_uid": "17319385", "comment": "test"},
     )
     assert token_resp.status_code == 200
     assert token_resp.json().get("token")
@@ -75,20 +73,19 @@ async def test_public_feed_not_found(async_client, async_db_session, company_a_a
     token_resp = await async_client.post(
         "/api/v1/kaspi/feed/public-tokens",
         headers=company_a_admin_headers,
-        params={"merchantUid": "M1"},
-        json={"comment": "test"},
+        json={"merchant_uid": "17319385", "comment": "test"},
     )
     token = token_resp.json()["token"]
 
     missing_token = await async_client.get(
         "/api/v1/kaspi/feed/public/offers.xml",
-        params={"merchantUid": "M1"},
+        params={"merchantUid": "17319385"},
     )
     assert missing_token.status_code == 404
 
     invalid = await async_client.get(
         "/api/v1/kaspi/feed/public/offers.xml",
-        params={"merchantUid": "M1", "token": "invalid"},
+        params={"merchantUid": "17319385", "token": "invalid"},
     )
     assert invalid.status_code == 404
 
@@ -103,13 +100,12 @@ async def test_public_feed_not_found(async_client, async_db_session, company_a_a
 async def test_public_feed_revoked_token(async_client, async_db_session, company_a_admin_headers, monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "development")
     await _create_company(async_db_session, 1001)
-    await _create_offer(async_db_session, 1001, "M1", "S1")
+    await _create_offer(async_db_session, 1001, "17319385", "S1")
 
     token_resp = await async_client.post(
         "/api/v1/kaspi/feed/public-tokens",
         headers=company_a_admin_headers,
-        params={"merchantUid": "M1"},
-        json={"comment": "test"},
+        json={"merchant_uid": "17319385", "comment": "test"},
     )
     token_id = token_resp.json()["id"]
     token = token_resp.json()["token"]
@@ -131,13 +127,12 @@ async def test_public_feed_revoked_token(async_client, async_db_session, company
 async def test_public_feed_wrong_merchant_uid(async_client, async_db_session, company_a_admin_headers, monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "development")
     await _create_company(async_db_session, 1001)
-    await _create_offer(async_db_session, 1001, "M1", "S1")
+    await _create_offer(async_db_session, 1001, "17319385", "S1")
 
     token_resp = await async_client.post(
         "/api/v1/kaspi/feed/public-tokens",
         headers=company_a_admin_headers,
-        params={"merchantUid": "M1"},
-        json={"comment": "test"},
+        json={"merchant_uid": "17319385", "comment": "test"},
     )
     token = token_resp.json()["token"]
 
@@ -159,13 +154,12 @@ async def test_public_feed_tenant_isolation(
     monkeypatch.setenv("ENVIRONMENT", "development")
     await _create_company(async_db_session, 1001)
     await _create_company(async_db_session, 2001)
-    await _create_offer(async_db_session, 2001, "M1", "S1")
+    await _create_offer(async_db_session, 2001, "17319385", "S1")
 
     token_resp = await async_client.post(
         "/api/v1/kaspi/feed/public-tokens",
         headers=company_a_admin_headers,
-        params={"merchantUid": "M1"},
-        json={"comment": "test"},
+        json={"merchant_uid": "17319385", "comment": "test"},
     )
     token = token_resp.json()["token"]
 


### PR DESCRIPTION
Fixes root cause: tokens were created without merchant_uid, forcing manual DB updates. Adds required merchant_uid to request schema and updates tests.