### PR TITLE
feat(kaspi): official feed upload + import status MVP

### DIFF
--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -35,7 +35,9 @@ import secrets
 import time
 from datetime import datetime, timedelta
 from hashlib import sha256
+from pathlib import Path
 from typing import Any
+from uuid import uuid4
 from xml.etree import ElementTree as ET
 
 import httpx
@@ -308,6 +310,35 @@ def _truncate_raw(raw: Any, max_len: int = 2000) -> str | None:
     return f"{text_value[:max_len]}..."
 
 
+def _normalize_kaspi_response(payload: Any) -> dict[str, Any]:
+    if isinstance(payload, dict):
+        return payload
+    if isinstance(payload, list):
+        return {"data": payload}
+    if payload is None:
+        return {}
+    return {"raw": payload}
+
+
+def _extract_error_info(payload: Any) -> tuple[str | None, str | None]:
+    if not isinstance(payload, dict):
+        return None, None
+    code = payload.get("errorCode") or payload.get("error_code") or payload.get("code") or payload.get("error")
+    message = payload.get("errorMessage") or payload.get("error_message") or payload.get("message")
+    return (str(code) if code else None), (str(message) if message else None)
+
+
+def _serialize_raw_response(payload: Any) -> str | None:
+    if payload is None:
+        return None
+    if isinstance(payload, dict | list):
+        try:
+            return json.dumps(payload, ensure_ascii=False, default=str)
+        except Exception:
+            return str(payload)
+    return str(payload)
+
+
 _KASPI_NS = "kaspiShopping"
 ET.register_namespace("", _KASPI_NS)
 
@@ -415,6 +446,27 @@ def _goods_import_to_out(record: KaspiGoodsImport) -> KaspiGoodsImportRecordOut:
         updated_at=record.updated_at,
         last_checked_at=record.last_checked_at,
         revoked_at=record.revoked_at,
+    )
+
+
+def _feed_upload_to_out(record: KaspiGoodsImport) -> KaspiFeedUploadRecordOut:
+    return KaspiFeedUploadRecordOut(
+        id=str(record.id),
+        merchant_uid=record.merchant_uid or "",
+        import_code=record.import_code,
+        status=record.status,
+        source=record.source,
+        comment=record.comment,
+        request_json=record.request_json,
+        status_json=record.status_json,
+        result_json=record.result_json,
+        raw_response=record.raw_response,
+        error_code=record.error_code,
+        error_message=record.error_message,
+        last_error_at=record.last_error_at,
+        last_checked_at=record.last_checked_at,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
     )
 
 
@@ -1230,8 +1282,8 @@ class KaspiProductListOut(BaseModel):
 
 
 class KaspiGoodsImportIn(BaseModel):
-    product_ids: list[int] | None = None
     payload: list[dict[str, Any]] | None = None
+    product_ids: list[int] | None = None
     content_type: str | None = None
 
 
@@ -1272,6 +1324,33 @@ class KaspiGoodsImportRecordOut(BaseModel):
     updated_at: datetime
     last_checked_at: datetime | None = None
     revoked_at: datetime | None = None
+
+
+class KaspiFeedUploadIn(BaseModel):
+    merchant_uid: str = Field(..., min_length=3, max_length=128)
+    source: str = Field(..., description="public_token | export_id | local_file_path")
+    comment: str | None = Field(None, max_length=500)
+    export_id: str | None = None
+    local_file_path: str | None = None
+
+
+class KaspiFeedUploadRecordOut(BaseModel):
+    id: str
+    merchant_uid: str
+    import_code: str
+    status: str
+    source: str | None = None
+    comment: str | None = None
+    request_json: dict[str, Any] | list[dict[str, Any]]
+    status_json: dict[str, Any] | None = None
+    result_json: dict[str, Any] | None = None
+    raw_response: str | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+    last_error_at: datetime | None = None
+    last_checked_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
 
 
 class KaspiTokenHealthOut(BaseModel):
@@ -2042,6 +2121,11 @@ async def kaspi_catalog_import(
 
 
 # ============================= MC SESSION + SYNC =============================
+#
+# TODO(MVP-DEFERRED): Kaspi Merchant Cabinet (MC) cookie-based automation is
+# experimental and deferred. MVP uses official flows only: Orders API, XML
+# feed generation/public link, and goods import/export. MC automation would
+# require browser automation (e.g., Playwright) and is out of scope for now.
 
 
 @router.post(
@@ -2658,6 +2742,245 @@ async def kaspi_feed_exports_list(
     )
     exports = result.scalars().all()
     return [_feed_export_to_out(export) for export in exports]
+
+
+@router.post(
+    "/feed/uploads",
+    summary="Upload Kaspi offers feed",
+    response_model=KaspiFeedUploadRecordOut,
+)
+async def kaspi_feed_upload_create(
+    body: KaspiFeedUploadIn,
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    _require_admin(current_user)
+
+    merchant_uid = (body.merchant_uid or "").strip()
+    if not merchant_uid:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="missing_merchant_uid")
+
+    source = (body.source or "").strip()
+    allowed_sources = {"public_token", "export_id", "local_file_path"}
+    if source not in allowed_sources:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid_source")
+
+    if source == "export_id" and not body.export_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="export_id_required")
+    if source == "local_file_path" and not body.local_file_path:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="local_file_path_required")
+
+    company_id = _resolve_company_id(current_user)
+    store_name, _ = await _resolve_kaspi_token(session, company_id)
+
+    xml_body: str
+    if source == "export_id":
+        export = await session.get(KaspiFeedExport, body.export_id)
+        if not export or export.company_id != company_id:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="export_not_found")
+        if not export.payload_text:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="export_payload_missing")
+        xml_body = export.payload_text
+    elif source == "local_file_path":
+        file_path = Path(body.local_file_path)
+        if not file_path.is_file():
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="local_file_not_found")
+        xml_body = file_path.read_text(encoding="utf-8", errors="replace")
+    else:
+        offers = (
+            (
+                await session.execute(
+                    sa.select(KaspiOffer)
+                    .where(
+                        KaspiOffer.company_id == company_id,
+                        KaspiOffer.merchant_uid == merchant_uid,
+                    )
+                    .order_by(KaspiOffer.updated_at.desc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if not offers:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="offers_not_found")
+        company = await session.get(Company, company_id)
+        company_name = (company.name if company else None) or f"Company {company_id}"
+        xml_body = _build_kaspi_offers_xml(offers, company=company_name, merchant_id=merchant_uid)
+
+    tmp_dir = settings.tmp_dir()
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    tmp_path = tmp_dir / f"kaspi_feed_{company_id}_{uuid4().hex}.xml"
+
+    try:
+        tmp_path.write_text(xml_body, encoding="utf-8")
+        response = KaspiAdapter().feed_upload(store_name, str(tmp_path), comment=body.comment)
+    except KaspiAdapterError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error("Kaspi feed upload failed: company_id=%s error=%s", company_id, exc)
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_feed_upload_failed") from exc
+    finally:
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except Exception:
+            logger.warning("Kaspi feed upload temp cleanup failed: path=%s", tmp_path)
+
+    normalized = _normalize_kaspi_response(response)
+    import_code = _extract_import_code(normalized)
+    if not import_code:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_import_code_missing")
+
+    now = datetime.utcnow()
+    error_code, error_message = _extract_error_info(normalized)
+
+    record = KaspiGoodsImport(
+        company_id=company_id,
+        created_by_user_id=current_user.id,
+        merchant_uid=merchant_uid,
+        import_code=str(import_code),
+        status="PENDING",
+        source=source,
+        comment=(body.comment or None),
+        request_json={
+            "source": source,
+            "export_id": body.export_id,
+            "local_file_path": body.local_file_path,
+            "comment": body.comment,
+        },
+        status_json=normalized,
+        result_json=None,
+        error_code=error_code,
+        error_message=error_message,
+        last_error_at=now if error_code or error_message else None,
+        last_checked_at=now,
+        raw_response=_serialize_raw_response(response),
+    )
+    session.add(record)
+    await session.commit()
+    await session.refresh(record)
+
+    return _feed_upload_to_out(record)
+
+
+@router.get(
+    "/feed/uploads",
+    summary="List Kaspi feed uploads",
+    response_model=list[KaspiFeedUploadRecordOut],
+)
+async def kaspi_feed_uploads_list(
+    limit: int = 50,
+    offset: int = 0,
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    _require_admin(current_user)
+    company_id = _resolve_company_id(current_user)
+
+    limit = max(1, min(limit, 200))
+    offset = max(0, offset)
+
+    result = await session.execute(
+        sa.select(KaspiGoodsImport)
+        .where(
+            KaspiGoodsImport.company_id == company_id,
+            KaspiGoodsImport.source.in_(["public_token", "export_id", "local_file_path"]),
+        )
+        .order_by(KaspiGoodsImport.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    uploads = result.scalars().all()
+    return [_feed_upload_to_out(record) for record in uploads]
+
+
+@router.get(
+    "/feed/uploads/{upload_id}",
+    summary="Get Kaspi feed upload",
+    response_model=KaspiFeedUploadRecordOut,
+)
+async def kaspi_feed_upload_get(
+    upload_id: str,
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    _require_admin(current_user)
+    company_id = _resolve_company_id(current_user)
+
+    record = (
+        (
+            await session.execute(
+                sa.select(KaspiGoodsImport).where(
+                    KaspiGoodsImport.company_id == company_id,
+                    KaspiGoodsImport.id == upload_id,
+                    KaspiGoodsImport.source.in_(["public_token", "export_id", "local_file_path"]),
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if not record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="upload_not_found")
+    return _feed_upload_to_out(record)
+
+
+@router.post(
+    "/feed/uploads/{upload_id}/refresh-status",
+    summary="Refresh Kaspi feed upload status",
+    response_model=KaspiFeedUploadRecordOut,
+)
+async def kaspi_feed_upload_refresh(
+    upload_id: str,
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    _require_admin(current_user)
+    company_id = _resolve_company_id(current_user)
+
+    record = (
+        (
+            await session.execute(
+                sa.select(KaspiGoodsImport).where(
+                    KaspiGoodsImport.company_id == company_id,
+                    KaspiGoodsImport.id == upload_id,
+                    KaspiGoodsImport.source.in_(["public_token", "export_id", "local_file_path"]),
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if not record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="upload_not_found")
+
+    store_name, _ = await _resolve_kaspi_token(session, company_id)
+    now = datetime.utcnow()
+    try:
+        response = KaspiAdapter().feed_import_status(store_name, import_id=record.import_code)
+    except KaspiAdapterError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error("Kaspi feed status failed: company_id=%s error=%s", company_id, exc)
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_feed_status_failed") from exc
+
+    normalized = _normalize_kaspi_response(response)
+    status_value = normalized.get("status") or record.status
+    error_code, error_message = _extract_error_info(normalized)
+
+    record.status = str(status_value)
+    record.status_json = normalized
+    record.result_json = normalized
+    record.raw_response = _serialize_raw_response(response)
+    record.last_checked_at = now
+    if error_code or error_message:
+        record.error_code = error_code
+        record.error_message = error_message
+        record.last_error_at = now
+
+    await session.commit()
+    await session.refresh(record)
+    return _feed_upload_to_out(record)
 
 
 @router.get(

--- a/app/integrations/kaspi_adapter.py
+++ b/app/integrations/kaspi_adapter.py
@@ -85,6 +85,19 @@ class KaspiAdapter:
         )
         return self._run_json(cmd)
 
+    def feed_upload(self, store: str, xml_path: str, comment: Optional[str] = None) -> Any:
+        comment_part = f"-Comment {shlex.quote(comment)}" if comment else ""
+        cmd = (
+            f". '{self.script_path}'; "
+            f"ks:feedUpload -Store {shlex.quote(store)} -XmlPath {shlex.quote(xml_path)} {comment_part}"
+        )
+        return self._run_json(cmd)
+
+    def feed_import_status(self, store: str, import_id: Optional[str] = None) -> Any:
+        import_part = f"-ImportId {shlex.quote(import_id)}" if import_id else ""
+        cmd = f". '{self.script_path}'; ks:feedStatus -Store {shlex.quote(store)} {import_part}"
+        return self._run_json(cmd)
+
     def import_status(self, store: str, import_id: Optional[str] = None) -> Any:
         import_part = f"-ImportId {shlex.quote(import_id)}" if import_id else ""
         cmd = f". '{self.script_path}'; ks:import -Store {shlex.quote(store)} {import_part} -StatusOnly"

--- a/app/models/kaspi_goods_import.py
+++ b/app/models/kaspi_goods_import.py
@@ -17,13 +17,18 @@ class KaspiGoodsImport(Base):
     merchant_uid = Column(String(128), nullable=True, index=True)
     import_code = Column(String(128), nullable=False, index=True)
     status = Column(String(64), nullable=False, server_default=text("'created'"))
+    source = Column(String(32), nullable=True, index=True)
+    comment = Column(Text, nullable=True)
     request_json = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
     status_json = Column(JSONB, nullable=True)
     result_json = Column(JSONB, nullable=True)
     error_code = Column(String(64), nullable=True)
     error_message = Column(Text, nullable=True)
+    last_error_at = Column(DateTime, nullable=True)
     last_checked_at = Column(DateTime, nullable=True)
     revoked_at = Column(DateTime, nullable=True)
+
+    raw_response = Column(Text, nullable=True)
 
     request_payload = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
     result_payload = Column(JSONB, nullable=True)

--- a/migrations/versions/20260122_kaspi_goods_imports_feed_uploads.py
+++ b/migrations/versions/20260122_kaspi_goods_imports_feed_uploads.py
@@ -1,0 +1,37 @@
+"""feat(kaspi): feed upload fields for goods imports
+
+Revision ID: 20260122_kaspi_feed_uploads
+Revises: 20260121_kaspi_mc_sessions
+Create Date: 2026-01-22 10:00:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "20260122_kaspi_feed_uploads"
+down_revision: Union[str, Sequence[str], None] = "20260121_kaspi_mc_sessions"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("kaspi_goods_imports", sa.Column("source", sa.String(length=32), nullable=True))
+    op.add_column("kaspi_goods_imports", sa.Column("comment", sa.Text(), nullable=True))
+    op.add_column("kaspi_goods_imports", sa.Column("last_error_at", sa.DateTime(), nullable=True))
+    op.add_column("kaspi_goods_imports", sa.Column("raw_response", sa.Text(), nullable=True))
+
+    op.create_index("ix_kaspi_goods_imports_source", "kaspi_goods_imports", ["source"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_kaspi_goods_imports_source", table_name="kaspi_goods_imports")
+
+    op.drop_column("kaspi_goods_imports", "raw_response")
+    op.drop_column("kaspi_goods_imports", "last_error_at")
+    op.drop_column("kaspi_goods_imports", "comment")
+    op.drop_column("kaspi_goods_imports", "source")

--- a/tests/app/test_kaspi_feed_public.py
+++ b/tests/app/test_kaspi_feed_public.py
@@ -70,19 +70,18 @@ async def test_public_feed_ok(async_client, async_db_session, company_a_admin_he
 async def test_public_feed_schema_minimal(async_client, async_db_session, company_a_admin_headers, monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "development")
     await _create_company(async_db_session, 1001)
-    await _create_offer_with_city_prices(async_db_session, 1001, "M1", "S-CITY")
+    await _create_offer_with_city_prices(async_db_session, 1001, "17319385", "S-CITY")
 
     token_resp = await async_client.post(
         "/api/v1/kaspi/feed/public-tokens",
         headers=company_a_admin_headers,
-        params={"merchantUid": "M1"},
-        json={"comment": "test"},
+        json={"merchant_uid": "17319385", "comment": "test"},
     )
     token = token_resp.json()["token"]
 
     resp = await async_client.get(
         "/api/v1/kaspi/feed/public/offers.xml",
-        params={"token": token},
+        params={"token": token, "merchantUid": "17319385"},
     )
     assert resp.status_code == 200
 

--- a/tests/app/test_kaspi_feed_uploads.py
+++ b/tests/app/test_kaspi_feed_uploads.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.models.company import Company
+from app.models.kaspi_goods_import import KaspiGoodsImport
+from app.models.kaspi_offer import KaspiOffer
+from app.models.marketplace import KaspiStoreToken
+
+
+class _FakeKaspiAdapter:
+    def __init__(self):
+        self.last_upload_path: Path | None = None
+
+    def feed_upload(self, store: str, xml_path: str, comment: str | None = None):
+        self.last_upload_path = Path(xml_path)
+        assert store == "store-a"
+        assert self.last_upload_path.is_file()
+        content = self.last_upload_path.read_text(encoding="utf-8")
+        assert "kaspi_catalog" in content
+        return {"importCode": "IC-FEED-1", "status": "received"}
+
+    def feed_import_status(self, store: str, import_id: str | None = None):
+        assert store == "store-a"
+        return {"importCode": import_id, "status": "done"}
+
+
+async def _ensure_company(async_db_session, company_id: int, store_id: str) -> None:
+    company = await async_db_session.get(Company, company_id)
+    if not company:
+        company = Company(id=company_id, name=f"Company {company_id}")
+        async_db_session.add(company)
+    company.kaspi_store_id = store_id
+    await async_db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_kaspi_feed_upload_create_and_refresh(
+    async_client,
+    async_db_session,
+    company_a_admin_headers,
+    monkeypatch,
+):
+    await _ensure_company(async_db_session, 1001, "store-a")
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    offer = KaspiOffer(
+        company_id=1001,
+        merchant_uid="M123",
+        sku="SKU-1",
+        title="Item 1",
+        price=1000,
+    )
+    async_db_session.add(offer)
+    await async_db_session.commit()
+
+    fake_adapter = _FakeKaspiAdapter()
+    from app.api.v1 import kaspi as kaspi_module
+
+    monkeypatch.setattr(kaspi_module, "KaspiAdapter", lambda: fake_adapter)
+
+    resp = await async_client.post(
+        "/api/v1/kaspi/feed/uploads",
+        headers=company_a_admin_headers,
+        json={"merchant_uid": "M123", "source": "public_token", "comment": "test"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["import_code"] == "IC-FEED-1"
+    assert data["status"] == "PENDING"
+    assert data["source"] == "public_token"
+    assert data["merchant_uid"] == "M123"
+
+    upload_id = data["id"]
+
+    refresh_resp = await async_client.post(
+        f"/api/v1/kaspi/feed/uploads/{upload_id}/refresh-status",
+        headers=company_a_admin_headers,
+    )
+    assert refresh_resp.status_code == 200
+    refresh_data = refresh_resp.json()
+    assert refresh_data["status"] == "done"
+    assert refresh_data["status_json"]["status"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_kaspi_feed_upload_permission_denied(
+    async_client,
+    async_db_session,
+    company_a_manager_headers,
+):
+    await _ensure_company(async_db_session, 1001, "store-a")
+
+    resp = await async_client.post(
+        "/api/v1/kaspi/feed/uploads",
+        headers=company_a_manager_headers,
+        json={"merchant_uid": "M123", "source": "public_token"},
+    )
+    assert resp.status_code == 403
+
+    record = KaspiGoodsImport(
+        company_id=1001,
+        merchant_uid="M123",
+        import_code="IC-OLD",
+        status="PENDING",
+        source="public_token",
+        request_json={},
+    )
+    async_db_session.add(record)
+    await async_db_session.commit()
+    await async_db_session.refresh(record)
+
+    refresh_resp = await async_client.post(
+        f"/api/v1/kaspi/feed/uploads/{record.id}/refresh-status",
+        headers=company_a_manager_headers,
+    )
+    assert refresh_resp.status_code == 403


### PR DESCRIPTION
Adds /api/v1/kaspi/feed/uploads (create/list/detail/refresh-status), persists import_code/status/raw/last_error via goods-import storage, includes migration + targeted tests. No MC cookies/scraping. No Redis changes.