### PR TITLE
fix: ProviderRegistry cache without Redis; notify on provider config update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,3 +339,6 @@ tmp/
 *.jsonl
 kaspi_*_response*.json
 kaspi_*_response*.csv
+
+*.pstats
+

--- a/app/core/provider_registry.py
+++ b/app/core/provider_registry.py
@@ -21,7 +21,10 @@ _HAS_REDIS = False
 log = logging.getLogger(__name__)
 
 _CHANNEL = getattr(settings, "SYSTEM_CONFIG_CHANNEL", "smartsell.config_changed")
-_TTL = max(1, int(getattr(settings, "SYSTEM_INTEGRATIONS_CACHE_TTL", 30) or 30))
+
+
+def _cache_ttl() -> int:
+    return max(1, int(getattr(settings, "SYSTEM_INTEGRATIONS_CACHE_TTL", 30) or 30))
 
 
 def _redis_disabled() -> bool:
@@ -162,6 +165,8 @@ class ProviderRegistry:
 
     @classmethod
     async def publish_change(cls, domain: str, version: int | None = None) -> None:
+        if _redis_disabled():
+            return
         client = await cls._redis_client()
         if not client or not hasattr(client, "publish"):
             return
@@ -206,11 +211,11 @@ class ProviderRegistry:
     @classmethod
     async def get_active_provider(cls, db: Any, domain: str) -> Optional[CachedProvider]:
         domain_key = cls._normalize_domain(domain)
-        await cls._ensure_listener()
+        if not _redis_disabled():
+            await cls._ensure_listener()
         entry = cls._cache.get(domain_key)
-        if entry and (time.monotonic() - entry.cached_at) < _TTL:
+        if entry and (time.monotonic() - entry.cached_at) < _cache_ttl():
             return entry
-
         entry = await cls._load_active(db, domain_key)
         if entry:
             cls._cache[domain_key] = entry
@@ -227,6 +232,8 @@ class ProviderRegistry:
     async def notify_change(cls, domain: str, version: int | None = None) -> None:
         domain_key = cls._normalize_domain(domain)
         cls.invalidate(domain_key)
+        if _redis_disabled():
+            return
         await cls.publish_change(domain_key, version)
         await cls._ensure_listener()
 

--- a/app/services/provider_configs.py
+++ b/app/services/provider_configs.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.crypto import decrypt_json, encrypt_json
 from app.core.logging import get_logger
+from app.core.provider_registry import ProviderRegistry
 from app.models.integration_provider import IntegrationProviderEvent
 from app.models.integration_provider_config import IntegrationProviderConfig
 
@@ -160,6 +161,8 @@ class ProviderConfigService:
         await _commit(db)
         await _refresh(db, item)
         await _refresh(db, event)
+
+        await ProviderRegistry.notify_change(domain_key, None)
         return item
 
     @classmethod


### PR DESCRIPTION
Changes:
- ProviderRegistry: keep in-process cache+TTL even when Redis disabled; listener only when Redis enabled.
- ProviderConfigService: call ProviderRegistry.notify_change() on config update.
- Ignore *.pstats in .gitignore.

Local checks:
- ruff format/check OK