### PR TITLE
fix(lint): ruff 0.1.6 config (exclude migrations + T201 per-file ignores)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.ruff]
 target-version = "py311"
 line-length = 120
+force-exclude = true
 
 # Поддерживаем твою прежнюю схему селекторов — она обратно совместима
 select = [
@@ -110,6 +111,7 @@ ignore = [
 unfixable = ["B"]
 
 exclude = [
+  "migrations/**",
   "migrations/versions/_quarantine",
   "migrations/versions/_quarantine/**",
   "migrations/versions/_backup",
@@ -129,17 +131,16 @@ exclude = [
 "app/main.py" = ["B008"]
 "app/core/dependencies.py" = ["B008"]
 "app/core/security.py" = ["B008"]
+"**/_create_tables_direct.py" = ["T201"]
+"**/_dbcheck_asyncpg.py" = ["T201"]
+"**/_patch_conftest.py" = ["T201"]
+"**/bootstrap_schema.py" = ["T201"]
+"**/check_migration_order.py" = ["T201"]
+"**/fix_migration_order.py" = ["T201"]
+"**/reset_testdb.py" = ["T201"]
+"**/tools_create_smart_sell_test_db.py" = ["T201"]
+"**/tools_create_test_db.py" = ["T201"]
 
-# ---------------- Black ----------------
-"_create_tables_direct.py" = ["T201"]
-"_dbcheck_asyncpg.py" = ["T201"]
-"_patch_conftest.py" = ["T201"]
-"bootstrap_schema.py" = ["T201"]
-"check_migration_order.py" = ["T201"]
-"fix_migration_order.py" = ["T201"]
-"reset_testdb.py" = ["T201"]
-"tools_create_smart_sell_test_db.py" = ["T201"]
-"tools_create_test_db.py" = ["T201"]
 [tool.black]
 target-version = ["py311"]
 line-length = 100
@@ -222,19 +223,22 @@ fail_under = 0
 # сам .pre-commit-config.yaml живёт отдельно; тут просто фиксируем, что у нас он используется
 # см. пример конфига в ./tools/.pre-commit-config.yaml (создадим при необходимости)
 
-[tool.ruff]
-extend-exclude = ["migrations"]
-
 [tool.ruff.lint.per-file-ignores]
-"_create_tables_direct.py" = ["T201"]
-"_dbcheck_asyncpg.py" = ["T201"]
-"_patch_conftest.py" = ["T201"]
-"bootstrap_schema.py" = ["T201"]
-"check_migration_order.py" = ["T201"]
-"fix_migration_order.py" = ["T201"]
-"reset_testdb.py" = ["T201"]
-"tools_create_smart_sell_test_db.py" = ["T201"]
-"tools_create_test_db.py" = ["T201"]
+"__init__.py" = ["E402"]
+"**/{tests,docs,tools}/*" = ["F401"]
+"app/api/**/*.py" = ["B008"]
+"app/main.py" = ["B008"]
+"app/core/dependencies.py" = ["B008"]
+"app/core/security.py" = ["B008"]
+"**/_create_tables_direct.py" = ["T201"]
+"**/_dbcheck_asyncpg.py" = ["T201"]
+"**/_patch_conftest.py" = ["T201"]
+"**/bootstrap_schema.py" = ["T201"]
+"**/check_migration_order.py" = ["T201"]
+"**/fix_migration_order.py" = ["T201"]
+"**/reset_testdb.py" = ["T201"]
+"**/tools_create_smart_sell_test_db.py" = ["T201"]
+"**/tools_create_test_db.py" = ["T201"]
 
 [tool.ruff.format]
-exclude = ["migrations"]
+exclude = ["migrations/**"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,15 @@ exclude = [
 "app/core/security.py" = ["B008"]
 
 # ---------------- Black ----------------
+"_create_tables_direct.py" = ["T201"]
+"_dbcheck_asyncpg.py" = ["T201"]
+"_patch_conftest.py" = ["T201"]
+"bootstrap_schema.py" = ["T201"]
+"check_migration_order.py" = ["T201"]
+"fix_migration_order.py" = ["T201"]
+"reset_testdb.py" = ["T201"]
+"tools_create_smart_sell_test_db.py" = ["T201"]
+"tools_create_test_db.py" = ["T201"]
 [tool.black]
 target-version = ["py311"]
 line-length = 100
@@ -227,3 +236,5 @@ extend-exclude = ["migrations"]
 "tools_create_smart_sell_test_db.py" = ["T201"]
 "tools_create_test_db.py" = ["T201"]
 
+[tool.ruff.format]
+exclude = ["migrations"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,3 +212,18 @@ fail_under = 0
 [tool.pre-commit]
 # сам .pre-commit-config.yaml живёт отдельно; тут просто фиксируем, что у нас он используется
 # см. пример конфига в ./tools/.pre-commit-config.yaml (создадим при необходимости)
+
+[tool.ruff]
+extend-exclude = ["migrations"]
+
+[tool.ruff.lint.per-file-ignores]
+"_create_tables_direct.py" = ["T201"]
+"_dbcheck_asyncpg.py" = ["T201"]
+"_patch_conftest.py" = ["T201"]
+"bootstrap_schema.py" = ["T201"]
+"check_migration_order.py" = ["T201"]
+"fix_migration_order.py" = ["T201"]
+"reset_testdb.py" = ["T201"]
+"tools_create_smart_sell_test_db.py" = ["T201"]
+"tools_create_test_db.py" = ["T201"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,23 +222,3 @@ fail_under = 0
 [tool.pre-commit]
 # сам .pre-commit-config.yaml живёт отдельно; тут просто фиксируем, что у нас он используется
 # см. пример конфига в ./tools/.pre-commit-config.yaml (создадим при необходимости)
-
-[tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["E402"]
-"**/{tests,docs,tools}/*" = ["F401"]
-"app/api/**/*.py" = ["B008"]
-"app/main.py" = ["B008"]
-"app/core/dependencies.py" = ["B008"]
-"app/core/security.py" = ["B008"]
-"**/_create_tables_direct.py" = ["T201"]
-"**/_dbcheck_asyncpg.py" = ["T201"]
-"**/_patch_conftest.py" = ["T201"]
-"**/bootstrap_schema.py" = ["T201"]
-"**/check_migration_order.py" = ["T201"]
-"**/fix_migration_order.py" = ["T201"]
-"**/reset_testdb.py" = ["T201"]
-"**/tools_create_smart_sell_test_db.py" = ["T201"]
-"**/tools_create_test_db.py" = ["T201"]
-
-[tool.ruff.format]
-exclude = ["migrations/**"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -28,3 +28,30 @@ exclude = [
 "app/core/dependencies.py" = ["B008"]
 "app/core/security.py"     = ["B008"]
 "tools/**/*.py"          = ["T201"]
+force-exclude = true
+extend-exclude = ["migrations/**"]
+
+"**/_create_tables_direct.py" = ["T201"]
+"**/_dbcheck_asyncpg.py" = ["T201"]
+"**/_patch_conftest.py" = ["T201"]
+"**/bootstrap_schema.py" = ["T201"]
+"**/check_migration_order.py" = ["T201"]
+"**/fix_migration_order.py" = ["T201"]
+"**/reset_testdb.py" = ["T201"]
+"**/tools_create_smart_sell_test_db.py" = ["T201"]
+"**/tools_create_test_db.py" = ["T201"]
+[format]
+
+exclude = ["migrations/**"]
+
+[per-file-ignores]
+
+"**/_create_tables_direct.py" = ["T201"]
+"**/_dbcheck_asyncpg.py" = ["T201"]
+"**/_patch_conftest.py" = ["T201"]
+"**/bootstrap_schema.py" = ["T201"]
+"**/check_migration_order.py" = ["T201"]
+"**/fix_migration_order.py" = ["T201"]
+"**/reset_testdb.py" = ["T201"]
+"**/tools_create_smart_sell_test_db.py" = ["T201"]
+"**/tools_create_test_db.py" = ["T201"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -28,7 +28,6 @@ exclude = [
 "app/core/dependencies.py" = ["B008"]
 "app/core/security.py"     = ["B008"]
 "tools/**/*.py"          = ["T201"]
-force-exclude = true
 extend-exclude = ["migrations/**"]
 
 "**/_create_tables_direct.py" = ["T201"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,9 +1,10 @@
 ﻿line-length = 120
 target-version = "py311"
 
-[lint]
 select = ["E","F","I","B","UP","C4","T20"]
 ignore = ["B904","E402","C401","C408","C416","B009","B010","UP007","E501"]  # временно, E501 handled by formatter
+
+extend-exclude = ["migrations/**"]
 
 exclude = [
 	"migrations/versions/_quarantine",
@@ -15,10 +16,10 @@ exclude = [
 	"_alembic_backup",
 	"_alembic_backup/**",
 	"**/_backup/**",
-	"**/_quarantine/**",
+"**/_quarantine/**",
 ]
 
-[lint.per-file-ignores]
+[per-file-ignores]
 "alembic/versions/*.py" = ["UP","B","E402","C408","C416","B009","B010"]
 "tests/**/*.py"          = ["B904","E402","F401"]
 "app/api/**/*.py"        = ["B904","UP007","B009","B010","E402","B008"]
@@ -27,24 +28,7 @@ exclude = [
 "app/main.py"            = ["B008"]
 "app/core/dependencies.py" = ["B008"]
 "app/core/security.py"     = ["B008"]
-"tools/**/*.py"          = ["T201"]
-extend-exclude = ["migrations/**"]
-
-"**/_create_tables_direct.py" = ["T201"]
-"**/_dbcheck_asyncpg.py" = ["T201"]
-"**/_patch_conftest.py" = ["T201"]
-"**/bootstrap_schema.py" = ["T201"]
-"**/check_migration_order.py" = ["T201"]
-"**/fix_migration_order.py" = ["T201"]
-"**/reset_testdb.py" = ["T201"]
-"**/tools_create_smart_sell_test_db.py" = ["T201"]
-"**/tools_create_test_db.py" = ["T201"]
-[format]
-
-exclude = ["migrations/**"]
-
-[per-file-ignores]
-
+"**/tools/inspect_models.py" = ["T201"]
 "**/_create_tables_direct.py" = ["T201"]
 "**/_dbcheck_asyncpg.py" = ["T201"]
 "**/_patch_conftest.py" = ["T201"]


### PR DESCRIPTION
Fix ruff.toml for Ruff 0.1.6: exclude migrations from check/format, ignore T201 for utility scripts. Verified: ruff check ., ruff format --check ., pytest security headers.