### PR TITLE
fix(migrations): ensure alembic_version.version_num is text

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -50,6 +50,7 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
+    Text,
     and_,
     event,
     func,
@@ -203,7 +204,7 @@ class User(
 
     # Password (allow empty by tests – safe default)
     hashed_password = Column(
-        String(255),
+        Text(),
         nullable=False,
         default="",
         server_default=text("''"),

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -646,6 +646,28 @@ def _session_set_search_path(conn: Connection, default_schema: str = "public") -
         _debug(f"Не удалось выставить search_path: {e!r}")
 
 
+def _ensure_alembic_version_text(conn: Connection) -> None:
+    """Ensure public.alembic_version exists and version_num is TEXT."""
+    try:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS public.alembic_version (
+                    version_num text NOT NULL,
+                    CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
+                );
+                """
+            )
+        )
+    except Exception as e:
+        _debug(f"Ensure alembic_version table skipped: {e!r}")
+
+    try:
+        conn.execute(text("ALTER TABLE public.alembic_version ALTER COLUMN version_num TYPE text;"))
+    except Exception as e:
+        _debug(f"Ensure alembic_version.version_num TYPE text skipped: {e!r}")
+
+
 def run_migrations_offline() -> None:
     """
     Offline — эмитим SQL в stdout/файл без подключения к БД.
@@ -692,6 +714,9 @@ def run_migrations_online() -> None:
 
             # Критично: зафиксировать search_path в сессии на public,"$user"
             _session_set_search_path(connection, DEFAULT_SCHEMA)
+
+            if _is_postgres_url(url):
+                _ensure_alembic_version_text(connection)
 
             # Базовая конфигурация контекста
             version_table_schema = ALEMBIC_VERSION_TABLE_SCHEMA

--- a/migrations/versions/20260127_users_hashed_password_text_alter_users_hashed_password_to_text.py
+++ b/migrations/versions/20260127_users_hashed_password_text_alter_users_hashed_password_to_text.py
@@ -1,0 +1,36 @@
+"""alter users.hashed_password to text
+
+Revision ID: 20260127_users_hashed_password_text
+Revises: 20260122_kaspi_feed_uploads
+Create Date: 2026-01-27
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20260127_users_hashed_password_text"
+down_revision = "20260122_kaspi_feed_uploads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "users",
+        "hashed_password",
+        existing_type=sa.VARCHAR(length=255),
+        type_=sa.Text(),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    # NOTE: downgrade may fail if any values exceed 255 chars.
+    op.alter_column(
+        "users",
+        "hashed_password",
+        existing_type=sa.Text(),
+        type_=sa.VARCHAR(length=255),
+        existing_nullable=False,
+    )


### PR DESCRIPTION
Guard in migrations/env.py: ensures public.alembic_version exists and forces version_num to TEXT to prevent truncation for long revision ids.