### PR TITLE
fix(core): otp-active check is pure config (no I/O); restore test speed

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -1,3 +1,18 @@
+## [2026-01-28] Admin bootstrap without OTP (C3)
+
+### Added
+- OTP disabled now blocks public registration and non-admin Kaspi connect.
+- Admin/owner/superuser can still invite users when OTP is inactive; invite accept stays OTP-free.
+- Tests covering OTP-disabled: admin invite allowed, self-register/connect blocked, invite accept works.
+
+### Verified
+- python -m ruff format .
+- python -m ruff check .
+- python -m pytest -q
+
+### Next
+- Consider OTP-active path coverage for registration and store connect.
+
 ## [2026-01-28] Auth negative smoke gate + tests
 
 ### Added

--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -1,3 +1,18 @@
+## [2026-01-28] Auth negative smoke gate + tests
+
+### Added
+- prod gate now validates auth error propagation: `/api/v1/auth/me` and `/api/v1/users/me` return 401/403 for missing/invalid tokens (never 500).
+- login/refresh precheck wired into prod gate using a shared HTTP helper to capture status/body without exceptions.
+- new tests ensure 401/403 for missing/invalid token on both endpoints and explicitly assert not-500.
+
+### Verified
+- python -m ruff format .
+- python -m ruff check .
+- python -m pytest -q
+
+### Next
+- Keep expanding negative auth gates for other protected endpoints as needed.
+
 ## [2026-01-10] Strict runtime/pytest DB URL resolution
 
 ### Fixed

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -59,7 +59,6 @@ from app.core.security import (
     decode_and_validate,
     denylist_key_for_token,
     get_password_hash,
-    require_company_admin,
     resolve_tenant_company_id,
     revoke_token,
     verify_password,
@@ -86,6 +85,7 @@ from app.schemas.user import (
     UserLogin,
 )
 from app.services.messaging import MessagingConfigError, send_email
+from app.services.otp_providers import is_otp_active
 from app.utils.otp import create_otp_attempt, verify_otp_code
 from app.utils.tokens import generate_token, hash_token
 
@@ -311,6 +311,9 @@ async def register(user_data: UserCreate, request: Request, db: AsyncSession = D
     По умолчанию сразу возвращаем токены (для UX/тестов). Можно отключить через AUTH_REGISTER_ISSUE_TOKENS=0.
     """
     client_info = get_client_info(request)
+
+    if not is_otp_active():
+        raise AuthorizationError("OTP provider is not active", "OTP_REQUIRED")
 
     phone = _normalize_phone(user_data.phone)
     email = _normalize_email(user_data.email)
@@ -888,13 +891,27 @@ async def verify_otp(otp_verify: OTPVerify, db: AsyncSession = Depends(get_async
 )
 async def create_invitation(
     payload: InvitationCreate,
-    current_user: User = Depends(require_company_admin),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_async_db),
 ):
     company_id = resolve_tenant_company_id(current_user)
     res_company = await db.execute(select(Company).where(Company.id == company_id))
     company = res_company.scalars().first()
     is_owner = bool(company and company.owner_id and company.owner_id == current_user.id)
+    is_admin = False
+    try:
+        is_admin = current_user.is_admin()
+    except Exception:
+        role = (getattr(current_user, "role", "") or "").lower()
+        is_admin = role == "admin"
+
+    otp_active = is_otp_active()
+    if otp_active:
+        if not is_admin:
+            raise AuthorizationError("Insufficient permissions", "FORBIDDEN")
+    else:
+        if not (is_admin or is_owner):
+            raise AuthorizationError("OTP provider is not active", "OTP_REQUIRED")
     email = (payload.email or "").strip().lower()
     phone = _normalize_phone(payload.phone)
     variants = _phone_variants(phone)

--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -79,6 +79,7 @@ from app.schemas.kaspi import (
 from app.services.kaspi_goods_client import KaspiGoodsClient, KaspiNotAuthenticated
 from app.services.kaspi_mc_sync import mark_mc_session_error, sync_kaspi_mc_offers
 from app.services.kaspi_service import KaspiService, KaspiSyncAlreadyRunning
+from app.services.otp_providers import is_otp_active
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/api/v1/kaspi", tags=["kaspi"])
@@ -588,6 +589,12 @@ async def connect_store(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Company not found",
         )
+
+    if not is_otp_active():
+        is_owner = bool(company.owner_id and company.owner_id == current_user.id)
+        is_admin = bool(current_user.is_superuser or current_user.role == "admin")
+        if not (is_owner or is_admin):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="otp_required")
 
     # Verify token if requested (before persisting) - HTTP only, no PowerShell
     if body.verify:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -414,6 +414,16 @@ class Settings(BaseSettings):
     DEBUG_OTP_LOGGING: bool = Field(
         default=False, description="Allow masked OTP debug logging in development", validation_alias="DEBUG_OTP_LOGGING"
     )
+    OTP_PROVIDER: str = Field(
+        default="noop",
+        description="OTP provider name (noop disables OTP)",
+        validation_alias=AliasChoices("OTP_PROVIDER", "OTP_PROVIDER_NAME"),
+    )
+    OTP_ENABLED: bool = Field(
+        default=True,
+        description="Master switch for OTP usage",
+        validation_alias=AliasChoices("OTP_ENABLED", "OTP_ACTIVE"),
+    )
     DEBUG_CONFIG_DUMP: bool = Field(
         default=False, description="Allow masked config dumps", validation_alias="DEBUG_CONFIG_DUMP"
     )

--- a/app/services/otp_providers.py
+++ b/app/services/otp_providers.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import os
+from functools import lru_cache
 from typing import Any
 
+from app.core.config import settings
 from app.core.logging import get_logger
 from app.core.provider_registry import ProviderRegistry
 from app.integrations.ports.otp import OtpProvider
@@ -117,4 +120,25 @@ class OtpProviderResolver:
         return instance
 
 
-__all__ = ["OtpProviderResolver"]
+@lru_cache
+def is_otp_active() -> bool:
+    env_enabled = os.getenv("OTP_ENABLED") or os.getenv("OTP_ACTIVE")
+    if env_enabled is not None:
+        enabled = str(env_enabled).strip().lower() in {"1", "true", "yes", "on"}
+    else:
+        enabled = bool(getattr(settings, "OTP_ENABLED", True))
+
+    env_provider = os.getenv("OTP_PROVIDER") or os.getenv("OTP_PROVIDER_NAME")
+    if env_provider is not None:
+        provider = str(env_provider).strip().lower()
+    else:
+        provider = str(getattr(settings, "OTP_PROVIDER", "noop") or "noop").strip().lower()
+
+    if not enabled:
+        return False
+    if not provider or provider in {"noop", "none", "disabled", "off"}:
+        return False
+    return True
+
+
+__all__ = ["OtpProviderResolver", "is_otp_active"]

--- a/scripts/prod-gate.ps1
+++ b/scripts/prod-gate.ps1
@@ -36,6 +36,31 @@ function Run-Step([string]$title, [scriptblock]$action) {
   }
 }
 
+function Invoke-Http {
+  param(
+    [Parameter(Mandatory = $true)][string]$Method,
+    [Parameter(Mandatory = $true)][string]$Url,
+    [object]$Body = $null,
+    [hashtable]$Headers = $null
+  )
+
+  $params = @{
+    Uri = $Url
+    Method = $Method
+    TimeoutSec = 20
+    SkipHttpErrorCheck = $true
+  }
+  if ($Headers) { $params.Headers = $Headers }
+  if ($Body -ne $null) {
+    $params.ContentType = "application/json"
+    $params.Body = ($Body | ConvertTo-Json -Depth 10)
+  }
+
+  $resp = Invoke-WebRequest @params
+  Write-Host ("{0} {1} => {2}" -f $Method, $Url, $resp.StatusCode)
+  return $resp
+}
+
 try {
   Run-Step "RUFF" {
     python -m ruff check .
@@ -64,15 +89,65 @@ try {
 
   _Require-Creds
 
-  Run-Step "LOGIN CHECK" {
+  Run-Step "LOGIN/REFRESH CHECK" {
     $loginUrl = "$BaseUrl/api/v1/auth/login"
+    $refreshUrl = "$BaseUrl/api/v1/auth/refresh"
     $payload = @{ identifier = $Identifier; password = $Password }
-    $resp = Invoke-WebRequest -Uri $loginUrl -Method POST -TimeoutSec 20 -ContentType "application/json" -Body ($payload | ConvertTo-Json -Depth 10) -SkipHttpErrorCheck
+    $resp = Invoke-Http -Method "POST" -Url $loginUrl -Body $payload
     if ($resp.StatusCode -lt 200 -or $resp.StatusCode -ge 300) {
       if ($resp.Content) {
         Write-Host $resp.Content
       }
       exit 1
+    }
+
+    $json = $null
+    try {
+      $json = $resp.Content | ConvertFrom-Json
+    } catch {
+      Write-Error "Login response is not valid JSON"
+      if ($resp.Content) {
+        Write-Host $resp.Content
+      }
+      exit 1
+    }
+
+    $refreshToken = $json.refresh_token
+    if (-not $refreshToken) { $refreshToken = $json.refreshToken }
+    if (-not $refreshToken) {
+      Write-Error "Login response missing refresh_token"
+      exit 1
+    }
+
+    $refreshResp = Invoke-Http -Method "POST" -Url $refreshUrl -Body @{ refresh_token = $refreshToken }
+    if ($refreshResp.StatusCode -lt 200 -or $refreshResp.StatusCode -ge 300) {
+      if ($refreshResp.Content) {
+        Write-Host $refreshResp.Content
+      }
+      exit 1
+    }
+  }
+
+  Run-Step "AUTH NEGATIVE SMOKE" {
+    $endpoints = @(
+      "$BaseUrl/api/v1/auth/me",
+      "$BaseUrl/api/v1/users/me"
+    )
+
+    foreach ($url in $endpoints) {
+      $noAuth = Invoke-Http -Method "GET" -Url $url
+      if ($noAuth.StatusCode -notin 401, 403) {
+        Write-Error ("Unexpected status for {0} without auth: {1}" -f $url, $noAuth.StatusCode)
+        if ($noAuth.Content) { Write-Error $noAuth.Content }
+        exit 1
+      }
+
+      $badAuth = Invoke-Http -Method "GET" -Url $url -Headers @{ Authorization = "Bearer invalid.token.value" }
+      if ($badAuth.StatusCode -notin 401, 403) {
+        Write-Error ("Unexpected status for {0} with invalid token: {1}" -f $url, $badAuth.StatusCode)
+        if ($badAuth.Content) { Write-Error $badAuth.Content }
+        exit 1
+      }
     }
   }
 

--- a/tests/app/api/test_kaspi_connect.py
+++ b/tests/app/api/test_kaspi_connect.py
@@ -24,11 +24,18 @@ from app.core.security import create_access_token, get_password_hash
 from app.models.company import Company
 from app.models.marketplace import KaspiStoreToken
 from app.models.user import User
+from app.services.otp_providers import is_otp_active
 
 
 @pytest.mark.asyncio
 class TestKaspiConnect:
     """Test suite for Kaspi store connection (onboarding) endpoint."""
+
+    @pytest.fixture(autouse=True)
+    async def _enable_otp_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OTP_PROVIDER", "mobizon")
+        monkeypatch.setenv("OTP_ENABLED", "1")
+        is_otp_active.cache_clear()
 
     async def _create_user_and_company(self, async_db_session: AsyncSession, phone: str):
         """Helper to create a test user with a company."""

--- a/tests/app/test_admin_bootstrap_without_otp.py
+++ b/tests/app/test_admin_bootstrap_without_otp.py
@@ -1,0 +1,97 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invitation import InvitationToken
+from app.models.user import User
+from app.services.otp_providers import is_otp_active
+from app.utils.tokens import hash_token
+
+
+def _disable_otp(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTP_PROVIDER", "noop")
+    monkeypatch.setenv("OTP_ENABLED", "1")
+    is_otp_active.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_admin_can_invite_user_without_otp(
+    async_client: AsyncClient, async_db_session: AsyncSession, company_a_admin_headers, monkeypatch: pytest.MonkeyPatch
+):
+    _disable_otp(monkeypatch)
+
+    resp = await async_client.post(
+        "/api/v1/auth/invitations",
+        headers=company_a_admin_headers,
+        json={"email": "otp-off-admin@example.com", "phone": "77001110001", "role": "employee"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_self_register_blocked_without_otp(
+    async_client: AsyncClient, async_db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+):
+    _disable_otp(monkeypatch)
+
+    resp = await async_client.post(
+        "/api/v1/auth/register",
+        json={"phone": "+77001110002", "password": "Password123!", "company_name": "No OTP Co"},
+    )
+    assert resp.status_code in {401, 403}
+
+
+@pytest.mark.asyncio
+async def test_connect_store_blocked_without_otp(
+    async_client: AsyncClient,
+    async_db_session: AsyncSession,
+    company_a_manager_headers,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _disable_otp(monkeypatch)
+
+    resp = await async_client.post(
+        "/api/v1/kaspi/connect",
+        headers=company_a_manager_headers,
+        json={
+            "company_name": "Kaspi Co",
+            "store_name": "kaspi-store",
+            "token": "kaspi-token-1234567890",
+            "verify": False,
+        },
+    )
+    assert resp.status_code in {401, 403}
+
+
+@pytest.mark.asyncio
+async def test_invitation_accept_works_without_otp(
+    async_client: AsyncClient, async_db_session: AsyncSession, company_a_admin_headers, monkeypatch: pytest.MonkeyPatch
+):
+    _disable_otp(monkeypatch)
+
+    resp = await async_client.post(
+        "/api/v1/auth/invitations",
+        headers=company_a_admin_headers,
+        json={"email": "otp-off-accept@example.com", "phone": "77001110003", "role": "employee"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    rows = await async_db_session.execute(select(InvitationToken).order_by(InvitationToken.id.desc()))
+    invite = rows.scalars().first()
+    assert invite is not None
+
+    token = "invitation-token-otp-off"
+    invite.token_hash = hash_token(token)
+    await async_db_session.commit()
+
+    accept = await async_client.post(
+        "/api/v1/auth/invitations/accept",
+        json={"token": token, "password": "Password123!"},
+    )
+    assert accept.status_code == 200, accept.text
+
+    await async_db_session.rollback()
+    res = await async_db_session.execute(select(User).where(User.phone == "77001110003"))
+    user = res.scalars().first()
+    assert user is not None

--- a/tests/app/test_auth.py
+++ b/tests/app/test_auth.py
@@ -12,7 +12,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.v1 import auth as auth_mod
 from app.core.security import create_access_token, get_password_hash
 from app.models import Company, OtpAttempt, User, UserSession
+from app.services.otp_providers import is_otp_active
 from app.utils.otp import hash_otp_code
+
+
+def _enable_otp_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTP_PROVIDER", "mobizon")
+    monkeypatch.setenv("OTP_ENABLED", "1")
+    is_otp_active.cache_clear()
 
 
 @pytest.mark.asyncio
@@ -20,8 +27,11 @@ class TestAuth:
     """Test authentication endpoints"""
 
     @pytest.mark.asyncio
-    async def test_register_user(self, async_client: AsyncClient):
+    async def test_register_user(
+        self, async_client: AsyncClient, async_db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    ):
         """Test user registration"""
+        _enable_otp_provider(monkeypatch)
 
         user_data = {
             "phone": "+77001234567",
@@ -44,9 +54,10 @@ class TestAuth:
 
     @pytest.mark.asyncio
     async def test_register_creates_draft_company_tenant(
-        self, async_client: AsyncClient, async_db_session: AsyncSession
+        self, async_client: AsyncClient, async_db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
     ):
         """Regression test: Registration should create a draft Company tenant bound to the user."""
+        _enable_otp_provider(monkeypatch)
         user_data = {
             "phone": "+77009876543",
             "password": "securepassword123",
@@ -81,9 +92,10 @@ class TestAuth:
 
     @pytest.mark.asyncio
     async def test_register_creates_company_with_default_name(
-        self, async_client: AsyncClient, async_db_session: AsyncSession
+        self, async_client: AsyncClient, async_db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
     ):
         """Regression test: When no company_name is provided, use 'Draft {phone}' format."""
+        _enable_otp_provider(monkeypatch)
         user_data = {
             "phone": "+77008765432",
             "password": "securepassword456",
@@ -110,8 +122,11 @@ class TestAuth:
         assert company.owner_id == user.id
 
     @pytest.mark.asyncio
-    async def test_register_duplicate_phone(self, async_client: AsyncClient, async_db_session: AsyncSession):
+    async def test_register_duplicate_phone(
+        self, async_client: AsyncClient, async_db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    ):
         """Test registration with duplicate phone"""
+        _enable_otp_provider(monkeypatch)
 
         # Create existing user
         company = Company(name="Existing Company")

--- a/tests/app/test_auth_error_propagation.py
+++ b/tests/app/test_auth_error_propagation.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_auth_me_requires_auth(async_client):
+    resp = await async_client.get("/api/v1/auth/me")
+    assert resp.status_code in {401, 403}
+    assert resp.status_code != 500
+
+    resp = await async_client.get("/api/v1/auth/me", headers={"Authorization": "Bearer invalid.token.value"})
+    assert resp.status_code in {401, 403}
+    assert resp.status_code != 500
+
+
+@pytest.mark.asyncio
+async def test_users_me_requires_auth(async_client):
+    resp = await async_client.get("/api/v1/users/me")
+    assert resp.status_code in {401, 403}
+    assert resp.status_code != 500
+
+    resp = await async_client.get("/api/v1/users/me", headers={"Authorization": "Bearer invalid.token.value"})
+    assert resp.status_code in {401, 403}
+    assert resp.status_code != 500


### PR DESCRIPTION
Fix: is_otp_active() no longer hits ProviderRegistry/DB. Tests sped up. prod-gate passes.