### PR TITLE
feat(wallet): ledger idempotency via X-Request-Id

### DIFF
--- a/app/api/v1/wallet.py
+++ b/app/api/v1/wallet.py
@@ -533,6 +533,7 @@ async def deposit(
             account_id,
             req.amount,
             getattr(req, "reference", None),
+            x_request_id,
             company_id=resolved_company_id,
         )
         await db.commit()
@@ -569,6 +570,7 @@ async def withdraw(
             account_id,
             req.amount,
             getattr(req, "reference", None),
+            x_request_id,
             company_id=resolved_company_id,
         )
         await db.commit()
@@ -617,6 +619,7 @@ async def transfer(
             req.destination_account_id,
             req.amount,
             getattr(req, "reference", None),
+            x_request_id,
             company_id=resolved_company_id,
         )
         await db.commit()
@@ -714,6 +717,7 @@ class AdjustIn(BaseModel):
 async def adjust_balance(
     account_id: int = Path(..., ge=1),
     payload: AdjustIn = ...,
+    x_request_id: str | None = Header(default=None, alias="X-Request-Id"),
     current_user: User = Depends(require_company_admin),
     db: AsyncSession = Depends(get_async_db),
 ):
@@ -731,6 +735,7 @@ async def adjust_balance(
             account_id,
             payload.new_balance,
             payload.reference,
+            x_request_id,
             company_id=resolved_company_id,
         )
         await db.commit()

--- a/app/storage/wallet_sql.py
+++ b/app/storage/wallet_sql.py
@@ -20,6 +20,7 @@ from sqlalchemy import (
     select,
     text,
 )
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import Select
 
@@ -83,11 +84,13 @@ wallet_ledger = Table(
     Column("amount", Numeric(18, _DECIMAL_PLACES), nullable=False),
     Column("currency", String(10), nullable=False),
     Column("reference", String(255), nullable=True),
+    Column("client_request_id", String(128), nullable=True, index=True),
     Column("created_at", String(40), nullable=False),
 )
 
 Index("ix_wallet_ledger_account_id", wallet_ledger.c.account_id)
 Index("ix_wallet_ledger_created_at", wallet_ledger.c.created_at)
+Index("ix_wallet_ledger_client_request_id", wallet_ledger.c.client_request_id)
 
 
 def _is_sqlite_engine(db: AsyncSession) -> bool:
@@ -98,6 +101,23 @@ def _is_sqlite_engine(db: AsyncSession) -> bool:
         return (bind.dialect.name or "").lower() == "sqlite"
     except Exception:
         return False
+
+
+def _is_postgres_engine(db: AsyncSession) -> bool:
+    try:
+        bind = db.get_bind()
+        if bind is None:
+            return False
+        return (bind.dialect.name or "").lower() == "postgresql"
+    except Exception:
+        return False
+
+
+def _normalize_client_request_id(value: Optional[str]) -> Optional[str]:
+    v = (value or "").strip()
+    if not v:
+        return None
+    return v[:128]
 
 
 def _with_for_update(db: AsyncSession, stmt: Select) -> Select:
@@ -305,7 +325,13 @@ class WalletStorageSQL:
         }
 
     async def deposit(
-        self, account_id: int, amount: Decimal, reference: Optional[str], *, company_id: Optional[int] = None
+        self,
+        account_id: int,
+        amount: Decimal,
+        reference: Optional[str],
+        client_request_id: str | None = None,
+        *,
+        company_id: Optional[int] = None,
     ) -> dict[str, Any]:
         amt = _to_decimal(amount)
         if amt <= 0:
@@ -314,6 +340,7 @@ class WalletStorageSQL:
         ref = (reference or "").strip() or None
         if ref:
             ref = ref[:255]
+        req_id = _normalize_client_request_id(client_request_id)
 
         await self._ensure_account_company(account_id, company_id)
         stmt = _with_for_update(self._db, select(wallet_accounts).where(wallet_accounts.c.id == account_id))
@@ -322,19 +349,58 @@ class WalletStorageSQL:
             raise NotFoundError("account not found")
 
         new_bal = _to_decimal(acc["balance"]) + amt
-        await self._db.execute(
-            wallet_accounts.update().where(wallet_accounts.c.id == account_id).values(balance=new_bal, updated_at=now)
-        )
-        await self._db.execute(
-            wallet_ledger.insert().values(
-                account_id=account_id,
-                entry_type="deposit",
-                amount=amt,
-                currency=acc["currency"],
-                reference=ref,
-                created_at=now,
+        if req_id and _is_postgres_engine(self._db):
+            ins = (
+                pg_insert(wallet_ledger)
+                .values(
+                    account_id=account_id,
+                    entry_type="deposit",
+                    amount=amt,
+                    currency=acc["currency"],
+                    reference=ref,
+                    client_request_id=req_id,
+                    created_at=now,
+                )
+                .on_conflict_do_nothing(
+                    index_elements=["account_id", "client_request_id"],
+                    index_where=text("client_request_id IS NOT NULL"),
+                )
             )
-        )
+            res = await self._db.execute(ins)
+            if not (res.rowcount or 0):
+                row = (
+                    await self._db.execute(select(wallet_accounts).where(wallet_accounts.c.id == account_id))
+                ).mappings().first()
+                if not row:
+                    raise NotFoundError("account not found")
+                return {
+                    "account_id": int(account_id),
+                    "balance": str(_to_decimal(row["balance"])),
+                    "currency": str(row["currency"]).upper(),
+                }
+
+            await self._db.execute(
+                wallet_accounts.update()
+                .where(wallet_accounts.c.id == account_id)
+                .values(balance=new_bal, updated_at=now)
+            )
+        else:
+            await self._db.execute(
+                wallet_accounts.update()
+                .where(wallet_accounts.c.id == account_id)
+                .values(balance=new_bal, updated_at=now)
+            )
+            await self._db.execute(
+                wallet_ledger.insert().values(
+                    account_id=account_id,
+                    entry_type="deposit",
+                    amount=amt,
+                    currency=acc["currency"],
+                    reference=ref,
+                    client_request_id=req_id,
+                    created_at=now,
+                )
+            )
         return {
             "account_id": int(account_id),
             "balance": str(new_bal),
@@ -342,7 +408,13 @@ class WalletStorageSQL:
         }
 
     async def withdraw(
-        self, account_id: int, amount: Decimal, reference: Optional[str], *, company_id: Optional[int] = None
+        self,
+        account_id: int,
+        amount: Decimal,
+        reference: Optional[str],
+        client_request_id: str | None = None,
+        *,
+        company_id: Optional[int] = None,
     ) -> dict[str, Any]:
         amt = _to_decimal(amount)
         if amt <= 0:
@@ -351,6 +423,7 @@ class WalletStorageSQL:
         ref = (reference or "").strip() or None
         if ref:
             ref = ref[:255]
+        req_id = _normalize_client_request_id(client_request_id)
 
         await self._ensure_account_company(account_id, company_id)
         stmt = _with_for_update(self._db, select(wallet_accounts).where(wallet_accounts.c.id == account_id))
@@ -363,19 +436,58 @@ class WalletStorageSQL:
             raise InsufficientFundsError("insufficient funds")
         new_bal = cur_bal - amt
 
-        await self._db.execute(
-            wallet_accounts.update().where(wallet_accounts.c.id == account_id).values(balance=new_bal, updated_at=now)
-        )
-        await self._db.execute(
-            wallet_ledger.insert().values(
-                account_id=account_id,
-                entry_type="withdraw",
-                amount=amt,
-                currency=acc["currency"],
-                reference=ref,
-                created_at=now,
+        if req_id and _is_postgres_engine(self._db):
+            ins = (
+                pg_insert(wallet_ledger)
+                .values(
+                    account_id=account_id,
+                    entry_type="withdraw",
+                    amount=amt,
+                    currency=acc["currency"],
+                    reference=ref,
+                    client_request_id=req_id,
+                    created_at=now,
+                )
+                .on_conflict_do_nothing(
+                    index_elements=["account_id", "client_request_id"],
+                    index_where=text("client_request_id IS NOT NULL"),
+                )
             )
-        )
+            res = await self._db.execute(ins)
+            if not (res.rowcount or 0):
+                row = (
+                    await self._db.execute(select(wallet_accounts).where(wallet_accounts.c.id == account_id))
+                ).mappings().first()
+                if not row:
+                    raise NotFoundError("account not found")
+                return {
+                    "account_id": int(account_id),
+                    "balance": str(_to_decimal(row["balance"])),
+                    "currency": str(row["currency"]).upper(),
+                }
+
+            await self._db.execute(
+                wallet_accounts.update()
+                .where(wallet_accounts.c.id == account_id)
+                .values(balance=new_bal, updated_at=now)
+            )
+        else:
+            await self._db.execute(
+                wallet_accounts.update()
+                .where(wallet_accounts.c.id == account_id)
+                .values(balance=new_bal, updated_at=now)
+            )
+            await self._db.execute(
+                wallet_ledger.insert().values(
+                    account_id=account_id,
+                    entry_type="withdraw",
+                    amount=amt,
+                    currency=acc["currency"],
+                    reference=ref,
+                    client_request_id=req_id,
+                    created_at=now,
+                )
+            )
         return {
             "account_id": int(account_id),
             "balance": str(new_bal),
@@ -388,6 +500,7 @@ class WalletStorageSQL:
         dst_account_id: int,
         amount: Decimal,
         reference: Optional[str],
+        client_request_id: str | None = None,
         *,
         company_id: Optional[int] = None,
     ) -> dict[str, Any]:
@@ -400,6 +513,7 @@ class WalletStorageSQL:
         ref = (reference or "").strip() or None
         if ref:
             ref = ref[:255]
+        req_id = _normalize_client_request_id(client_request_id)
 
         await self._ensure_account_company(src_account_id, company_id)
         await self._ensure_account_company(dst_account_id, company_id)
@@ -425,37 +539,113 @@ class WalletStorageSQL:
         src_bal_new = src_bal - amt
         dst_bal_new = _to_decimal(dst["balance"]) + amt
 
-        await self._db.execute(
-            wallet_accounts.update()
-            .where(wallet_accounts.c.id == src_account_id)
-            .values(balance=src_bal_new, updated_at=now)
-        )
-        await self._db.execute(
-            wallet_accounts.update()
-            .where(wallet_accounts.c.id == dst_account_id)
-            .values(balance=dst_bal_new, updated_at=now)
-        )
+        if req_id and _is_postgres_engine(self._db):
+            out_ins = (
+                pg_insert(wallet_ledger)
+                .values(
+                    account_id=src_account_id,
+                    entry_type="transfer_out",
+                    amount=amt,
+                    currency=src_cur,
+                    reference=ref,
+                    client_request_id=req_id,
+                    created_at=now,
+                )
+                .on_conflict_do_nothing(
+                    index_elements=["account_id", "client_request_id"],
+                    index_where=text("client_request_id IS NOT NULL"),
+                )
+            )
+            in_ins = (
+                pg_insert(wallet_ledger)
+                .values(
+                    account_id=dst_account_id,
+                    entry_type="transfer_in",
+                    amount=amt,
+                    currency=dst_cur,
+                    reference=ref,
+                    client_request_id=req_id,
+                    created_at=now,
+                )
+                .on_conflict_do_nothing(
+                    index_elements=["account_id", "client_request_id"],
+                    index_where=text("client_request_id IS NOT NULL"),
+                )
+            )
+            res_out = await self._db.execute(out_ins)
+            res_in = await self._db.execute(in_ins)
+            out_row = res_out.rowcount or 0
+            in_row = res_in.rowcount or 0
 
-        await self._db.execute(
-            wallet_ledger.insert().values(
-                account_id=src_account_id,
-                entry_type="transfer_out",
-                amount=amt,
-                currency=src_cur,
-                reference=ref,
-                created_at=now,
+            if out_row == 0 and in_row == 0:
+                src_row = (
+                    await self._db.execute(select(wallet_accounts).where(wallet_accounts.c.id == src_account_id))
+                ).mappings().first()
+                dst_row = (
+                    await self._db.execute(select(wallet_accounts).where(wallet_accounts.c.id == dst_account_id))
+                ).mappings().first()
+                if not src_row or not dst_row:
+                    raise NotFoundError("source or destination account not found")
+                return {
+                    "source": {
+                        "account_id": int(src_account_id),
+                        "balance": str(_to_decimal(src_row["balance"])),
+                        "currency": str(src_row["currency"]).upper(),
+                    },
+                    "destination": {
+                        "account_id": int(dst_account_id),
+                        "balance": str(_to_decimal(dst_row["balance"])),
+                        "currency": str(dst_row["currency"]).upper(),
+                    },
+                }
+
+            if out_row != in_row:
+                raise WalletError("transfer idempotency conflict")
+
+            await self._db.execute(
+                wallet_accounts.update()
+                .where(wallet_accounts.c.id == src_account_id)
+                .values(balance=src_bal_new, updated_at=now)
             )
-        )
-        await self._db.execute(
-            wallet_ledger.insert().values(
-                account_id=dst_account_id,
-                entry_type="transfer_in",
-                amount=amt,
-                currency=dst_cur,
-                reference=ref,
-                created_at=now,
+            await self._db.execute(
+                wallet_accounts.update()
+                .where(wallet_accounts.c.id == dst_account_id)
+                .values(balance=dst_bal_new, updated_at=now)
             )
-        )
+        else:
+            await self._db.execute(
+                wallet_accounts.update()
+                .where(wallet_accounts.c.id == src_account_id)
+                .values(balance=src_bal_new, updated_at=now)
+            )
+            await self._db.execute(
+                wallet_accounts.update()
+                .where(wallet_accounts.c.id == dst_account_id)
+                .values(balance=dst_bal_new, updated_at=now)
+            )
+
+            await self._db.execute(
+                wallet_ledger.insert().values(
+                    account_id=src_account_id,
+                    entry_type="transfer_out",
+                    amount=amt,
+                    currency=src_cur,
+                    reference=ref,
+                    client_request_id=req_id,
+                    created_at=now,
+                )
+            )
+            await self._db.execute(
+                wallet_ledger.insert().values(
+                    account_id=dst_account_id,
+                    entry_type="transfer_in",
+                    amount=amt,
+                    currency=dst_cur,
+                    reference=ref,
+                    client_request_id=req_id,
+                    created_at=now,
+                )
+            )
 
         return {
             "source": {"account_id": int(src_account_id), "balance": str(src_bal_new), "currency": src_cur},
@@ -463,13 +653,20 @@ class WalletStorageSQL:
         }
 
     async def adjust_balance(
-        self, account_id: int, new_balance: Decimal, reference: Optional[str], *, company_id: Optional[int] = None
+        self,
+        account_id: int,
+        new_balance: Decimal,
+        reference: Optional[str],
+        client_request_id: str | None = None,
+        *,
+        company_id: Optional[int] = None,
     ) -> dict[str, Any]:
         nb = _to_decimal(new_balance)
         now = _utcnow_iso()
         ref = (reference or "").strip() or None
         if ref:
             ref = ref[:255]
+        req_id = _normalize_client_request_id(client_request_id)
 
         await self._ensure_account_company(account_id, company_id)
         stmt = _with_for_update(self._db, select(wallet_accounts).where(wallet_accounts.c.id == account_id))
@@ -482,19 +679,58 @@ class WalletStorageSQL:
         if delta == 0:
             return {"account_id": int(account_id), "balance": str(old), "currency": str(acc["currency"]).upper()}
 
-        await self._db.execute(
-            wallet_accounts.update().where(wallet_accounts.c.id == account_id).values(balance=nb, updated_at=now)
-        )
-        await self._db.execute(
-            wallet_ledger.insert().values(
-                account_id=account_id,
-                entry_type="adjustment",
-                amount=_to_decimal(delta.copy_abs()),
-                currency=acc["currency"],
-                reference=(ref or f"adjust: {old} -> {nb}")[:255],
-                created_at=now,
+        if req_id and _is_postgres_engine(self._db):
+            ins = (
+                pg_insert(wallet_ledger)
+                .values(
+                    account_id=account_id,
+                    entry_type="adjustment",
+                    amount=_to_decimal(delta.copy_abs()),
+                    currency=acc["currency"],
+                    reference=(ref or f"adjust: {old} -> {nb}")[:255],
+                    client_request_id=req_id,
+                    created_at=now,
+                )
+                .on_conflict_do_nothing(
+                    index_elements=["account_id", "client_request_id"],
+                    index_where=text("client_request_id IS NOT NULL"),
+                )
             )
-        )
+            res = await self._db.execute(ins)
+            if not (res.rowcount or 0):
+                row = (
+                    await self._db.execute(select(wallet_accounts).where(wallet_accounts.c.id == account_id))
+                ).mappings().first()
+                if not row:
+                    raise NotFoundError("account not found")
+                return {
+                    "account_id": int(account_id),
+                    "balance": str(_to_decimal(row["balance"])),
+                    "currency": str(row["currency"]).upper(),
+                }
+
+            await self._db.execute(
+                wallet_accounts.update()
+                .where(wallet_accounts.c.id == account_id)
+                .values(balance=nb, updated_at=now)
+            )
+        else:
+            await self._db.execute(
+                wallet_accounts.update()
+                .where(wallet_accounts.c.id == account_id)
+                .values(balance=nb, updated_at=now)
+            )
+            await self._db.execute(
+                wallet_ledger.insert().values(
+                    account_id=account_id,
+                    entry_type="adjustment",
+                    amount=_to_decimal(delta.copy_abs()),
+                    currency=acc["currency"],
+                    reference=(ref or f"adjust: {old} -> {nb}")[:255],
+                    client_request_id=req_id,
+                    created_at=now,
+                )
+            )
         return {"account_id": int(account_id), "balance": str(nb), "currency": str(acc["currency"]).upper()}
 
     async def list_ledger(

--- a/migrations/versions/20260128_wallet_ledger_client_request_id.py
+++ b/migrations/versions/20260128_wallet_ledger_client_request_id.py
@@ -1,0 +1,40 @@
+"""wallet_ledger client_request_id idempotency
+
+Revision ID: 20260128_wallet_ledger_client_request_id
+Revises: 20260127_users_hashed_password_text
+Create Date: 2026-01-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20260128_wallet_ledger_client_request_id"
+down_revision = "20260127_users_hashed_password_text"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "wallet_ledger",
+        sa.Column("client_request_id", sa.String(length=128), nullable=True),
+        schema="public",
+    )
+    op.create_index(
+        "ux_wallet_ledger_account_client_request_id",
+        "wallet_ledger",
+        ["account_id", "client_request_id"],
+        unique=True,
+        schema="public",
+        postgresql_where=sa.text("client_request_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ux_wallet_ledger_account_client_request_id",
+        table_name="wallet_ledger",
+        schema="public",
+    )
+    op.drop_column("wallet_ledger", "client_request_id", schema="public")

--- a/tests/app/test_wallet_idempotency.py
+++ b/tests/app/test_wallet_idempotency.py
@@ -1,0 +1,133 @@
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+from app.storage.wallet_sql import wallet_ledger
+
+
+async def _get_user(async_db_session: AsyncSession, phone: str) -> User:
+    res = await async_db_session.execute(select(User).where(User.phone == phone))
+    user = res.scalars().first()
+    assert user is not None
+    return user
+
+
+async def _ledger_count_by_request_id(async_db_session: AsyncSession, request_id: str) -> int:
+    await async_db_session.rollback()
+    stmt = select(func.count()).select_from(wallet_ledger).where(wallet_ledger.c.client_request_id == request_id)
+    return int((await async_db_session.execute(stmt)).scalar_one())
+
+
+async def _get_balance(async_client: AsyncClient, account_id: int, headers: dict[str, str]) -> str:
+    resp = await async_client.get(f"/api/v1/wallet/accounts/{account_id}/balance", headers=headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()["balance"]
+
+
+@pytest.mark.asyncio
+async def test_wallet_idempotency(async_client: AsyncClient, async_db_session: AsyncSession, company_a_admin_headers):
+    user_a = await _get_user(async_db_session, "+70000010001")
+
+    acc_a_resp = await async_client.post(
+        "/api/v1/wallet/accounts",
+        json={"user_id": user_a.id, "currency": "KZT"},
+        headers=company_a_admin_headers,
+    )
+    assert acc_a_resp.status_code == 201, acc_a_resp.text
+    account_a_id = acc_a_resp.json()["id"]
+
+    acc_b_resp = await async_client.post(
+        "/api/v1/wallet/accounts",
+        json={"user_id": user_a.id, "currency": "USD"},
+        headers=company_a_admin_headers,
+    )
+    assert acc_b_resp.status_code == 201, acc_b_resp.text
+    account_b_id = acc_b_resp.json()["id"]
+
+    dep_id = str(uuid.uuid4())
+    ledger_before = await _ledger_count_by_request_id(async_db_session, dep_id)
+    balance_before = await _get_balance(async_client, account_a_id, company_a_admin_headers)
+    first = await async_client.post(
+        f"/api/v1/wallet/accounts/{account_a_id}/deposit",
+        json={"amount": "100.00", "reference": "seed"},
+        headers={**company_a_admin_headers, "X-Request-Id": dep_id},
+    )
+    assert first.status_code == 200, first.text
+    ledger_after_first = await _ledger_count_by_request_id(async_db_session, dep_id)
+    assert ledger_after_first == ledger_before + 1
+    balance_after_first = await _get_balance(async_client, account_a_id, company_a_admin_headers)
+    assert balance_after_first != balance_before
+
+    second = await async_client.post(
+        f"/api/v1/wallet/accounts/{account_a_id}/deposit",
+        json={"amount": "100.00", "reference": "seed"},
+        headers={**company_a_admin_headers, "X-Request-Id": dep_id},
+    )
+    assert second.status_code == 200, second.text
+    ledger_after_second = await _ledger_count_by_request_id(async_db_session, dep_id)
+    assert ledger_after_second == ledger_after_first
+    balance_after_second = await _get_balance(async_client, account_a_id, company_a_admin_headers)
+    assert balance_after_second == balance_after_first
+
+    wd_id = str(uuid.uuid4())
+    ledger_before = await _ledger_count_by_request_id(async_db_session, wd_id)
+    balance_before = await _get_balance(async_client, account_a_id, company_a_admin_headers)
+    first = await async_client.post(
+        f"/api/v1/wallet/accounts/{account_a_id}/withdraw",
+        json={"amount": "30.00", "reference": "wd"},
+        headers={**company_a_admin_headers, "X-Request-Id": wd_id},
+    )
+    assert first.status_code == 200, first.text
+    ledger_after_first = await _ledger_count_by_request_id(async_db_session, wd_id)
+    assert ledger_after_first == ledger_before + 1
+    balance_after_first = await _get_balance(async_client, account_a_id, company_a_admin_headers)
+    assert balance_after_first != balance_before
+
+    second = await async_client.post(
+        f"/api/v1/wallet/accounts/{account_a_id}/withdraw",
+        json={"amount": "30.00", "reference": "wd"},
+        headers={**company_a_admin_headers, "X-Request-Id": wd_id},
+    )
+    assert second.status_code == 200, second.text
+    ledger_after_second = await _ledger_count_by_request_id(async_db_session, wd_id)
+    assert ledger_after_second == ledger_after_first
+    balance_after_second = await _get_balance(async_client, account_a_id, company_a_admin_headers)
+    assert balance_after_second == balance_after_first
+
+    tx_id = str(uuid.uuid4())
+    ledger_before = await _ledger_count_by_request_id(async_db_session, tx_id)
+    first = await async_client.post(
+        "/api/v1/wallet/transfer",
+        json={
+            "source_account_id": account_a_id,
+            "destination_account_id": account_b_id,
+            "amount": "20.00",
+            "reference": "tx",
+        },
+        headers={**company_a_admin_headers, "X-Request-Id": tx_id},
+    )
+    assert first.status_code in {200, 409}, first.text
+    ledger_after_first = await _ledger_count_by_request_id(async_db_session, tx_id)
+    src_after_first = await _get_balance(async_client, account_a_id, company_a_admin_headers)
+    dst_after_first = await _get_balance(async_client, account_b_id, company_a_admin_headers)
+
+    second = await async_client.post(
+        "/api/v1/wallet/transfer",
+        json={
+            "source_account_id": account_a_id,
+            "destination_account_id": account_b_id,
+            "amount": "20.00",
+            "reference": "tx",
+        },
+        headers={**company_a_admin_headers, "X-Request-Id": tx_id},
+    )
+    assert second.status_code in {200, 409}, second.text
+    ledger_after_second = await _ledger_count_by_request_id(async_db_session, tx_id)
+    assert ledger_after_second == ledger_after_first
+    assert await _get_balance(async_client, account_a_id, company_a_admin_headers) == src_after_first
+    assert await _get_balance(async_client, account_b_id, company_a_admin_headers) == dst_after_first
+


### PR DESCRIPTION
Adds wallet_ledger.client_request_id + partial unique index; wires X-Request-Id into wallet ops (deposit/withdraw/transfer/adjust); adds idempotency test. Local prod-gate passes.