### PR TITLE
feat(dev): reset-password CLI (argon2) + unlock

### DIFF
--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI utilities for SmartSell."""

--- a/app/cli/reset_password.py
+++ b/app/cli/reset_password.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Any
+
+from sqlalchemy import create_engine, text
+
+
+def _to_sync_url(url: str) -> str:
+    if url.startswith("postgresql+asyncpg://"):
+        return "postgresql+psycopg2://" + url.split("postgresql+asyncpg://", 1)[1]
+    if url.startswith("postgresql+psycopg://"):
+        return "postgresql+psycopg2://" + url.split("postgresql+psycopg://", 1)[1]
+    return url
+
+from app.core.config import get_settings
+from app.core.security import get_password_hash
+
+
+def _is_dev_or_test(settings: Any) -> bool:
+    try:
+        if getattr(settings, "is_testing", False):
+            return True
+        if getattr(settings, "is_development", False):
+            return True
+    except Exception:
+        pass
+    env = (os.getenv("ENVIRONMENT") or "").strip().lower()
+    return env in {"development", "dev", "local", "testing", "test"} or bool(os.getenv("TESTING"))
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Reset user password (dev-only CLI).")
+    parser.add_argument("--identifier", required=True, help="User phone or email")
+    parser.add_argument("--password", required=True, help="New password")
+    parser.add_argument("--unlock", action="store_true", help="Reset lock counters and unlock user")
+    return parser.parse_args(argv)
+
+
+def _reset_password(identifier: str, password: str, unlock: bool) -> int:
+    settings = get_settings()
+    if not _is_dev_or_test(settings):
+        sys.stderr.write("ERR: reset-password CLI is dev/test only\n")
+        return 1
+
+    db_url = getattr(settings, "DATABASE_URL", None) or os.getenv("DATABASE_URL")
+    if not db_url:
+        sys.stderr.write("ERR: DATABASE_URL is required\n")
+        return 1
+
+    engine = create_engine(_to_sync_url(db_url))
+    hashed = get_password_hash(password)
+    with engine.begin() as conn:
+        row = conn.execute(
+            text(
+                "SELECT id, phone, email FROM public.users "
+                "WHERE phone = :identifier OR email = :identifier "
+                "LIMIT 1"
+            ),
+            {"identifier": identifier},
+        ).mappings().first()
+
+        if not row:
+            return 2
+
+        params = {
+            "uid": int(row["id"]),
+            "hashed_password": hashed,
+        }
+        if unlock:
+            conn.execute(
+                text(
+                    "UPDATE public.users "
+                    "SET hashed_password = :hashed_password, "
+                    "failed_login_attempts = 0, "
+                    "locked_until = NULL, "
+                    "locked_at = NULL "
+                    "WHERE id = :uid"
+                ),
+                params,
+            )
+        else:
+            conn.execute(
+                text("UPDATE public.users SET hashed_password = :hashed_password WHERE id = :uid"),
+                params,
+            )
+
+    sys.stdout.write(f"user_id={row['id']} identifier={identifier} updated unlock={bool(unlock)}\n")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    return _reset_password(args.identifier, args.password, bool(args.unlock))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/app/test_cli_reset_password.py
+++ b/tests/app/test_cli_reset_password.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from datetime import timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.security import get_password_hash, verify_password
+from app.models import Company, User
+from app.models.user import utc_now
+from tests.conftest import SYNC_TEST_DATABASE_URL
+
+
+@pytest.mark.asyncio
+async def test_reset_password_cli_updates_hash_and_unlocks(async_db_session: AsyncSession) -> None:
+    company = Company(name="CLI Co")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    user = User(
+        company_id=company.id,
+        phone="77079990011",
+        email="cli.reset.77079990011@example.com",
+        hashed_password=get_password_hash("OldPass123!"),
+        role="admin",
+        is_active=True,
+        is_verified=True,
+        failed_login_attempts=3,
+        locked_until=utc_now() + timedelta(minutes=10),
+        locked_at=utc_now(),
+    )
+    async_db_session.add(user)
+    await async_db_session.commit()
+
+    old_hash = user.hashed_password
+
+    env = os.environ.copy()
+    env["DATABASE_URL"] = SYNC_TEST_DATABASE_URL
+    env["DB_URL"] = SYNC_TEST_DATABASE_URL
+    env.setdefault("TESTING", "1")
+    cmd = [
+        sys.executable,
+        "-m",
+        "app.cli.reset_password",
+        "--identifier",
+        "cli.reset.77079990011@example.com",
+        "--password",
+        "NewPass123!",
+        "--unlock",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env, check=False)
+
+    assert result.returncode == 0
+    assert "user_id=" in result.stdout
+    assert "identifier=cli.reset.77079990011@example.com" in result.stdout
+    assert "updated" in result.stdout
+    assert "unlock=True" in result.stdout
+    assert result.stderr == ""
+
+    sessionmaker = async_sessionmaker(async_db_session.bind, expire_on_commit=False)
+    async with sessionmaker() as session:
+        refreshed = (await session.execute(select(User).where(User.id == user.id))).scalars().first()
+    assert refreshed is not None
+    assert refreshed.hashed_password != old_hash
+    assert verify_password("NewPass123!", refreshed.hashed_password)
+    assert refreshed.failed_login_attempts == 0
+    assert refreshed.locked_until is None
+    assert refreshed.locked_at is None


### PR DESCRIPTION
Adds DEV-only CLI to reset a user's password and optionally clear account lock; includes tests.