### PR TITLE
feat(kaspi): onboarding logs A1/A2

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -88,6 +88,7 @@ wallet = _try_import("app.api.v1.wallet")
 payments = _try_import("app.api.v1.payments")
 invoices = _try_import("app.api.v1.invoices")
 kaspi_mod = _try_import("app.api.v1.kaspi")  # ⬅ добавлено
+integrations_mod = _try_import("app.api.v1.integrations")
 debug_db_mod = _try_import("app.api.v1.debug_db")
 
 # Переэкспорт удобных имён/алиасов (для внешнего кода)
@@ -163,6 +164,8 @@ if invoices and _router_or_none(invoices):
 if kaspi_mod and _router_or_none(kaspi_mod):
     # в kaspi.py объявлен prefix '/api/v1/kaspi' → абсолютный
     V1_ROUTERS.append(("kaspi", kaspi_mod.router, True))
+if integrations_mod and _router_or_none(integrations_mod):
+    V1_ROUTERS.append(("integrations", integrations_mod.router, True))
 if debug_db_mod and _router_or_none(debug_db_mod):
     V1_ROUTERS.append(("debug_db", debug_db_mod.router, True))
 

--- a/app/api/v1/integrations.py
+++ b/app/api/v1/integrations.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import sqlalchemy as sa
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_async_db
+from app.core.security import get_current_user, resolve_tenant_company_id
+from app.models.integration_event import IntegrationEvent
+from app.models.user import User
+
+router = APIRouter(prefix="/api/v1/integrations", tags=["integrations"])
+
+
+class IntegrationEventOut(BaseModel):
+    id: int
+    company_id: int
+    merchant_uid: str | None = None
+    kind: str
+    status: str
+    error_code: str | None = None
+    error_message: str | None = None
+    request_id: str | None = None
+    occurred_at: datetime
+    meta_json: dict[str, Any] | None = None
+
+
+def _require_admin(current_user: User) -> None:
+    if not (current_user.is_superuser or current_user.role == "admin"):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
+
+
+@router.get(
+    "/events",
+    summary="List integration events",
+    response_model=list[IntegrationEventOut],
+)
+async def list_integration_events(
+    kind: str | None = Query(None),
+    limit: int = Query(100, ge=1, le=200),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_async_db),
+) -> list[IntegrationEventOut]:
+    _require_admin(current_user)
+    company_id = resolve_tenant_company_id(current_user, not_found_detail="Company not set")
+
+    stmt = sa.select(IntegrationEvent).where(IntegrationEvent.company_id == company_id)
+    if kind:
+        if kind == "kaspi":
+            stmt = stmt.where(IntegrationEvent.kind.like("kaspi%"))
+        else:
+            stmt = stmt.where(IntegrationEvent.kind == kind)
+
+    stmt = stmt.order_by(IntegrationEvent.occurred_at.desc()).limit(limit)
+    rows = (await session.execute(stmt)).scalars().all()
+
+    return [
+        IntegrationEventOut(
+            id=row.id,
+            company_id=row.company_id,
+            merchant_uid=row.merchant_uid,
+            kind=row.kind,
+            status=row.status,
+            error_code=row.error_code,
+            error_message=row.error_message,
+            request_id=row.request_id,
+            occurred_at=row.occurred_at,
+            meta_json=row.meta_json,
+        )
+        for row in rows
+    ]

--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -76,6 +76,7 @@ from app.schemas.kaspi import (
     KaspiTokenOut,
     OrdersQuery,
 )
+from app.services.integration_events import record_integration_event
 from app.services.kaspi_goods_client import KaspiGoodsClient, KaspiNotAuthenticated
 from app.services.kaspi_mc_sync import mark_mc_session_error, sync_kaspi_mc_offers
 from app.services.kaspi_service import KaspiService, KaspiSyncAlreadyRunning
@@ -90,6 +91,7 @@ router = APIRouter(prefix="/api/v1/kaspi", tags=["kaspi"])
 MASK_HEX_LEN = 10
 MASK_CHAR = "..."
 STATUS_LAST_ERROR_MAX_LEN = 500
+FAST_PROBE_TIMEOUT = 5.0
 
 
 def normalize_name(name: str) -> str:
@@ -546,6 +548,40 @@ class KaspiTokenMaskedOut(BaseModel):
     token_hex_masked: str
     created_at: Any
     updated_at: Any
+    last_selftest_at: datetime | None = None
+    last_selftest_status: str | None = None
+    last_selftest_error_code: str | None = None
+    last_selftest_error_message: str | None = None
+
+
+async def _record_kaspi_event(
+    session: AsyncSession,
+    *,
+    company_id: int,
+    kind: str,
+    status: str,
+    request_id: str | None,
+    merchant_uid: str | None = None,
+    error_code: str | None = None,
+    error_message: str | None = None,
+    meta_json: dict[str, Any] | None = None,
+    commit: bool = True,
+) -> None:
+    try:
+        await record_integration_event(
+            session,
+            company_id=company_id,
+            merchant_uid=merchant_uid,
+            kind=kind,
+            status=status,
+            error_code=error_code,
+            error_message=error_message,
+            request_id=request_id,
+            meta_json=meta_json,
+            commit=commit,
+        )
+    except Exception as exc:
+        logger.warning("Kaspi integration event write failed: kind=%s err=%s", kind, exc)
 
 
 @router.post(
@@ -555,6 +591,7 @@ class KaspiTokenMaskedOut(BaseModel):
     summary="Kaspi onboarding: connect and configure store (main entry point)",
 )
 async def connect_store(
+    request: Request,
     body: KaspiConnectIn,
     current_user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_db),
@@ -615,6 +652,16 @@ async def connect_store(
                     logger.warning(
                         "Kaspi connect: invalid token store=%s status=%s", body.store_name, e.response.status_code
                     )
+                    await _record_kaspi_event(
+                        session,
+                        company_id=company_id,
+                        kind="kaspi_connect",
+                        status="failed",
+                        request_id=getattr(getattr(request, "state", None), "request_id", None),
+                        error_code="kaspi_invalid_token",
+                        error_message="NOT_AUTHENTICATED",
+                        meta_json={"store_name": body.store_name, "verify": body.verify},
+                    )
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
                         detail="kaspi_invalid_token",
@@ -624,6 +671,16 @@ async def connect_store(
                     logger.error(
                         "Kaspi connect: upstream HTTP error store=%s status=%s", body.store_name, e.response.status_code
                     )
+                    await _record_kaspi_event(
+                        session,
+                        company_id=company_id,
+                        kind="kaspi_connect",
+                        status="failed",
+                        request_id=getattr(getattr(request, "state", None), "request_id", None),
+                        error_code="kaspi_upstream_error",
+                        error_message="upstream_error",
+                        meta_json={"store_name": body.store_name, "verify": body.verify},
+                    )
                     raise HTTPException(
                         status_code=status.HTTP_502_BAD_GATEWAY,
                         detail="kaspi_upstream_error",
@@ -631,6 +688,16 @@ async def connect_store(
             elif isinstance(e, httpx.TimeoutException | httpx.NetworkError):
                 # Network/timeout errors
                 logger.error("Kaspi connect: network error store=%s error=%s", body.store_name, type(e).__name__)
+                await _record_kaspi_event(
+                    session,
+                    company_id=company_id,
+                    kind="kaspi_connect",
+                    status="failed",
+                    request_id=getattr(getattr(request, "state", None), "request_id", None),
+                    error_code="kaspi_upstream_unavailable",
+                    error_message="upstream_unavailable",
+                    meta_json={"store_name": body.store_name, "verify": body.verify},
+                )
                 raise HTTPException(
                     status_code=status.HTTP_502_BAD_GATEWAY,
                     detail="kaspi_upstream_error",
@@ -638,6 +705,16 @@ async def connect_store(
             else:
                 # Unexpected errors
                 logger.error("Kaspi connect: verification error store=%s error=%s", body.store_name, str(e))
+                await _record_kaspi_event(
+                    session,
+                    company_id=company_id,
+                    kind="kaspi_connect",
+                    status="failed",
+                    request_id=getattr(getattr(request, "state", None), "request_id", None),
+                    error_code="kaspi_upstream_error",
+                    error_message=str(e),
+                    meta_json={"store_name": body.store_name, "verify": body.verify},
+                )
                 raise HTTPException(
                     status_code=status.HTTP_502_BAD_GATEWAY,
                     detail="kaspi_upstream_error",
@@ -686,6 +763,15 @@ async def connect_store(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to save configuration: {str(e)}",
         )
+
+    await _record_kaspi_event(
+        session,
+        company_id=company_id,
+        kind="kaspi_connect",
+        status="success",
+        request_id=getattr(getattr(request, "state", None), "request_id", None),
+        meta_json={"store_name": body.store_name, "verify": body.verify},
+    )
 
     return KaspiConnectOut(
         store_name=body.store_name,
@@ -750,7 +836,11 @@ async def get_token_by_store_name(
             store_name,
             left(encode(token_ciphertext,'hex'), :mask_len) || :mask_char AS token_hex_masked,
             created_at,
-            updated_at
+            updated_at,
+            last_selftest_at,
+            last_selftest_status,
+            last_selftest_error_code,
+            last_selftest_error_message
         FROM kaspi_store_tokens
         WHERE lower(trim(store_name)) = lower(trim(:name))
         LIMIT 1
@@ -777,6 +867,10 @@ async def get_token_by_store_name(
         token_hex_masked=row["token_hex_masked"],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
+        last_selftest_at=row.get("last_selftest_at"),
+        last_selftest_status=row.get("last_selftest_status"),
+        last_selftest_error_code=row.get("last_selftest_error_code"),
+        last_selftest_error_message=row.get("last_selftest_error_message"),
     )
 
 
@@ -1834,11 +1928,12 @@ async def kaspi_goods_import_refresh(
     response_model=KaspiTokenHealthOut,
 )
 async def kaspi_token_health(
+    request: Request,
     current_user: User = Depends(_auth_user),
     session: AsyncSession = Depends(get_async_db),
 ):
     company_id = _resolve_company_id(current_user)
-    _, token = await _resolve_kaspi_token(session, company_id)
+    store_name, token = await _resolve_kaspi_token(session, company_id)
 
     now = datetime.utcnow()
     ge_ms = int((now - timedelta(days=14)).timestamp() * 1000)
@@ -1863,26 +1958,51 @@ async def kaspi_token_health(
     }
 
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=FAST_PROBE_TIMEOUT) as client:
             orders_resp = await client.get(orders_url, headers=orders_headers, params=orders_params)
             goods_resp = await client.get("https://kaspi.kz/shop/api/products/import/schema", headers=goods_headers)
-    except httpx.RequestError:
-        return KaspiTokenHealthOut(
-            ok=False,
-            orders_http=0,
-            goods_http=0,
-            cause="upstream_unavailable",
+    except httpx.TimeoutException:
+        await KaspiStoreToken.update_selftest(
+            session,
+            store_name,
+            status="upstream_unavailable",
+            error_code="timeout",
+            error_message="upstream_unavailable",
         )
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="upstream_unavailable")
+    except httpx.RequestError:
+        await KaspiStoreToken.update_selftest(
+            session,
+            store_name,
+            status="upstream_unavailable",
+            error_code="request_error",
+            error_message="upstream_unavailable",
+        )
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="upstream_unavailable")
 
-    cause = None
-    if orders_resp.status_code == 401 or goods_resp.status_code == 401:
-        cause = "NOT_AUTHENTICATED"
+    if orders_resp.status_code in {401, 403} or goods_resp.status_code in {401, 403}:
+        await KaspiStoreToken.update_selftest(
+            session,
+            store_name,
+            status="invalid_token",
+            error_code="NOT_AUTHENTICATED",
+            error_message="NOT_AUTHENTICATED",
+        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="NOT_AUTHENTICATED")
+
+    await KaspiStoreToken.update_selftest(
+        session,
+        store_name,
+        status="ok",
+        error_code=None,
+        error_message=None,
+    )
 
     return KaspiTokenHealthOut(
-        ok=cause is None,
+        ok=True,
         orders_http=orders_resp.status_code,
         goods_http=goods_resp.status_code,
-        cause=cause,
+        cause=None,
     )
 
 
@@ -1892,11 +2012,12 @@ async def kaspi_token_health(
     response_model=KaspiTokenSelftestOut,
 )
 async def kaspi_token_selftest(
+    request: Request,
     current_user: User = Depends(_auth_user),
     session: AsyncSession = Depends(get_async_db),
 ):
     company_id = _resolve_company_id(current_user)
-    _, token = await _resolve_kaspi_token(session, company_id)
+    store_name, token = await _resolve_kaspi_token(session, company_id)
 
     now = datetime.utcnow()
     ge_ms = int((now - timedelta(days=14)).timestamp() * 1000)
@@ -1920,8 +2041,10 @@ async def kaspi_token_selftest(
         "Accept": "application/json",
     }
 
+    request_id = getattr(getattr(request, "state", None), "request_id", None)
+
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=FAST_PROBE_TIMEOUT) as client:
             orders_resp = await client.get(orders_url, headers=orders_headers, params=orders_params)
             goods_schema_resp = await client.get(
                 "https://kaspi.kz/shop/api/products/import/schema",
@@ -1931,27 +2054,102 @@ async def kaspi_token_selftest(
                 "https://kaspi.kz/shop/api/products/classification/categories",
                 headers=goods_headers,
             )
-    except httpx.RequestError:
-        return KaspiTokenSelftestOut(
-            orders_http=0,
-            goods_schema_http=0,
-            goods_categories_http=0,
-            goods_access=None,
-            orders_error="upstream_unavailable",
+    except httpx.TimeoutException:
+        await KaspiStoreToken.update_selftest(
+            session,
+            store_name,
+            status="upstream_unavailable",
+            error_code="timeout",
+            error_message="upstream_unavailable",
         )
+        await _record_kaspi_event(
+            session,
+            company_id=company_id,
+            kind="kaspi_selftest",
+            status="failed",
+            request_id=request_id,
+            error_code="timeout",
+            error_message="upstream_unavailable",
+            meta_json={"orders_http": 0, "goods_schema_http": 0, "goods_categories_http": 0},
+        )
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="upstream_unavailable")
+    except httpx.RequestError:
+        await KaspiStoreToken.update_selftest(
+            session,
+            store_name,
+            status="upstream_unavailable",
+            error_code="request_error",
+            error_message="upstream_unavailable",
+        )
+        await _record_kaspi_event(
+            session,
+            company_id=company_id,
+            kind="kaspi_selftest",
+            status="failed",
+            request_id=request_id,
+            error_code="request_error",
+            error_message="upstream_unavailable",
+            meta_json={"orders_http": 0, "goods_schema_http": 0, "goods_categories_http": 0},
+        )
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="upstream_unavailable")
 
-    if orders_resp.status_code == 401:
+    if orders_resp.status_code in {401, 403}:
+        await KaspiStoreToken.update_selftest(
+            session,
+            store_name,
+            status="invalid_token",
+            error_code="NOT_AUTHENTICATED",
+            error_message="NOT_AUTHENTICATED",
+        )
+        await _record_kaspi_event(
+            session,
+            company_id=company_id,
+            kind="kaspi_selftest",
+            status="failed",
+            request_id=request_id,
+            error_code="NOT_AUTHENTICATED",
+            error_message="NOT_AUTHENTICATED",
+            meta_json={
+                "orders_http": orders_resp.status_code,
+                "goods_schema_http": goods_schema_resp.status_code,
+                "goods_categories_http": goods_categories_resp.status_code,
+            },
+        )
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="NOT_AUTHENTICATED")
 
     orders_error = None
+    status_value = "ok"
     if orders_resp.status_code >= 400:
         orders_error = "orders_request_failed"
+        status_value = "failed"
 
     goods_access = None
     if orders_resp.status_code == 200 and (
-        goods_schema_resp.status_code == 401 or goods_categories_resp.status_code == 401
+        goods_schema_resp.status_code in {401, 403} or goods_categories_resp.status_code in {401, 403}
     ):
         goods_access = "missing_or_not_enabled"
+
+    await KaspiStoreToken.update_selftest(
+        session,
+        store_name,
+        status=status_value,
+        error_code=orders_error,
+        error_message=orders_error,
+    )
+    await _record_kaspi_event(
+        session,
+        company_id=company_id,
+        kind="kaspi_selftest",
+        status="success" if status_value == "ok" else "failed",
+        request_id=request_id,
+        error_code=orders_error,
+        error_message=orders_error,
+        meta_json={
+            "orders_http": orders_resp.status_code,
+            "goods_schema_http": goods_schema_resp.status_code,
+            "goods_categories_http": goods_categories_resp.status_code,
+        },
+    )
 
     return KaspiTokenSelftestOut(
         orders_http=orders_resp.status_code,

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -185,6 +185,7 @@ _LAZY_MODELS: dict[str, tuple[str, str]] = {
         "app.models.integration_provider_config",
         "IntegrationProviderConfig",
     ),
+    "IntegrationEvent": ("app.models.integration_event", "IntegrationEvent"),
     "KaspiOrderSyncState": ("app.models.kaspi_order_sync_state", "KaspiOrderSyncState"),
     "KaspiCatalogProduct": ("app.models.kaspi_catalog_product", "KaspiCatalogProduct"),
     "KaspiFeedExport": ("app.models.kaspi_feed_export", "KaspiFeedExport"),
@@ -220,6 +221,7 @@ _DOMAIN_MODULES: tuple[str, ...] = (
     "app.models.system_integrations",
     "app.models.integration_provider",
     "app.models.integration_provider_config",
+    "app.models.integration_event",
 )
 
 # Критичные модули/классы, чья регистрация нужна даже при «холодном» старте (FK/relationship)

--- a/app/models/integration_event.py
+++ b/app/models/integration_event.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, BigInteger, DateTime, ForeignKey, String, Text, func
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import BaseModel, LenientInitMixin
+
+
+class IntegrationEvent(LenientInitMixin, BaseModel):
+    __tablename__ = "integration_events"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    company_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("companies.id"), nullable=False, index=True)
+    merchant_uid: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    kind: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String(64), nullable=False)
+    error_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    request_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    meta_json: Mapped[Any | None] = mapped_column(
+        JSON().with_variant(postgresql.JSONB(astext_type=Text()), "postgresql"), nullable=True
+    )

--- a/app/models/marketplace.py
+++ b/app/models/marketplace.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Any, Optional
 
 import sqlalchemy as sa
-from sqlalchemy import BigInteger, Boolean, Numeric, String, text
+from sqlalchemy import BigInteger, Boolean, DateTime, Numeric, String, text
 from sqlalchemy.dialects.postgresql import BYTEA, UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
@@ -35,6 +35,10 @@ class KaspiStoreToken(Base):
     updated_at: Mapped[datetime] = mapped_column(
         nullable=False, server_default=text("now()"), server_onupdate=text("now()")
     )
+    last_selftest_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_selftest_status: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    last_selftest_error_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    last_selftest_error_message: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
     @classmethod
     async def upsert_token(
@@ -117,7 +121,11 @@ class KaspiStoreToken(Base):
                 store_name,
                 left(encode(token_ciphertext,'hex'), {mask_len}) || :mask AS token_hex_masked,
                 created_at,
-                updated_at
+                updated_at,
+                last_selftest_at,
+                last_selftest_status,
+                last_selftest_error_code,
+                last_selftest_error_message
             FROM kaspi_store_tokens
             WHERE lower(trim(store_name)) = lower(trim(:name))
             LIMIT 1
@@ -126,6 +134,55 @@ class KaspiStoreToken(Base):
         res = await session.execute(sql, {"name": store_name, "mask": mask_char})
         row = res.mappings().first()
         return dict(row) if row else None
+
+    @classmethod
+    async def update_selftest(
+        cls,
+        session: AsyncSession,
+        store_name: str,
+        status: str,
+        *,
+        error_code: str | None = None,
+        error_message: str | None = None,
+        occurred_at: datetime | None = None,
+        commit: bool = True,
+    ) -> None:
+        if not store_name:
+            return
+        when = occurred_at or datetime.utcnow()
+        msg = (error_message or "").strip()
+        if msg:
+            msg = msg[:500]
+
+        sql = sa.text(
+            """
+            UPDATE kaspi_store_tokens
+            SET
+                last_selftest_at = :when,
+                last_selftest_status = :status,
+                last_selftest_error_code = :error_code,
+                last_selftest_error_message = :error_message,
+                updated_at = now()
+            WHERE lower(trim(store_name)) = lower(trim(:name))
+            """
+        )
+        try:
+            await session.execute(
+                sql,
+                {
+                    "when": when,
+                    "status": status,
+                    "error_code": error_code,
+                    "error_message": msg or None,
+                    "name": store_name,
+                },
+            )
+            if commit:
+                await session.commit()
+        except Exception:
+            if commit:
+                await session.rollback()
+            raise
 
     @classmethod
     async def delete_by_store(cls, session: AsyncSession, store_name: str) -> bool:

--- a/app/services/integration_events.py
+++ b/app/services/integration_events.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.integration_event import IntegrationEvent
+
+
+async def record_integration_event(
+    session: AsyncSession,
+    *,
+    company_id: int,
+    merchant_uid: str | None,
+    kind: str,
+    status: str,
+    error_code: str | None = None,
+    error_message: str | None = None,
+    request_id: str | None = None,
+    occurred_at: datetime | None = None,
+    meta_json: dict[str, Any] | None = None,
+    commit: bool = True,
+) -> IntegrationEvent:
+    msg = (error_message or "").strip()
+    event = IntegrationEvent(
+        company_id=company_id,
+        merchant_uid=merchant_uid,
+        kind=kind,
+        status=status,
+        error_code=error_code,
+        error_message=msg or None,
+        request_id=request_id,
+        occurred_at=occurred_at or datetime.utcnow(),
+        meta_json=meta_json,
+    )
+    session.add(event)
+    if commit:
+        await session.commit()
+        await session.refresh(event)
+    return event

--- a/docs/SMARTSELL_NEXT_PHASE_PLAN.md
+++ b/docs/SMARTSELL_NEXT_PHASE_PLAN.md
@@ -1,0 +1,377 @@
+# SmartSell — Next Phase Plan (Post CORE_PROD_PLAN)
+**Version:** 2026-01-29  
+**Owner:** Ақыл  
+**Purpose:** Step-by-step roadmap for the next implementation phase after CORE_PROD_PLAN is complete, focused on first Kaspi client value and production-like operability.
+
+---
+
+## 0) Context & Principles
+
+### Current baseline (assumed true)
+- Core production hardening is complete and gated by `scripts/prod-gate.ps1`.
+- Error contract unified: JSON `{detail, code, request_id}` + response header `X-Request-ID` everywhere.
+- Local-only checks are the source of truth until CI resumes (you already use `prod-gate.ps1`).
+
+### Non-negotiables (to keep speed and avoid regressions)
+1. **No rewrites.** Only incremental changes with tight tests.
+2. **Every epic ends with:** migrations (if needed) + tests + updated docs + journal entry.
+3. **Single quality gate:** `pwsh -NoProfile -File .\scripts\prod-gate.ps1` must pass.
+4. **No Redis dependency for dev/MVP flows** (as decided).
+5. **Root-cause fixes only.** If a symptom appears in ops, fix the cause, not the surface.
+
+### Target outcome
+A Kaspi merchant can:
+1) Connect store (token + merchantUid)  
+2) Import/update catalog (file-based)  
+3) Generate & publish feed (upload lifecycle)  
+4) Sync orders reliably (with visible status & logs)  
+5) Be billable (subscription enforcement on key features)  
+6) Operate system (backup/restore + update flow)
+
+---
+
+## 1) Work Method (Step-by-step)
+
+### The loop we follow for every step
+1. **Create branch** from `dev`: `feat/<area>-<short>-v1`  
+2. Implement smallest slice that changes behavior safely  
+3. Add/extend tests (unit + API)  
+4. Run:
+   - `python -m ruff format .`
+   - `python -m ruff check .`
+   - `python -m pytest -q`
+   - `pwsh -NoProfile -File .\scripts\prod-gate.ps1`
+5. Commit, push, PR to `dev`, merge  
+6. Fast-forward `main` from `origin/dev` (your standard flow)  
+7. Delete feature branch (local + origin)
+
+---
+
+## 2) Milestones (recommended order)
+
+### Milestone A — Integration Observability (Kaspi Onboarding + Logs)
+Goal: Every failure has a structured trace (request_id) and a persistent “why”.
+
+### Milestone B — Catalog Import v2 (client-ready)
+Goal: Client can import from CSV/XLSX with predictable normalization and reporting.
+
+### Milestone C — Feed Lifecycle (upload → status → publish)
+Goal: Official/real “feed upload job” with statuses and troubleshooting.
+
+### Milestone D — Orders Operations
+Goal: Reliable sync and “operator view”: last success, last error, and list of recent orders.
+
+### Milestone E — Subscription Enforcement (real)
+Goal: Enforce paid features on the endpoints that matter (feed upload, autosync, pricing).
+
+### Milestone F — Ops Minimum (backup/restore, update flow)
+Goal: Real deploy/upgrade/restore steps that a future operator can follow.
+
+> Notes:
+> - Pricing min/max (dumping) and preorder are upsell add-ons. Do them after feed+catalog are solid.
+
+---
+
+# 3) Detailed Plan (Tasks + DoD)
+
+## Milestone A — Kaspi Onboarding + Integration Logs
+
+### A1. Store connection status (connect/selftest)
+**Deliverables**
+- Endpoint returns explicit structured status and saves diagnostics.
+- Selftest uses short timeouts and never blocks long (≤ 5s).
+
+**Tasks**
+- Add/verify fields in Kaspi store token model:
+  - `last_selftest_at`, `last_selftest_status`, `last_selftest_error_code`, `last_selftest_error_message`
+- Ensure `/api/v1/kaspi/*` endpoints pass `request_id` into service layer and include `X-Request-ID` in response.
+- Add fast probe behavior (timeout and no retries) for selftest/health.
+
+**DoD**
+- Tests:
+  - connect with invalid token → 401/400 (never 500)
+  - selftest returns `upstream_unavailable` quickly when Kaspi unreachable
+- `prod-gate.ps1` passes.
+
+---
+
+### A2. Persistent integration events log (operator minimum)
+**Deliverables**
+- A DB table + service to write integration events.
+- Read endpoint for recent events.
+
+**Tasks**
+- Create model + migration: `integration_events` (or `kaspi_integration_events`)
+  - `id`, `company_id`, `merchant_uid`, `kind`, `status`, `error_code`, `error_message`, `request_id`, `occurred_at`, `meta_json`
+- Write events from:
+  - Kaspi connect
+  - feed upload lifecycle
+  - orders sync
+- Endpoint:
+  - `GET /api/v1/integrations/events?kind=kaspi&limit=100` (or Kaspi-scoped)
+
+**DoD**
+- Tests: failure path creates event row.
+- Doc: where to look (DEPLOYMENT or dedicated doc).
+- `prod-gate.ps1` passes.
+
+---
+
+## Milestone B — Catalog Import v2 (CSV/XLSX + normalization + reporting)
+
+### B1. Input formats and canonical mapping
+**Deliverables**
+- Import supports CSV now + XLSX (recommended) + optional JSON.
+- Canonical columns and alias map are stable.
+
+**Tasks**
+- Implement parser abstraction:
+  - `parse_catalog_file(file_bytes, filename) -> rows`
+- CSV: robust delimiter detection; proper UTF-8 handling.
+- XLSX: `openpyxl` parsing (first sheet) with header row detection.
+- Normalization:
+  - `sku`, `masterSku`, `title`, `price`, `oldprice`, `stockCount`, `preOrder`, `images`, `attributes`
+- Validation:
+  - per-row error reasons (missing sku, invalid price, etc.)
+
+**DoD**
+- Tests on multiple header variants.
+- Import response includes:
+  - `rows_total`, `rows_ok`, `rows_skipped`, `top_errors`
+- `prod-gate.ps1` passes.
+
+---
+
+### B2. Upsert + dry-run + safety rules
+**Deliverables**
+- Idempotent upsert by `(company_id, merchant_uid, sku)`.
+- Dry-run mode returns report without DB writes.
+
+**Tasks**
+- Add query param `dry_run=true` to import endpoint.
+- Upsert rules:
+  - do not overwrite canonical fields with empty values
+  - prevent known bad alias collisions (regression tests)
+- Optional: store import batch record with report and file fingerprint.
+
+**DoD**
+- Tests:
+  - repeated import does not create duplicates
+  - dry-run does not write
+- `prod-gate.ps1` passes.
+
+---
+
+### B3. Client template export
+**Deliverables**
+- Template CSV/XLSX for client to fill.
+
+**Tasks**
+- `GET /api/v1/kaspi/catalog/template?format=csv|xlsx`
+- Include minimal example row and required columns.
+
+**DoD**
+- Template can be imported with 0 errors (if filled correctly).
+- Document usage.
+
+---
+
+## Milestone C — Feed Upload Lifecycle (upload → status → publish)
+
+### C1. FeedUploadJob model + state machine
+**Deliverables**
+- Job table with statuses and importCode tracking.
+
+**Tasks**
+- Migration + model: `kaspi_feed_uploads`
+  - `id`, `company_id`, `merchant_uid`, `source`, `status`,
+    `import_code`, `attempts`, `last_error_code`, `last_error_message`,
+    `created_at`, `updated_at`, `request_id`
+- Service:
+  - create job
+  - upload feed (Kaspi adapter)
+  - poll status
+  - publish (if applicable)
+- Ensure idempotency: repeated request with same `request_id` returns same job.
+
+**DoD**
+- Tests for state transitions.
+- No double uploads from retries.
+- `prod-gate.ps1` passes.
+
+---
+
+### C2. API endpoints for lifecycle
+**Deliverables**
+- `POST /api/v1/kaspi/feed/uploads`
+- `GET /api/v1/kaspi/feed/uploads`
+- `GET /api/v1/kaspi/feed/uploads/{id}`
+- `POST /api/v1/kaspi/feed/uploads/{id}/refresh`
+- `POST /api/v1/kaspi/feed/uploads/{id}/publish` (if needed)
+
+**DoD**
+- Contract tests on codes + request_id.
+- Clear error codes (`kaspi_upstream_unavailable`, `invalid_token`, etc.)
+- Doc “Golden path”.
+
+---
+
+### C3. Documentation: “Kaspi feed from zero to publish”
+**Deliverables**
+- A clear guide for a non-technical merchant admin.
+
+**Tasks**
+- Add to `docs/DEPLOYMENT.md` or `docs/KASPI_FEED.md`:
+  - how to generate feed
+  - how to upload
+  - how to find status
+  - what errors mean
+
+**DoD**
+- Doc includes exact endpoints and sample commands.
+
+---
+
+## Milestone D — Orders Operations
+
+### D1. Sync reliability + operator status
+**Deliverables**
+- Visible last sync status per store/company.
+
+**Tasks**
+- Persist:
+  - `last_orders_sync_at`, `last_orders_sync_status`, `last_orders_sync_error`
+- Ensure scheduled sync uses PROCESS_ROLE gating and advisory lock.
+
+**DoD**
+- Tests: sync sets last status; errors recorded.
+- `prod-gate.ps1` passes.
+
+---
+
+### D2. Minimal “orders list” endpoint (for client value)
+**Deliverables**
+- Client can view recent orders without DB access.
+
+**Tasks**
+- `GET /api/v1/orders?limit=50` (or `GET /api/v1/kaspi/orders?limit=50`)
+- Return: id, created_at, status, total, customer summary (as allowed), items count.
+
+**DoD**
+- Tenant isolation tests.
+- Basic pagination.
+
+---
+
+## Milestone E — Subscription Enforcement (real enforcement)
+
+### E1. Feature matrix (without pricing)
+**Deliverables**
+- Plans and features defined (prices remain external).
+
+**Tasks**
+- Document matrix (trial/basic/pro):
+  - stores count
+  - feed upload
+  - autosync
+  - pricing/preorder
+- Configurable via env/db.
+
+**DoD**
+- Test coverage for allowed/blocked.
+
+---
+
+### E2. Enforce on critical endpoints
+**Deliverables**
+- Hard blocks on premium actions.
+
+**Targets**
+- feed upload endpoints
+- autosync enable endpoints
+- pricing/preorder endpoints
+
+**DoD**
+- Tests show correct HTTP (403/402 depending on your contract) and never 500.
+
+---
+
+## Milestone F — Ops Minimum
+
+### F1. Backup/restore scripts
+**Deliverables**
+- `scripts/backup.ps1` and `scripts/restore.ps1` for Postgres.
+
+**DoD**
+- Documented commands and a “restore verification” step.
+
+---
+
+### F2. Upgrade procedure
+**Deliverables**
+- A consistent “upgrade playbook”:
+  - pull
+  - migrate
+  - restart
+  - smoke check
+
+**DoD**
+- Written in `docs/DEPLOYMENT.md` with real commands.
+
+---
+
+# 4) Definition of Done (Global)
+
+A milestone is considered complete only if:
+- All tests pass (`pytest -q`, `prod-gate.ps1`)
+- All new endpoints follow the error contract and propagate `X-Request-ID`
+- At least one doc section updated (DEPLOYMENT or feature doc)
+- Journal entry appended (append-only)
+- No historical migrations were edited (MIGRATIONS_POLICY)
+
+---
+
+# 5) Immediate Next Step (Start Now)
+
+**Start with Milestone A (A1 + A2).**  
+Reason: it makes every subsequent Kaspi task debuggable for the first client.
+
+### Step 1: Create branch
+```powershell
+Set-Location D:\LLM_HUB\SmartSell
+git checkout dev
+git pull --ff-only
+git checkout -b feat/kaspi-onboarding-logs-a1a2-v1
+```
+
+### Step 2: Work items for this branch
+- Implement A1 (selftest status persistence + fast probe)
+- Implement A2 (integration_events table + write events + read endpoint)
+- Tests + prod-gate
+
+### Step 3: Finish
+```powershell
+python -m ruff format .
+python -m ruff check .
+python -m pytest -q
+pwsh -NoProfile -File .\scripts\prod-gate.ps1
+```
+
+---
+
+## Appendix: Branch naming convention
+- `feat/kaspi-onboarding-logs-a1a2-v1`
+- `feat/kaspi-catalog-import-v2-v1`
+- `feat/kaspi-feed-lifecycle-v1`
+- `feat/kaspi-orders-ops-v1`
+- `feat/subscription-enforcement-e2-v1`
+- `feat/ops-backup-restore-v1`
+
+---
+
+## Appendix: Optional “Docs split” (later)
+If `docs/DEPLOYMENT.md` becomes too big, split:
+- `docs/KASPI_ONBOARDING.md`
+- `docs/KASPI_CATALOG_IMPORT.md`
+- `docs/KASPI_FEED.md`
+- `docs/OPS_BACKUP_RESTORE.md`

--- a/migrations/versions/20260129_integration_events.py
+++ b/migrations/versions/20260129_integration_events.py
@@ -1,0 +1,106 @@
+"""Integration events log
+
+Revision ID: 20260129_integration_events
+Revises: 20260129_invoices_mvp_core
+Create Date: 2026-01-29
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+try:
+    from migrations.utils.pghelpers import safe_inspect
+except Exception:  # pragma: no cover - fallback if utils import fails
+    safe_inspect = None  # type: ignore
+
+revision = "20260129_integration_events"
+down_revision = "20260129_invoices_mvp_core"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = safe_inspect(bind) if safe_inspect else None
+
+    if not insp or insp.has_table("kaspi_store_tokens"):
+        op.add_column(
+            "kaspi_store_tokens",
+            sa.Column("last_selftest_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.add_column(
+            "kaspi_store_tokens",
+            sa.Column("last_selftest_status", sa.String(length=64), nullable=True),
+        )
+        op.add_column(
+            "kaspi_store_tokens",
+            sa.Column("last_selftest_error_code", sa.String(length=64), nullable=True),
+        )
+        op.add_column(
+            "kaspi_store_tokens",
+            sa.Column("last_selftest_error_message", sa.String(length=500), nullable=True),
+        )
+
+    if not insp or not insp.has_table("integration_events"):
+        op.create_table(
+            "integration_events",
+            sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+            sa.Column("company_id", sa.BigInteger(), sa.ForeignKey("companies.id"), nullable=False),
+            sa.Column("merchant_uid", sa.String(length=128), nullable=True),
+            sa.Column("kind", sa.String(length=64), nullable=False),
+            sa.Column("status", sa.String(length=64), nullable=False),
+            sa.Column("error_code", sa.String(length=64), nullable=True),
+            sa.Column("error_message", sa.Text(), nullable=True),
+            sa.Column("request_id", sa.String(length=128), nullable=True),
+            sa.Column("occurred_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column("meta_json", sa.JSON(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+        )
+        op.create_index(
+            "ix_integration_events_company_kind_occurred",
+            "integration_events",
+            ["company_id", "kind", "occurred_at"],
+            unique=False,
+        )
+
+    if bind.dialect.name.lower().startswith("postgres"):
+        op.execute(
+            "ALTER TABLE integration_events "
+            "ALTER COLUMN meta_json TYPE JSONB USING meta_json::jsonb"
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = safe_inspect(bind) if safe_inspect else None
+
+    if not insp or insp.has_table("kaspi_store_tokens"):
+        try:
+            op.drop_column("kaspi_store_tokens", "last_selftest_error_message")
+        except Exception:
+            pass
+        try:
+            op.drop_column("kaspi_store_tokens", "last_selftest_error_code")
+        except Exception:
+            pass
+        try:
+            op.drop_column("kaspi_store_tokens", "last_selftest_status")
+        except Exception:
+            pass
+        try:
+            op.drop_column("kaspi_store_tokens", "last_selftest_at")
+        except Exception:
+            pass
+
+    if not insp or insp.has_table("integration_events"):
+        try:
+            op.drop_index("ix_integration_events_company_kind_occurred", table_name="integration_events")
+        except Exception:
+            pass
+        op.drop_table("integration_events")

--- a/tests/app/test_integration_events.py
+++ b/tests/app/test_integration_events.py
@@ -1,0 +1,81 @@
+import pytest
+import sqlalchemy as sa
+
+from app.models.integration_event import IntegrationEvent
+from app.models.marketplace import KaspiStoreToken
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        self.content = b""
+
+
+class _FakeAsyncClient:
+    def __init__(self, responses: list[_FakeResponse]):
+        self._responses = responses
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, *args, **kwargs):
+        return self._responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_integration_events_connect_and_selftest(
+    async_client, async_db_session, monkeypatch, company_a_admin_headers
+):
+    payload = {
+        "company_name": "Company A",
+        "store_name": "store-a",
+        "token": "token-a-123456",
+        "verify": False,
+    }
+
+    async def _upsert_token(session, store_name: str, plaintext_token: str):
+        session.add(KaspiStoreToken(store_name=store_name, token_ciphertext=plaintext_token.encode("utf-8")))
+        await session.commit()
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "upsert_token", _upsert_token)
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    resp = await async_client.post("/api/v1/kaspi/connect", json=payload, headers=company_a_admin_headers)
+    assert resp.status_code == 200, resp.text
+
+    from app.api.v1 import kaspi as kaspi_router
+
+    fake_client = _FakeAsyncClient(
+        [
+            _FakeResponse(200),
+            _FakeResponse(200),
+            _FakeResponse(200),
+        ]
+    )
+    monkeypatch.setattr(kaspi_router.httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+
+    resp = await async_client.get("/api/v1/kaspi/token/selftest", headers=company_a_admin_headers)
+    assert resp.status_code == 200, resp.text
+
+    events = (
+        (
+            await async_db_session.execute(
+                sa.select(IntegrationEvent).where(IntegrationEvent.kind.in_(["kaspi_connect", "kaspi_selftest"]))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {e.kind for e in events} >= {"kaspi_connect", "kaspi_selftest"}
+
+    resp = await async_client.get("/api/v1/integrations/events?kind=kaspi&limit=100", headers=company_a_admin_headers)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert len(data) >= 2
+    assert all(str(item["kind"]).startswith("kaspi") for item in data)

--- a/tests/app/test_kaspi_goods_api.py
+++ b/tests/app/test_kaspi_goods_api.py
@@ -72,9 +72,5 @@ async def test_kaspi_token_health_401(async_client, async_db_session, monkeypatc
     monkeypatch.setattr(kaspi_router.httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
 
     resp = await async_client.get("/api/v1/kaspi/token/health", headers=company_a_admin_headers)
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["ok"] is False
-    assert data["cause"] == "NOT_AUTHENTICATED"
-    assert data["orders_http"] == 401
-    assert data["goods_http"] == 401
+    assert resp.status_code == 401
+    assert resp.json().get("detail") == "NOT_AUTHENTICATED"

--- a/tests/app/test_kaspi_token_selftest.py
+++ b/tests/app/test_kaspi_token_selftest.py
@@ -1,4 +1,5 @@
 import pytest
+import sqlalchemy as sa
 
 from app.models.company import Company
 from app.models.marketplace import KaspiStoreToken
@@ -11,8 +12,9 @@ class _FakeResponse:
 
 
 class _FakeAsyncClient:
-    def __init__(self, responses: list[_FakeResponse]):
+    def __init__(self, responses: list[_FakeResponse], timeout=None):
         self._responses = responses
+        self.timeout = timeout
 
     async def __aenter__(self):
         return self
@@ -34,12 +36,17 @@ async def test_kaspi_token_selftest_goods_hint(async_client, async_db_session, m
         company.kaspi_store_id = "store-a"
     await async_db_session.commit()
 
+    async_db_session.add(KaspiStoreToken(store_name="store-a", token_ciphertext=b"token-a"))
+    await async_db_session.commit()
+
     async def _get_token(session, store_name: str):
         return "token-a"
 
     monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
 
     from app.api.v1 import kaspi as kaspi_router
+
+    timeouts: dict[str, object] = {}
 
     fake_client = _FakeAsyncClient(
         [
@@ -48,7 +55,12 @@ async def test_kaspi_token_selftest_goods_hint(async_client, async_db_session, m
             _FakeResponse(401),
         ]
     )
-    monkeypatch.setattr(kaspi_router.httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+
+    def _client_factory(*args, **kwargs):
+        timeouts["value"] = kwargs.get("timeout")
+        return fake_client
+
+    monkeypatch.setattr(kaspi_router.httpx, "AsyncClient", _client_factory)
 
     resp = await async_client.get("/api/v1/kaspi/token/selftest", headers=company_a_admin_headers)
     assert resp.status_code == 200
@@ -57,6 +69,20 @@ async def test_kaspi_token_selftest_goods_hint(async_client, async_db_session, m
     assert data["goods_schema_http"] == 401
     assert data["goods_categories_http"] == 401
     assert data["goods_access"] == "missing_or_not_enabled"
+
+    row = (
+        (
+            await async_db_session.execute(
+                sa.select(KaspiStoreToken).where(sa.func.lower(KaspiStoreToken.store_name) == "store-a")
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert row is not None
+    assert row.last_selftest_at is not None
+    assert row.last_selftest_status == "ok"
+    assert timeouts.get("value") == 5.0
 
 
 @pytest.mark.asyncio
@@ -69,6 +95,9 @@ async def test_kaspi_token_selftest_orders_unauthorized(
         async_db_session.add(company)
     else:
         company.kaspi_store_id = "store-a"
+    await async_db_session.commit()
+
+    async_db_session.add(KaspiStoreToken(store_name="store-a", token_ciphertext=b"token-a"))
     await async_db_session.commit()
 
     async def _get_token(session, store_name: str):
@@ -90,3 +119,67 @@ async def test_kaspi_token_selftest_orders_unauthorized(
     resp = await async_client.get("/api/v1/kaspi/token/selftest", headers=company_a_admin_headers)
     assert resp.status_code == 401
     assert resp.json().get("detail") == "NOT_AUTHENTICATED"
+
+    row = (
+        (
+            await async_db_session.execute(
+                sa.select(KaspiStoreToken).where(sa.func.lower(KaspiStoreToken.store_name) == "store-a")
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert row is not None
+    assert row.last_selftest_status == "invalid_token"
+    assert row.last_selftest_error_code == "NOT_AUTHENTICATED"
+
+
+@pytest.mark.asyncio
+async def test_kaspi_token_selftest_upstream_unavailable(
+    async_client, async_db_session, monkeypatch, company_a_admin_headers
+):
+    company = await async_db_session.get(Company, 1001)
+    if not company:
+        company = Company(id=1001, name="Company 1001", kaspi_store_id="store-a")
+        async_db_session.add(company)
+    else:
+        company.kaspi_store_id = "store-a"
+    await async_db_session.commit()
+
+    async_db_session.add(KaspiStoreToken(store_name="store-a", token_ciphertext=b"token-a"))
+    await async_db_session.commit()
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    from app.api.v1 import kaspi as kaspi_router
+
+    class _FailingClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, *args, **kwargs):
+            raise kaspi_router.httpx.RequestError("boom")
+
+    monkeypatch.setattr(kaspi_router.httpx, "AsyncClient", lambda *args, **kwargs: _FailingClient())
+
+    resp = await async_client.get("/api/v1/kaspi/token/selftest", headers=company_a_admin_headers)
+    assert resp.status_code == 502
+    assert resp.json().get("detail") == "upstream_unavailable"
+
+    row = (
+        (
+            await async_db_session.execute(
+                sa.select(KaspiStoreToken).where(sa.func.lower(KaspiStoreToken.store_name) == "store-a")
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert row is not None
+    assert row.last_selftest_status == "upstream_unavailable"


### PR DESCRIPTION
A1: persisted fast selftest diagnostics (<=5s, no retries). A2: integration_events model+migration + write/read API. Local gates: ruff, pytest, prod-gate OK.