### PR TITLE
fix(kaspi): goods schema/categories fail fast with 502 on timeout

### DIFF
--- a/app/services/kaspi_goods_client.py
+++ b/app/services/kaspi_goods_client.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import httpx
+from fastapi import status
 
+from app.core.exceptions import http_error
 from app.core.logging import get_logger
 
 logger = get_logger(__name__)
@@ -17,6 +19,8 @@ class KaspiGoodsClient:
             raise ValueError("kaspi_token_required")
         self._token = token
         self._base_url = base_url.rstrip("/")
+        self._default_timeout = 30.0
+        self._fast_timeout = 8.0
 
     def _headers(self) -> dict[str, str]:
         return {
@@ -37,22 +41,30 @@ class KaspiGoodsClient:
         params: dict[str, str] | None = None,
         json_body: object | None = None,
         content_type: str | None = None,
+        timeout_sec: float | None = None,
     ) -> dict:
         headers = self._headers()
         if content_type:
             headers["Content-Type"] = content_type
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.request(method, self._url(path), headers=headers, params=params, json=json_body)
+        timeout_value = float(timeout_sec) if timeout_sec is not None else self._default_timeout
+        try:
+            async with httpx.AsyncClient(timeout=timeout_value) as client:
+                resp = await client.request(method, self._url(path), headers=headers, params=params, json=json_body)
+        except (httpx.TimeoutException, httpx.RequestError) as exc:
+            logger.warning("Kaspi goods upstream unavailable: %s", exc)
+            raise http_error(status.HTTP_502_BAD_GATEWAY, "kaspi_upstream_unavailable") from exc
         if resp.status_code == 401:
             raise KaspiNotAuthenticated("Kaspi token is not authenticated")
         resp.raise_for_status()
         return resp.json() if resp.content else {}
 
     async def get_schema(self) -> dict:
-        return await self._request("GET", "/shop/api/products/import/schema")
+        return await self._request("GET", "/shop/api/products/import/schema", timeout_sec=self._fast_timeout)
 
     async def get_categories(self) -> dict:
-        return await self._request("GET", "/shop/api/products/classification/categories")
+        return await self._request(
+            "GET", "/shop/api/products/classification/categories", timeout_sec=self._fast_timeout
+        )
 
     async def get_attributes(self, *, category_code: str) -> dict:
         return await self._request(

--- a/tests/app/test_kaspi_goods_api.py
+++ b/tests/app/test_kaspi_goods_api.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 
 from app.models.company import Company
@@ -22,6 +23,20 @@ class _FakeAsyncClient:
 
     async def get(self, *args, **kwargs):
         return self._responses.pop(0) if self._responses else _FakeResponse(200)
+
+
+class _TimeoutAsyncClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def request(self, *args, **kwargs):
+        raise httpx.ReadTimeout("timeout")
 
 
 @pytest.mark.asyncio
@@ -74,3 +89,57 @@ async def test_kaspi_token_health_401(async_client, async_db_session, monkeypatc
     resp = await async_client.get("/api/v1/kaspi/token/health", headers=company_a_admin_headers)
     assert resp.status_code == 401
     assert resp.json().get("detail") == "NOT_AUTHENTICATED"
+
+
+@pytest.mark.asyncio
+async def test_kaspi_goods_schema_timeout_returns_502(
+    async_client, async_db_session, monkeypatch, company_a_admin_headers
+):
+    company = await async_db_session.get(Company, 1001)
+    if not company:
+        company = Company(id=1001, name="Company 1001", kaspi_store_id="store-a")
+        async_db_session.add(company)
+    else:
+        company.kaspi_store_id = "store-a"
+    await async_db_session.commit()
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    from app.services import kaspi_goods_client as goods_client
+
+    monkeypatch.setattr(goods_client.httpx, "AsyncClient", lambda *args, **kwargs: _TimeoutAsyncClient())
+
+    resp = await async_client.get("/api/v1/kaspi/goods/schema", headers=company_a_admin_headers)
+    assert resp.status_code == 502
+    assert resp.json().get("detail") == "kaspi_upstream_unavailable"
+    assert resp.json().get("code") == "HTTP_502"
+
+
+@pytest.mark.asyncio
+async def test_kaspi_goods_categories_timeout_returns_502(
+    async_client, async_db_session, monkeypatch, company_a_admin_headers
+):
+    company = await async_db_session.get(Company, 1001)
+    if not company:
+        company = Company(id=1001, name="Company 1001", kaspi_store_id="store-a")
+        async_db_session.add(company)
+    else:
+        company.kaspi_store_id = "store-a"
+    await async_db_session.commit()
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    from app.services import kaspi_goods_client as goods_client
+
+    monkeypatch.setattr(goods_client.httpx, "AsyncClient", lambda *args, **kwargs: _TimeoutAsyncClient())
+
+    resp = await async_client.get("/api/v1/kaspi/goods/categories", headers=company_a_admin_headers)
+    assert resp.status_code == 502
+    assert resp.json().get("detail") == "kaspi_upstream_unavailable"
+    assert resp.json().get("code") == "HTTP_502"


### PR DESCRIPTION
Fix: handle httpx timeouts/request errors in KaspiGoodsClient and return HTTP_502 kaspi_upstream_unavailable for schema/categories via fast timeout (8s). Adds regression tests for timeout -> 502. Local prod-gate OK.