### PR TITLE
fix(kaspi): add browser-like headers for goods client

### DIFF
--- a/app/services/kaspi_goods_client.py
+++ b/app/services/kaspi_goods_client.py
@@ -8,6 +8,12 @@ from app.core.logging import get_logger
 
 logger = get_logger(__name__)
 
+DEFAULT_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
+    "Accept": "application/json,text/plain,*/*",
+    "Accept-Language": "ru-RU,ru;q=0.9,en-US;q=0.8,en;q=0.7",
+}
+
 
 class KaspiNotAuthenticated(RuntimeError):
     """Kaspi token is invalid or not authenticated."""
@@ -23,10 +29,14 @@ class KaspiGoodsClient:
         self._fast_timeout = 8.0
 
     def _headers(self) -> dict[str, str]:
-        return {
-            "X-Auth-Token": self._token,
-            "Accept": "application/json",
-        }
+        return self._build_headers(self._token)
+
+    @staticmethod
+    def _build_headers(token: str, extra: dict[str, str] | None = None) -> dict[str, str]:
+        headers = {**DEFAULT_HEADERS, "X-Auth-Token": token}
+        if extra:
+            headers.update(extra)
+        return headers
 
     def _url(self, path: str) -> str:
         if not path.startswith("/"):
@@ -43,9 +53,10 @@ class KaspiGoodsClient:
         content_type: str | None = None,
         timeout_sec: float | None = None,
     ) -> dict:
-        headers = self._headers()
+        extra_headers: dict[str, str] = {}
         if content_type:
-            headers["Content-Type"] = content_type
+            extra_headers["Content-Type"] = content_type
+        headers = self._build_headers(self._token, extra=extra_headers)
         timeout_value = float(timeout_sec) if timeout_sec is not None else self._default_timeout
         try:
             async with httpx.AsyncClient(timeout=timeout_value) as client:

--- a/tests/app/test_kaspi_goods_api.py
+++ b/tests/app/test_kaspi_goods_api.py
@@ -3,7 +3,7 @@ import pytest
 
 from app.models.company import Company
 from app.models.marketplace import KaspiStoreToken
-from app.services.kaspi_goods_client import KaspiNotAuthenticated
+from app.services.kaspi_goods_client import KaspiGoodsClient, KaspiNotAuthenticated
 
 
 class _FakeResponse:
@@ -143,3 +143,11 @@ async def test_kaspi_goods_categories_timeout_returns_502(
     assert resp.status_code == 502
     assert resp.json().get("detail") == "kaspi_upstream_unavailable"
     assert resp.json().get("code") == "HTTP_502"
+
+
+def test_kaspi_goods_headers_builder():
+    headers = KaspiGoodsClient._build_headers("token-123")
+    assert headers["User-Agent"]
+    assert headers["Accept"] == "application/json,text/plain,*/*"
+    assert headers["Accept-Language"] == "ru-RU,ru;q=0.9,en-US;q=0.8,en;q=0.7"
+    assert headers["X-Auth-Token"] == "token-123"


### PR DESCRIPTION
Kaspi goods endpoints were timing out for httpx/curl, but respond with 401 when browser-like headers are used. Add DEFAULT_HEADERS (UA/Accept/Accept-Language) + _build_headers() helper, and a regression test. Local prod-gate OK.