### PR TITLE
chore: promote dev to main (kaspi goods import + sync now)

### DIFF
--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -27,6 +27,7 @@ app/api/v1/kaspi.py — Полный, боевой роутер интеграц
 """
 
 import csv
+import hashlib
 import inspect
 import io
 import json
@@ -44,6 +45,7 @@ from xml.etree import ElementTree as ET
 import httpx
 import sqlalchemy as sa
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, Response, UploadFile, status
+from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from openpyxl import load_workbook
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -82,11 +84,21 @@ from app.services.integration_events import record_integration_event
 from app.services.kaspi_feed_upload_service import (
     create_feed_upload_job,
     get_feed_upload_by_request_id,
-    mark_feed_upload_attempt,
     normalize_kaspi_payload,
     update_feed_upload_job,
 )
 from app.services.kaspi_goods_client import KaspiGoodsClient, KaspiNotAuthenticated
+from app.services.kaspi_goods_import_client import (
+    KaspiGoodsImportClient,
+    KaspiImportNotAuthenticated,
+    KaspiImportUpstreamError,
+    KaspiImportUpstreamUnavailable,
+)
+from app.services.kaspi_goods_import_service import (
+    build_payload_json,
+    compute_payload_hash,
+    load_offers_payload,
+)
 from app.services.kaspi_mc_sync import mark_mc_session_error, sync_kaspi_mc_offers
 from app.services.kaspi_service import KaspiService, KaspiSyncAlreadyRunning
 from app.services.otp_providers import is_otp_active, require_otp_provider_or_admin_bypass
@@ -132,6 +144,46 @@ def _resolve_company_id(current_user: User) -> int:
 def _require_admin(current_user: User) -> None:
     if not (current_user.is_superuser or current_user.role == "admin"):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
+
+
+def _load_company_settings(company: Company | None) -> dict[str, Any]:
+    if not company or not company.settings:
+        return {}
+    try:
+        return json.loads(company.settings) or {}
+    except (TypeError, json.JSONDecodeError):
+        return {}
+
+
+def _get_goods_import_flags(company: Company | None, merchant_uid: str) -> dict[str, bool]:
+    settings_obj = _load_company_settings(company)
+    defaults = {
+        "include_price": bool(settings_obj.get("kaspi.goods_import.include_price", False)),
+        "include_stock": bool(settings_obj.get("kaspi.goods_import.include_stock", False)),
+    }
+    merchant_map = settings_obj.get("kaspi.goods_import.merchants") or {}
+    merchant_cfg = merchant_map.get(merchant_uid) if isinstance(merchant_map, dict) else None
+    if isinstance(merchant_cfg, dict):
+        defaults["include_price"] = bool(merchant_cfg.get("include_price", defaults["include_price"]))
+        defaults["include_stock"] = bool(merchant_cfg.get("include_stock", defaults["include_stock"]))
+    return defaults
+
+
+def _sync_now_lock_key(company_id: int, merchant_uid: str) -> int:
+    raw = f"kaspi-sync-now-{company_id}-{merchant_uid}".encode()
+    h = int.from_bytes(hashlib.sha1(raw).digest()[:8], "big", signed=False)
+    return h % (2**63 - 1)
+
+
+async def _try_sync_now_lock(session: AsyncSession, *, company_id: int, merchant_uid: str) -> bool:
+    lock_key = _sync_now_lock_key(company_id, merchant_uid)
+    res = await session.execute(text("SELECT pg_try_advisory_lock(:lock_key)").bindparams(lock_key=lock_key))
+    return bool(res.scalar_one_or_none())
+
+
+async def _release_sync_now_lock(session: AsyncSession, *, company_id: int, merchant_uid: str) -> None:
+    lock_key = _sync_now_lock_key(company_id, merchant_uid)
+    await session.execute(text("SELECT pg_advisory_unlock(:lock_key)").bindparams(lock_key=lock_key))
 
 
 async def _resolve_kaspi_token(session: AsyncSession, company_id: int) -> tuple[str, str]:
@@ -550,8 +602,12 @@ def _goods_import_to_out(record: KaspiGoodsImport) -> KaspiGoodsImportRecordOut:
         merchant_uid=record.merchant_uid,
         import_code=record.import_code,
         status=record.status,
+        source=record.source,
+        payload_hash=record.payload_hash,
+        attempts=record.attempts,
         request_json=record.request_json,
         status_json=record.status_json,
+        raw_status_json=record.raw_status_json,
         result_json=record.result_json,
         error_code=record.error_code,
         error_message=record.error_message,
@@ -1533,8 +1589,11 @@ class KaspiGoodsImportIn(BaseModel):
 
 
 class KaspiGoodsImportCreateIn(BaseModel):
-    payload: list[dict[str, Any]] | dict[str, Any]
-    content_type: str | None = None
+    model_config = ConfigDict(populate_by_name=True)
+
+    merchant_uid: str = Field(..., min_length=1, alias="merchantUid")
+    source: str = Field("db")
+    comment: str | None = None
 
 
 class KaspiGoodsImportOut(BaseModel):
@@ -1566,8 +1625,12 @@ class KaspiGoodsImportRecordOut(BaseModel):
     merchant_uid: str | None = None
     import_code: str
     status: str
+    source: str | None = None
+    payload_hash: str | None = None
+    attempts: int | None = None
     request_json: list[dict[str, Any]] | dict[str, Any]
     status_json: dict[str, Any] | None = None
+    raw_status_json: dict[str, Any] | None = None
     result_json: dict[str, Any] | None = None
     error_code: str | None = None
     error_message: str | None = None
@@ -1575,6 +1638,22 @@ class KaspiGoodsImportRecordOut(BaseModel):
     updated_at: datetime
     last_checked_at: datetime | None = None
     revoked_at: datetime | None = None
+
+
+class KaspiSyncNowIn(BaseModel):
+    merchant_uid: str = Field(..., min_length=1)
+    refresh_once: bool = True
+
+
+class KaspiSyncNowOut(BaseModel):
+    ok: bool
+    company_id: int
+    merchant_uid: str
+    orders_sync: dict[str, Any] | None = None
+    goods_import_id: str | None = None
+    goods_import_code: str | None = None
+    goods_import_status: str | None = None
+    feed_last_generated_at: datetime | None = None
 
 
 class KaspiFeedUploadIn(BaseModel):
@@ -2016,42 +2095,77 @@ async def kaspi_goods_import_result(
 )
 async def kaspi_goods_import_create(
     body: KaspiGoodsImportCreateIn,
-    merchant_uid: str | None = Query(None, alias="merchantUid"),
     current_user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_db),
 ):
     _require_admin(current_user)
-    if not merchant_uid or not merchant_uid.strip():
+
+    merchant_uid = (body.merchant_uid or "").strip()
+    if not merchant_uid:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="missing_merchant_uid")
+    source = (body.source or "db").strip() or "db"
+    if source != "db":
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid_source")
 
     company_id = _resolve_company_id(current_user)
+    company = await session.get(Company, company_id)
     _, token = await _resolve_kaspi_token(session, company_id)
-    payload = _normalize_goods_payload(body.payload)
 
-    client = KaspiGoodsClient(token=token, base_url="https://kaspi.kz")
+    from app.services.kaspi_goods_import_client import (
+        KaspiGoodsImportClient,
+        KaspiImportNotAuthenticated,
+        KaspiImportUpstreamError,
+        KaspiImportUpstreamUnavailable,
+    )
+    from app.services.kaspi_goods_import_service import (
+        build_payload_json,
+        compute_payload_hash,
+        load_offers_payload,
+    )
+
+    flags = _get_goods_import_flags(company, merchant_uid)
+    payload = await load_offers_payload(
+        session,
+        company_id=company_id,
+        merchant_uid=merchant_uid,
+        include_price=flags["include_price"],
+        include_stock=flags["include_stock"],
+    )
+    if not payload:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="offers_not_found")
+
+    payload_json = build_payload_json(payload)
+    payload_hash = compute_payload_hash(payload_json)
+
+    client = KaspiGoodsImportClient(token=token, base_url="https://kaspi.kz")
     try:
-        response = await client.post_import(payload, content_type=body.content_type or "text/plain")
-    except KaspiNotAuthenticated as exc:
+        response = await client.submit_import(payload_json)
+    except KaspiImportNotAuthenticated as exc:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="NOT_AUTHENTICATED") from exc
-    except httpx.HTTPStatusError:
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_upstream_error")
-    except httpx.RequestError:
+    except KaspiImportUpstreamUnavailable:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_upstream_unavailable")
+    except KaspiImportUpstreamError:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_upstream_error")
 
     import_code = _extract_import_code(response)
     if not import_code:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_import_code_missing")
 
-    status_value = response.get("status") or "submitted"
+    status_value = response.get("status") or "UPLOADED"
     now = datetime.utcnow()
 
     record = KaspiGoodsImport(
         company_id=company_id,
         created_by_user_id=current_user.id,
-        merchant_uid=merchant_uid.strip(),
+        merchant_uid=merchant_uid,
         import_code=str(import_code),
         status=str(status_value),
+        source=source,
+        comment=body.comment,
+        payload_hash=payload_hash,
+        attempts=1,
         request_json=payload,
+        raw_status_json=response,
         status_json=response,
         result_json=None,
         error_code=None,
@@ -2066,6 +2180,31 @@ async def kaspi_goods_import_create(
     await session.refresh(record)
 
     return _goods_import_to_out(record)
+
+
+@router.get(
+    "/goods/imports",
+    summary="List Kaspi goods imports",
+    response_model=list[KaspiGoodsImportRecordOut],
+)
+async def kaspi_goods_import_list(
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    _require_admin(current_user)
+    company_id = _resolve_company_id(current_user)
+
+    result = await session.execute(
+        sa.select(KaspiGoodsImport)
+        .where(KaspiGoodsImport.company_id == company_id)
+        .order_by(KaspiGoodsImport.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    records = result.scalars().all()
+    return [_goods_import_to_out(record) for record in records]
 
 
 @router.get(
@@ -2105,6 +2244,7 @@ async def kaspi_goods_import_get(
 )
 async def kaspi_goods_import_refresh(
     import_id: str,
+    request: Request,
     current_user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_db),
 ):
@@ -2126,31 +2266,48 @@ async def kaspi_goods_import_refresh(
     if not record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="import_not_found")
 
+    if not record.import_code:
+        rid = getattr(getattr(request, "state", None), "request_id", None) or request.headers.get("X-Request-ID")
+        if not rid:
+            rid = str(uuid4())
+        payload = {
+            "detail": "kaspi_import_missing_code",
+            "code": "kaspi_import_missing_code",
+            "request_id": rid or "",
+        }
+        return JSONResponse(status_code=status.HTTP_409_CONFLICT, content=payload, headers={"X-Request-ID": rid})
+
     _, token = await _resolve_kaspi_token(session, company_id)
-    client = KaspiGoodsClient(token=token, base_url="https://kaspi.kz")
+    from app.services.kaspi_goods_import_client import (
+        KaspiGoodsImportClient,
+        KaspiImportNotAuthenticated,
+        KaspiImportUpstreamError,
+        KaspiImportUpstreamUnavailable,
+    )
+
+    client = KaspiGoodsImportClient(token=token, base_url="https://kaspi.kz")
     now = datetime.utcnow()
     try:
-        status_response = await client.get_import_status(import_code=record.import_code)
-        result_response = await client.get_import_result(import_code=record.import_code)
-    except KaspiNotAuthenticated as exc:
+        status_response = await client.get_status(import_code=record.import_code)
+    except KaspiImportNotAuthenticated as exc:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="NOT_AUTHENTICATED") from exc
-    except httpx.HTTPStatusError as exc:
-        record.error_code = str(getattr(exc.response, "status_code", "")) or "kaspi_http_error"
-        record.error_message = "kaspi_upstream_error"
-        record.last_checked_at = now
-        await session.commit()
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_upstream_error")
-    except httpx.RequestError:
-        record.error_code = "kaspi_request_error"
+    except KaspiImportUpstreamUnavailable:
+        record.error_code = "upstream_unavailable"
         record.error_message = "kaspi_upstream_unavailable"
         record.last_checked_at = now
         await session.commit()
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_upstream_unavailable")
+    except KaspiImportUpstreamError:
+        record.error_code = "upstream_error"
+        record.error_message = "kaspi_upstream_error"
+        record.last_checked_at = now
+        await session.commit()
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_upstream_error")
 
     status_value = status_response.get("status") or record.status
     record.status = str(status_value)
+    record.raw_status_json = status_response
     record.status_json = status_response
-    record.result_json = result_response
     record.error_code = None
     record.error_message = None
     record.last_checked_at = now
@@ -2158,6 +2315,176 @@ async def kaspi_goods_import_refresh(
     await session.refresh(record)
 
     return _goods_import_to_out(record)
+
+
+@router.post(
+    "/sync/now",
+    summary="Kaspi sync now",
+    response_model=KaspiSyncNowOut,
+)
+async def kaspi_sync_now(
+    request: Request,
+    body: KaspiSyncNowIn,
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_async_db),
+):
+    _require_admin(current_user)
+
+    merchant_uid = (body.merchant_uid or "").strip()
+    if not merchant_uid:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="missing_merchant_uid")
+
+    company_id = _resolve_company_id(current_user)
+    request_id = getattr(getattr(request, "state", None), "request_id", None)
+
+    lock_acquired = await _try_sync_now_lock(session, company_id=company_id, merchant_uid=merchant_uid)
+    if not lock_acquired:
+        rid = request_id or request.headers.get("X-Request-ID") or str(uuid4())
+        payload = {
+            "detail": "kaspi_sync_in_progress",
+            "code": "kaspi_sync_in_progress",
+            "request_id": rid,
+        }
+        return JSONResponse(status_code=status.HTTP_409_CONFLICT, content=payload, headers={"X-Request-ID": rid})
+
+    try:
+        logger.info(
+            "Kaspi sync now started",
+            extra={"company_id": company_id, "merchant_uid": merchant_uid, "request_id": request_id},
+        )
+
+        orders_result = await KaspiService().sync_orders(
+            db=session,
+            company_id=company_id,
+            request_id=request_id,
+        )
+
+        company = await session.get(Company, company_id)
+        flags = _get_goods_import_flags(company, merchant_uid)
+        payload = await load_offers_payload(
+            session,
+            company_id=company_id,
+            merchant_uid=merchant_uid,
+            include_price=flags["include_price"],
+            include_stock=flags["include_stock"],
+        )
+        if not payload:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="offers_not_found")
+
+        payload_json = build_payload_json(payload)
+        payload_hash = compute_payload_hash(payload_json)
+
+        _, token = await _resolve_kaspi_token(session, company_id)
+        import_client = KaspiGoodsImportClient(token=token, base_url="https://kaspi.kz")
+        try:
+            response = await import_client.submit_import(payload_json)
+        except KaspiImportNotAuthenticated as exc:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="NOT_AUTHENTICATED") from exc
+        except KaspiImportUpstreamUnavailable:
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_upstream_unavailable")
+        except KaspiImportUpstreamError:
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_upstream_error")
+
+        import_code = _extract_import_code(response)
+        if not import_code:
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_import_code_missing")
+
+        status_value = response.get("status") or "UPLOADED"
+        now = datetime.utcnow()
+
+        record = KaspiGoodsImport(
+            company_id=company_id,
+            created_by_user_id=current_user.id,
+            merchant_uid=merchant_uid,
+            import_code=str(import_code),
+            status=str(status_value),
+            source="db",
+            payload_hash=payload_hash,
+            attempts=1,
+            request_json=payload,
+            raw_status_json=response,
+            status_json=response,
+            result_json=None,
+            error_code=None,
+            error_message=None,
+            last_checked_at=now,
+            request_payload=payload,
+            result_payload=None,
+            last_error=None,
+        )
+        session.add(record)
+        await session.commit()
+        await session.refresh(record)
+
+        if body.refresh_once:
+            try:
+                status_response = await import_client.get_status(import_code=str(import_code))
+                record.status = str(status_response.get("status") or record.status)
+                record.raw_status_json = status_response
+                record.status_json = status_response
+                record.last_checked_at = datetime.utcnow()
+                await session.commit()
+                await session.refresh(record)
+            except KaspiImportNotAuthenticated as exc:
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="NOT_AUTHENTICATED") from exc
+            except KaspiImportUpstreamUnavailable:
+                record.error_code = "upstream_unavailable"
+                record.error_message = "kaspi_upstream_unavailable"
+                record.last_checked_at = datetime.utcnow()
+                await session.commit()
+                raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_upstream_unavailable")
+            except KaspiImportUpstreamError:
+                record.error_code = "upstream_error"
+                record.error_message = "kaspi_upstream_error"
+                record.last_checked_at = datetime.utcnow()
+                await session.commit()
+                raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_upstream_error")
+
+        offers = (
+            (
+                await session.execute(
+                    sa.select(KaspiOffer)
+                    .where(
+                        KaspiOffer.company_id == company_id,
+                        KaspiOffer.merchant_uid == merchant_uid,
+                    )
+                    .order_by(KaspiOffer.updated_at.desc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if not offers:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="offers_not_found")
+
+        company_name = (company.name if company else None) or f"Company {company_id}"
+        _build_kaspi_offers_xml(offers, company=company_name, merchant_id=merchant_uid)
+
+        settings_obj = _load_company_settings(company)
+        generated_at = datetime.utcnow()
+        settings_obj["kaspi.feed_last_generated_at"] = generated_at.isoformat()
+        settings_obj["kaspi.feed_last_generated_merchant_uid"] = merchant_uid
+        if company is not None:
+            company.settings = json.dumps(settings_obj, ensure_ascii=False, separators=(",", ":"))
+            await session.commit()
+
+        logger.info(
+            "Kaspi sync now finished",
+            extra={"company_id": company_id, "merchant_uid": merchant_uid, "request_id": request_id},
+        )
+
+        return KaspiSyncNowOut(
+            ok=True,
+            company_id=company_id,
+            merchant_uid=merchant_uid,
+            orders_sync=orders_result,
+            goods_import_id=str(record.id),
+            goods_import_code=str(import_code),
+            goods_import_status=record.status,
+            feed_last_generated_at=generated_at,
+        )
+    finally:
+        await _release_sync_now_lock(session, company_id=company_id, merchant_uid=merchant_uid)
 
 
 @router.get(
@@ -3319,7 +3646,12 @@ async def kaspi_feed_upload_create(
         request_id=request_id,
         comment=body.comment,
     )
-    await mark_feed_upload_attempt(session, job=job)
+    now_attempt = datetime.utcnow()
+    job.attempts = int(job.attempts or 0) + 1
+    job.last_attempt_at = now_attempt
+    job.updated_at = now_attempt
+    await session.commit()
+    await session.refresh(job)
 
     tmp_dir = settings.tmp_dir()
     tmp_dir.mkdir(parents=True, exist_ok=True)
@@ -3338,8 +3670,9 @@ async def kaspi_feed_upload_create(
             session,
             job=job,
             status="failed",
-            error_code="kaspi_upstream_unavailable",
+            error_code="upstream_unavailable",
             error_message=str(exc)[:500],
+            last_attempt_at=now_attempt,
         )
         await _record_kaspi_event(
             session,
@@ -3348,19 +3681,21 @@ async def kaspi_feed_upload_create(
             kind="kaspi_feed",
             status="error",
             request_id=request_id,
-            error_code="kaspi_upstream_unavailable",
+            error_code="upstream_unavailable",
             error_message=str(exc)[:500],
             meta_json={"upload_id": str(job.id), "import_code": None},
         )
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_upstream_unavailable") from exc
+        payload = jsonable_encoder(_feed_upload_to_out(job))
+        return JSONResponse(status_code=status.HTTP_201_CREATED, content=payload)
     except Exception as exc:
         logger.error("Kaspi feed upload failed: company_id=%s error=%s", company_id, exc)
         await update_feed_upload_job(
             session,
             job=job,
             status="failed",
-            error_code="kaspi_feed_upload_failed",
+            error_code="upstream_unavailable",
             error_message=str(exc)[:500],
+            last_attempt_at=now_attempt,
         )
         await _record_kaspi_event(
             session,
@@ -3369,11 +3704,12 @@ async def kaspi_feed_upload_create(
             kind="kaspi_feed",
             status="error",
             request_id=request_id,
-            error_code="kaspi_feed_upload_failed",
+            error_code="upstream_unavailable",
             error_message=str(exc)[:500],
             meta_json={"upload_id": str(job.id), "import_code": None},
         )
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi_feed_upload_failed") from exc
+        payload = jsonable_encoder(_feed_upload_to_out(job))
+        return JSONResponse(status_code=status.HTTP_201_CREATED, content=payload)
     finally:
         try:
             if tmp_path.exists():

--- a/app/models/kaspi_feed_upload.py
+++ b/app/models/kaspi_feed_upload.py
@@ -22,6 +22,7 @@ class KaspiFeedUpload(Base):
     attempts = Column(Integer, nullable=False, server_default=text("0"))
     last_error_code = Column(String(64), nullable=True)
     last_error_message = Column(Text, nullable=True)
+    last_attempt_at = Column(DateTime, nullable=True)
     request_id = Column(String(128), nullable=True, index=True)
 
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/app/models/kaspi_goods_import.py
+++ b/app/models/kaspi_goods_import.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, ForeignKey, String, Text, text
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 from app.models.base import Base
@@ -20,7 +20,10 @@ class KaspiGoodsImport(Base):
     status = Column(String(64), nullable=False, server_default=text("'created'"))
     source = Column(String(32), nullable=True, index=True)
     comment = Column(Text, nullable=True)
+    payload_hash = Column(String(64), nullable=True, index=True)
+    attempts = Column(Integer, nullable=False, server_default=text("0"))
     request_json = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
+    raw_status_json = Column(JSONB, nullable=True)
     status_json = Column(JSONB, nullable=True)
     result_json = Column(JSONB, nullable=True)
     error_code = Column(String(64), nullable=True)

--- a/app/services/kaspi_feed_upload_service.py
+++ b/app/services/kaspi_feed_upload_service.py
@@ -60,6 +60,7 @@ async def mark_feed_upload_attempt(
     *,
     job: KaspiFeedUpload,
 ) -> KaspiFeedUpload:
+    job.last_attempt_at = datetime.utcnow()
     job.attempts = int(job.attempts or 0) + 1
     job.updated_at = datetime.utcnow()
     await session.commit()
@@ -75,6 +76,7 @@ async def update_feed_upload_job(
     import_code: str | None = None,
     error_code: str | None = None,
     error_message: str | None = None,
+    last_attempt_at: datetime | None = None,
 ) -> KaspiFeedUpload:
     if status is not None:
         job.status = status
@@ -82,6 +84,8 @@ async def update_feed_upload_job(
         job.import_code = import_code
     job.last_error_code = error_code
     job.last_error_message = error_message
+    if last_attempt_at is not None:
+        job.last_attempt_at = last_attempt_at
     job.updated_at = datetime.utcnow()
     await session.commit()
     await session.refresh(job)

--- a/app/services/kaspi_goods_import_client.py
+++ b/app/services/kaspi_goods_import_client.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import httpx
+
+from app.services.kaspi_goods_client import DEFAULT_HEADERS
+
+
+class KaspiImportUpstreamUnavailable(RuntimeError):
+    """Kaspi import upstream unavailable (timeouts/network/5xx)."""
+
+
+class KaspiImportUpstreamError(RuntimeError):
+    """Kaspi import upstream error (4xx or unexpected)."""
+
+
+class KaspiImportNotAuthenticated(RuntimeError):
+    """Kaspi token is invalid or not authenticated."""
+
+
+class KaspiGoodsImportClient:
+    def __init__(
+        self,
+        *,
+        token: str,
+        base_url: str = "https://kaspi.kz",
+        timeout_seconds: float = 8.0,
+        max_attempts: int = 2,
+    ) -> None:
+        if not token:
+            raise ValueError("kaspi_token_required")
+        self._token = token
+        self._base_url = base_url.rstrip("/")
+        self._timeout = httpx.Timeout(timeout_seconds, connect=5.0, read=timeout_seconds, write=timeout_seconds)
+        self._max_attempts = max(1, min(int(max_attempts), 3))
+
+    def _url(self, path: str) -> str:
+        if not path.startswith("/"):
+            path = "/" + path
+        return f"{self._base_url}{path}"
+
+    def _headers(self, content_type: str | None = None) -> dict[str, str]:
+        headers = {**DEFAULT_HEADERS, "X-Auth-Token": self._token}
+        if content_type:
+            headers["Content-Type"] = content_type
+        return headers
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        content: str | bytes | None = None,
+        content_type: str | None = None,
+    ) -> dict:
+        last_exc: Exception | None = None
+        for attempt in range(self._max_attempts):
+            try:
+                async with httpx.AsyncClient(timeout=self._timeout, follow_redirects=True) as client:
+                    resp = await client.request(
+                        method,
+                        self._url(path),
+                        headers=self._headers(content_type),
+                        params=params,
+                        content=content,
+                    )
+                if resp.status_code in {401, 403}:
+                    raise KaspiImportNotAuthenticated("Kaspi token is not authenticated")
+                if resp.status_code >= 500:
+                    raise KaspiImportUpstreamUnavailable("kaspi_upstream_unavailable")
+                resp.raise_for_status()
+                return resp.json() if resp.content else {}
+            except (httpx.TimeoutException, httpx.RequestError) as exc:
+                last_exc = exc
+                if attempt + 1 < self._max_attempts:
+                    continue
+                raise KaspiImportUpstreamUnavailable("kaspi_upstream_unavailable") from exc
+            except httpx.HTTPStatusError as exc:
+                last_exc = exc
+                if exc.response is not None and exc.response.status_code >= 500:
+                    if attempt + 1 < self._max_attempts:
+                        continue
+                    raise KaspiImportUpstreamUnavailable("kaspi_upstream_unavailable") from exc
+                raise KaspiImportUpstreamError("kaspi_upstream_error") from exc
+        if last_exc:
+            raise KaspiImportUpstreamUnavailable("kaspi_upstream_unavailable") from last_exc
+        raise KaspiImportUpstreamUnavailable("kaspi_upstream_unavailable")
+
+    async def submit_import(self, payload_json: str) -> dict:
+        return await self._request(
+            "POST",
+            "/shop/api/products/import",
+            content=payload_json,
+            content_type="text/plain",
+        )
+
+    async def get_status(self, import_code: str) -> dict:
+        return await self._request(
+            "GET",
+            "/shop/api/products/import",
+            params={"i": import_code},
+        )
+
+    async def get_schema(self) -> dict:
+        return await self._request("GET", "/shop/api/products/import/schema")

--- a/app/services/kaspi_goods_import_service.py
+++ b/app/services/kaspi_goods_import_service.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from hashlib import sha256
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.kaspi_offer import KaspiOffer
+
+
+def build_goods_import_payload(
+    offers: list[KaspiOffer],
+    *,
+    include_price: bool = False,
+    include_stock: bool = False,
+) -> list[dict[str, Any]]:
+    payload: list[dict[str, Any]] = []
+    sorted_offers = sorted(offers, key=lambda item: (item.sku or "", item.id))
+    for offer in sorted_offers:
+        sku = (offer.sku or "").strip() or f"SKU-{offer.id}"
+        name = (offer.title or "").strip() or sku
+        item: dict[str, Any] = {
+            "sku": sku,
+            "name": name,
+        }
+        if include_price and offer.price is not None:
+            item["price"] = float(offer.price)
+        if include_stock and offer.stock_count is not None:
+            item["stockCount"] = int(offer.stock_count)
+        payload.append(item)
+    return payload
+
+
+def build_payload_json(payload: list[dict[str, Any]]) -> str:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def compute_payload_hash(payload_json: str) -> str:
+    return sha256(payload_json.encode("utf-8")).hexdigest()
+
+
+async def load_offers_payload(
+    session: AsyncSession,
+    *,
+    company_id: int,
+    merchant_uid: str,
+    include_price: bool = False,
+    include_stock: bool = False,
+) -> list[dict[str, Any]]:
+    result = await session.execute(
+        sa.select(KaspiOffer)
+        .where(
+            KaspiOffer.company_id == company_id,
+            KaspiOffer.merchant_uid == merchant_uid,
+        )
+        .order_by(KaspiOffer.sku.asc())
+    )
+    offers = result.scalars().all()
+    return build_goods_import_payload(offers, include_price=include_price, include_stock=include_stock)

--- a/migrations/versions/20260130_kaspi_feed_uploads_last_attempt_at.py
+++ b/migrations/versions/20260130_kaspi_feed_uploads_last_attempt_at.py
@@ -1,0 +1,24 @@
+"""feat(kaspi): add last_attempt_at to feed uploads
+
+Revision ID: 20260130_kaspi_feed_uploads_last_attempt_at
+Revises: 20260130_kaspi_feed_uploads_export_id
+Create Date: 2026-01-30 00:00:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20260130_kaspi_feed_uploads_last_attempt_at"
+down_revision: Union[str, Sequence[str], None] = "20260130_kaspi_feed_uploads_export_id"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("kaspi_feed_uploads", sa.Column("last_attempt_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("kaspi_feed_uploads", "last_attempt_at")

--- a/migrations/versions/20260130_kaspi_goods_imports_official_columns.py
+++ b/migrations/versions/20260130_kaspi_goods_imports_official_columns.py
@@ -1,0 +1,37 @@
+"""feat(kaspi): add goods import official columns
+
+Revision ID: 20260130_kaspi_goods_imports_official_columns
+Revises: 20260130_kaspi_feed_uploads_last_attempt_at
+Create Date: 2026-01-30 00:00:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260130_kaspi_goods_imports_official_columns"
+down_revision: Union[str, Sequence[str], None] = "20260130_kaspi_feed_uploads_last_attempt_at"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("kaspi_goods_imports", sa.Column("payload_hash", sa.String(length=64), nullable=True))
+    op.add_column(
+        "kaspi_goods_imports",
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default=sa.text("0")),
+    )
+    op.add_column(
+        "kaspi_goods_imports",
+        sa.Column("raw_status_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    op.create_index("ix_kaspi_goods_imports_payload_hash", "kaspi_goods_imports", ["payload_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_kaspi_goods_imports_payload_hash", table_name="kaspi_goods_imports")
+    op.drop_column("kaspi_goods_imports", "raw_status_json")
+    op.drop_column("kaspi_goods_imports", "attempts")
+    op.drop_column("kaspi_goods_imports", "payload_hash")

--- a/tests/app/test_kaspi_feed_uploads.py
+++ b/tests/app/test_kaspi_feed_uploads.py
@@ -50,6 +50,11 @@ class _FakeKaspiAdapter:
         return {"importCode": import_id, "status": "done"}
 
 
+class _FailingKaspiAdapter:
+    def feed_upload(self, *args, **kwargs):
+        raise RuntimeError("upstream_unavailable")
+
+
 async def _ensure_company(async_db_session, company_id: int, store_id: str) -> None:
     company = await async_db_session.get(Company, company_id)
     if not company:
@@ -335,6 +340,54 @@ async def test_kaspi_feed_upload_publish(
     assert publish_resp.status_code == 200
     publish_data = publish_resp.json()
     assert publish_data["status"] == "published"
+
+
+@pytest.mark.asyncio
+async def test_kaspi_feed_upload_upstream_error_returns_201(
+    async_client,
+    async_db_session,
+    company_a_admin_headers,
+    monkeypatch,
+):
+    await _ensure_company(async_db_session, 1001, "store-a")
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    offer = KaspiOffer(
+        company_id=1001,
+        merchant_uid="M123",
+        sku="SKU-1",
+        title="Item 1",
+        price=1000,
+    )
+    async_db_session.add(offer)
+    await async_db_session.commit()
+
+    from app.api.v1 import kaspi as kaspi_module
+
+    monkeypatch.setattr(kaspi_module, "KaspiAdapter", lambda: _FailingKaspiAdapter())
+
+    resp = await async_client.post(
+        "/api/v1/kaspi/feed/uploads",
+        headers=company_a_admin_headers,
+        json={"merchant_uid": "M123", "source": "public_token"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["status"] == "failed"
+    assert data["last_error_code"] == "upstream_unavailable"
+
+    record = (
+        (await async_db_session.execute(select(KaspiFeedUpload).where(KaspiFeedUpload.company_id == 1001)))
+        .scalars()
+        .first()
+    )
+    assert record is not None
+    assert record.status == "failed"
+    assert record.last_error_code == "upstream_unavailable"
 
 
 @pytest.mark.asyncio

--- a/tests/app/test_kaspi_goods_imports.py
+++ b/tests/app/test_kaspi_goods_imports.py
@@ -4,7 +4,9 @@ import sqlalchemy as sa
 
 from app.models.company import Company
 from app.models.kaspi_goods_import import KaspiGoodsImport
+from app.models.kaspi_offer import KaspiOffer
 from app.models.marketplace import KaspiStoreToken
+from app.services.kaspi_goods_import_service import build_goods_import_payload, build_payload_json, compute_payload_hash
 
 
 class _FakeResponse:
@@ -36,7 +38,7 @@ class _FakeAsyncClient:
     async def __aexit__(self, exc_type, exc, tb):
         return False
 
-    async def request(self, method, url, headers=None, params=None, json=None, files=None):
+    async def request(self, method, url, headers=None, params=None, json=None, files=None, content=None):
         self._recorder.append(
             {
                 "method": method,
@@ -45,6 +47,7 @@ class _FakeAsyncClient:
                 "params": params,
                 "json": json,
                 "files": files,
+                "content": content,
             }
         )
         return self._responses.pop(0) if self._responses else _FakeResponse(200)
@@ -68,6 +71,16 @@ async def test_kaspi_goods_import_create_and_refresh(
 ):
     await _ensure_company(async_db_session, 1001, "store-a")
 
+    offer = KaspiOffer(
+        company_id=1001,
+        merchant_uid="M1",
+        sku="S1",
+        title="Item 1",
+        price=1000,
+    )
+    async_db_session.add(offer)
+    await async_db_session.commit()
+
     async def _get_token(session, store_name: str):
         return "token-a"
 
@@ -77,20 +90,20 @@ async def test_kaspi_goods_import_create_and_refresh(
     responses = [
         _FakeResponse(200, {"importCode": "IC-1", "status": "submitted"}),
     ]
-    from app.services import kaspi_goods_client
+    from app.services import kaspi_goods_import_client
 
     monkeypatch.setattr(
-        kaspi_goods_client.httpx,
+        kaspi_goods_import_client.httpx,
         "AsyncClient",
         lambda *args, **kwargs: _FakeAsyncClient(responses, recorder),
     )
 
-    payload = [{"sku": "S1", "name": "Item 1", "price": 1000}]
+    payload = build_goods_import_payload([offer])
+    payload_json = build_payload_json(payload)
     resp = await async_client.post(
         "/api/v1/kaspi/goods/imports",
         headers=company_a_admin_headers,
-        params={"merchantUid": "M1"},
-        json={"payload": payload},
+        json={"merchant_uid": "M1", "source": "db"},
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -101,17 +114,16 @@ async def test_kaspi_goods_import_create_and_refresh(
     assert recorder[0]["url"].endswith("/shop/api/products/import")
     assert recorder[0]["headers"]["X-Auth-Token"] == "token-a"
     assert recorder[0]["headers"]["Content-Type"] == "text/plain"
-    assert recorder[0]["json"] == payload
+    assert recorder[0]["content"] == payload_json
 
     import_id = data["id"]
 
     recorder.clear()
     responses = [
         _FakeResponse(200, {"status": "processing"}),
-        _FakeResponse(200, {"status": "done", "items": []}),
     ]
     monkeypatch.setattr(
-        kaspi_goods_client.httpx,
+        kaspi_goods_import_client.httpx,
         "AsyncClient",
         lambda *args, **kwargs: _FakeAsyncClient(responses, recorder),
     )
@@ -124,15 +136,15 @@ async def test_kaspi_goods_import_create_and_refresh(
     refresh_data = refresh_resp.json()
     assert refresh_data["status"] == "processing"
     assert refresh_data["status_json"]["status"] == "processing"
-    assert refresh_data["result_json"]["status"] == "done"
+    assert refresh_data["raw_status_json"]["status"] == "processing"
 
     assert recorder[0]["method"] == "GET"
     assert recorder[0]["url"].endswith("/shop/api/products/import")
     assert recorder[0]["params"] == {"i": "IC-1"}
 
-    assert recorder[1]["method"] == "GET"
-    assert recorder[1]["url"].endswith("/shop/api/products/import/result")
-    assert recorder[1]["params"] == {"i": "IC-1"}
+    assert recorder[0]["method"] == "GET"
+    assert recorder[0]["url"].endswith("/shop/api/products/import")
+    assert recorder[0]["params"] == {"i": "IC-1"}
 
 
 @pytest.mark.asyncio
@@ -178,27 +190,34 @@ async def test_kaspi_goods_import_handles_upstream_error(
 ):
     await _ensure_company(async_db_session, 1001, "store-a")
 
+    offer = KaspiOffer(
+        company_id=1001,
+        merchant_uid="M1",
+        sku="S1",
+        title="Item 1",
+        price=1000,
+    )
+    async_db_session.add(offer)
+    await async_db_session.commit()
+
     async def _get_token(session, store_name: str):
         return "token-a"
 
     monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
 
     async def _raise_error(*args, **kwargs):
-        raise httpx.HTTPStatusError(
-            "error",
-            request=httpx.Request("POST", "https://kaspi.kz"),
-            response=httpx.Response(500),
-        )
+        from app.services.kaspi_goods_import_client import KaspiImportUpstreamError
 
-    from app.services.kaspi_goods_client import KaspiGoodsClient
+        raise KaspiImportUpstreamError("kaspi_upstream_error")
 
-    monkeypatch.setattr(KaspiGoodsClient, "post_import", _raise_error)
+    from app.services.kaspi_goods_import_client import KaspiGoodsImportClient
+
+    monkeypatch.setattr(KaspiGoodsImportClient, "submit_import", _raise_error)
 
     resp = await async_client.post(
         "/api/v1/kaspi/goods/imports",
         headers=company_a_admin_headers,
-        params={"merchantUid": "M1"},
-        json={"payload": [{"sku": "S1"}]},
+        json={"merchant_uid": "M1", "source": "db"},
     )
     assert resp.status_code == 502
     assert resp.json().get("detail") == "kaspi_upstream_error"
@@ -261,6 +280,34 @@ async def test_kaspi_goods_import_upload_mvp(
     assert record.filename == "goods.csv"
     assert record.merchant_uid == "M1"
     assert "IC-UP-1" in (record.raw_response or "")
+
+
+def test_goods_import_payload_builder_is_deterministic():
+    offer_a = KaspiOffer(id=2, sku="B", title="B item", price=200, company_id=1, merchant_uid="M1")
+    offer_b = KaspiOffer(id=1, sku="A", title="A item", price=100, company_id=1, merchant_uid="M1")
+    payload = build_goods_import_payload([offer_a, offer_b])
+    payload_json = build_payload_json(payload)
+    payload_hash = compute_payload_hash(payload_json)
+
+    assert payload[0]["sku"] == "A"
+    assert all("merchant_uid" not in item for item in payload)
+    assert all("price" not in item for item in payload)
+    assert payload_hash == compute_payload_hash(payload_json)
+
+    payload_with_price = build_goods_import_payload([offer_a, offer_b], include_price=True)
+    assert any("price" in item for item in payload_with_price)
+
+
+@pytest.mark.asyncio
+async def test_kaspi_goods_import_missing_merchant_uid_validation(async_client, company_a_admin_headers):
+    resp = await async_client.post(
+        "/api/v1/kaspi/goods/imports",
+        headers=company_a_admin_headers,
+        json={"source": "db"},
+    )
+    assert resp.status_code == 422
+    data = resp.json()
+    assert data.get("code") == "REQUEST_VALIDATION_ERROR"
 
 
 @pytest.mark.asyncio

--- a/tests/app/test_kaspi_sync_now.py
+++ b/tests/app/test_kaspi_sync_now.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pytest
+
+from app.models.company import Company
+from app.models.kaspi_offer import KaspiOffer
+from app.models.marketplace import KaspiStoreToken
+
+
+async def _ensure_company(async_db_session, company_id: int, store_id: str) -> None:
+    company = await async_db_session.get(Company, company_id)
+    if not company:
+        company = Company(id=company_id, name=f"Company {company_id}")
+        async_db_session.add(company)
+    company.kaspi_store_id = store_id
+    await async_db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_kaspi_sync_now_lock_prevents_parallel(async_client, monkeypatch, company_a_admin_headers):
+    from app.api.v1 import kaspi as kaspi_module
+
+    async def _lock_false(*args, **kwargs):
+        return False
+
+    monkeypatch.setattr(kaspi_module, "_try_sync_now_lock", _lock_false)
+
+    resp = await async_client.post(
+        "/api/v1/kaspi/sync/now",
+        headers=company_a_admin_headers,
+        json={"merchant_uid": "M1"},
+    )
+    assert resp.status_code == 409
+    data = resp.json()
+    assert data.get("detail") == "kaspi_sync_in_progress"
+    assert data.get("code") == "kaspi_sync_in_progress"
+
+
+@pytest.mark.asyncio
+async def test_kaspi_sync_now_order_flow(
+    async_client,
+    async_db_session,
+    monkeypatch,
+    company_a_admin_headers,
+):
+    await _ensure_company(async_db_session, 1001, "store-a")
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    offer = KaspiOffer(
+        company_id=1001,
+        merchant_uid="M1",
+        sku="S1",
+        title="Item 1",
+        price=1000,
+    )
+    async_db_session.add(offer)
+    await async_db_session.commit()
+
+    order = []
+
+    from app.api.v1 import kaspi as kaspi_module
+
+    async def _lock_true(*args, **kwargs):
+        return True
+
+    async def _unlock(*args, **kwargs):
+        return None
+
+    async def _sync_orders(*args, **kwargs):
+        order.append("orders")
+        return {"ok": True}
+
+    async def _submit_import(*args, **kwargs):
+        order.append("goods_import")
+        return {"code": "IC-1", "status": "UPLOADED"}
+
+    async def _get_status(*args, **kwargs):
+        order.append("goods_refresh")
+        return {"status": "UPLOADED"}
+
+    def _build_xml(*args, **kwargs):
+        order.append("feed")
+        return "<xml/>"
+
+    monkeypatch.setattr(kaspi_module, "_try_sync_now_lock", _lock_true)
+    monkeypatch.setattr(kaspi_module, "_release_sync_now_lock", _unlock)
+    monkeypatch.setattr(kaspi_module.KaspiService, "sync_orders", _sync_orders)
+    monkeypatch.setattr(kaspi_module.KaspiGoodsImportClient, "submit_import", _submit_import)
+    monkeypatch.setattr(kaspi_module.KaspiGoodsImportClient, "get_status", _get_status)
+    monkeypatch.setattr(kaspi_module, "_build_kaspi_offers_xml", _build_xml)
+
+    resp = await async_client.post(
+        "/api/v1/kaspi/sync/now",
+        headers=company_a_admin_headers,
+        json={"merchant_uid": "M1"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["goods_import_code"] == "IC-1"
+    assert order == ["orders", "goods_import", "goods_refresh", "feed"]


### PR DESCRIPTION
Promote dev -> main.

Includes:
- Kaspi GOODS IMPORT (official) client/service + migrations + tests
- Kaspi Sync Now orchestration (orders + goods import + offers.xml upkeep) + locking + tests

Note:
- dev includes the latest main (merged main -> dev).
- Local prod-gate.ps1 is green.