### PR TITLE
fix(kaspi): orders sync status mapping + timeouts

### DIFF
--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -26,6 +26,7 @@ app/api/v1/kaspi.py — Полный, боевой роутер интеграц
 - Расширяемость: аккуратные модели ввода/вывода; готово к будущим эндпоинтам.
 """
 
+import asyncio
 import csv
 import hashlib
 import inspect
@@ -50,6 +51,7 @@ from fastapi.responses import JSONResponse
 from openpyxl import load_workbook
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import bindparam, text
+from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -1110,6 +1112,7 @@ async def kaspi_import_status(req: ImportStatusQuery):
 )
 async def kaspi_orders_sync(
     request: Request,
+    response: Response,
     current_user: User = Depends(_auth_user),
     session: AsyncSession = Depends(get_async_db),
 ):
@@ -1120,20 +1123,64 @@ async def kaspi_orders_sync(
         svc = KaspiService()
         request_id = getattr(getattr(request, "state", None), "request_id", None) if request else None
         result = await svc.sync_orders(db=session, company_id=resolved_company_id, request_id=request_id)
+        if "ok" not in result and "status" not in result and "code" not in result:
+            response.status_code = status.HTTP_200_OK
+            return result
+
+        if result.get("ok") is True:
+            await _record_kaspi_event(
+                session,
+                company_id=resolved_company_id,
+                kind="kaspi_orders_sync",
+                status="success",
+                request_id=request_id,
+                meta_json={
+                    "fetched": result.get("fetched"),
+                    "inserted": result.get("inserted"),
+                    "updated": result.get("updated"),
+                    "watermark": result.get("watermark"),
+                },
+            )
+            return result
+
+        code = str(result.get("code") or "internal_error")
+        status_value = str(result.get("status") or "failed")
+        retry_after = result.get("retry_after")
+
+        if code in {"locked", "sync_locked"} or status_value == "locked":
+            response.status_code = status.HTTP_423_LOCKED
+            detail = "kaspi sync already running"
+        elif code in {"timeout", "connect_timeout", "read_timeout"} or status_value == "timeout":
+            response.status_code = status.HTTP_504_GATEWAY_TIMEOUT
+            detail = "kaspi timeout"
+        elif code == "rate_limited" or status_value == "rate_limited":
+            response.status_code = status.HTTP_429_TOO_MANY_REQUESTS
+            detail = "kaspi rate limited"
+            if retry_after is not None:
+                response.headers["Retry-After"] = str(retry_after)
+        elif code == "upstream_unavailable":
+            response.status_code = status.HTTP_502_BAD_GATEWAY
+            detail = "kaspi upstream error"
+        else:
+            response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+            detail = "kaspi sync failed"
+
         await _record_kaspi_event(
             session,
             company_id=resolved_company_id,
             kind="kaspi_orders_sync",
-            status="success",
+            status="failed" if response.status_code >= 500 else "skipped",
             request_id=request_id,
-            meta_json={
-                "fetched": result.get("fetched"),
-                "inserted": result.get("inserted"),
-                "updated": result.get("updated"),
-                "watermark": result.get("watermark"),
-            },
+            error_code=code,
+            error_message=detail,
         )
-        return result
+
+        return {
+            **result,
+            "detail": detail,
+            "code": code,
+            "request_id": request_id,
+        }
     except KaspiSyncAlreadyRunning:
         request_id = getattr(getattr(request, "state", None), "request_id", None) if request else None
         if resolved_company_id is not None:
@@ -1146,7 +1193,14 @@ async def kaspi_orders_sync(
                 error_code="sync_locked",
                 error_message="already_running",
             )
-        raise HTTPException(status_code=status.HTTP_423_LOCKED, detail="kaspi sync already running")
+        response.status_code = status.HTTP_423_LOCKED
+        return {
+            "ok": False,
+            "status": "locked",
+            "code": "locked",
+            "detail": "kaspi sync already running",
+            "request_id": request_id,
+        }
     except Exception as e:
         svc = svc or KaspiService()
         error_code = svc.classify_sync_error(e)
@@ -1165,18 +1219,27 @@ async def kaspi_orders_sync(
             )
 
         if error_code == "kaspi_http_429":
-            headers = {"Retry-After": str(retry_after)} if retry_after is not None else None
-            raise HTTPException(
-                status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="kaspi rate limited", headers=headers
-            )
+            response.status_code = status.HTTP_429_TOO_MANY_REQUESTS
+            if retry_after is not None:
+                response.headers["Retry-After"] = str(retry_after)
+            detail = "kaspi rate limited"
+        elif error_code in {"kaspi_timeout", "timeout"}:
+            response.status_code = status.HTTP_504_GATEWAY_TIMEOUT
+            detail = "kaspi timeout"
+        elif error_code.startswith("kaspi_http_") or error_code == "kaspi_adapter_error":
+            response.status_code = status.HTTP_502_BAD_GATEWAY
+            detail = "kaspi upstream error"
+        else:
+            response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+            detail = "kaspi sync failed"
 
-        if error_code in {"kaspi_timeout", "timeout"}:
-            raise HTTPException(status_code=status.HTTP_504_GATEWAY_TIMEOUT, detail="kaspi timeout")
-
-        if error_code.startswith("kaspi_http_") or error_code == "kaspi_adapter_error":
-            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="kaspi upstream error")
-
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="kaspi sync failed")
+        return {
+            "ok": False,
+            "status": "failed",
+            "code": error_code,
+            "detail": detail,
+            "request_id": request_id,
+        }
 
 
 @router.get(
@@ -1653,7 +1716,9 @@ class KaspiSyncNowOut(BaseModel):
     goods_import_id: str | None = None
     goods_import_code: str | None = None
     goods_import_status: str | None = None
+    goods_import_result: dict[str, Any] | None = None
     feed_last_generated_at: datetime | None = None
+    offers_feed_result: dict[str, Any] | None = None
 
 
 class KaspiFeedUploadIn(BaseModel):
@@ -2330,6 +2395,9 @@ async def kaspi_sync_now(
 ):
     _require_admin(current_user)
 
+    insp = sa_inspect(current_user)
+    current_user_id = insp.identity[0] if insp.identity else int(current_user.id)
+
     merchant_uid = (body.merchant_uid or "").strip()
     if not merchant_uid:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="missing_merchant_uid")
@@ -2353,11 +2421,47 @@ async def kaspi_sync_now(
             extra={"company_id": company_id, "merchant_uid": merchant_uid, "request_id": request_id},
         )
 
-        orders_result = await KaspiService().sync_orders(
-            db=session,
-            company_id=company_id,
-            request_id=request_id,
-        )
+        try:
+            orders_result = await KaspiService().sync_orders(
+                db=session,
+                company_id=company_id,
+                request_id=request_id,
+            )
+        except httpx.ConnectTimeout:
+            orders_result = {
+                "ok": False,
+                "status": "failed",
+                "code": "connect_timeout",
+                "message": "kaspi orders sync failed",
+            }
+        except httpx.ReadTimeout:
+            orders_result = {
+                "ok": False,
+                "status": "failed",
+                "code": "read_timeout",
+                "message": "kaspi orders sync failed",
+            }
+        except httpx.TimeoutException:
+            orders_result = {
+                "ok": False,
+                "status": "failed",
+                "code": "timeout",
+                "message": "kaspi orders sync failed",
+            }
+        except (TimeoutError, asyncio.TimeoutError):
+            orders_result = {
+                "ok": False,
+                "status": "timeout",
+                "code": "timeout",
+                "message": "kaspi orders sync timeout",
+            }
+
+        if not isinstance(orders_result, dict) or "ok" not in orders_result:
+            orders_result = {
+                "ok": True,
+                "status": "success",
+                "result": orders_result,
+            }
 
         company = await session.get(Company, company_id)
         flags = _get_goods_import_flags(company, merchant_uid)
@@ -2394,7 +2498,7 @@ async def kaspi_sync_now(
 
         record = KaspiGoodsImport(
             company_id=company_id,
-            created_by_user_id=current_user.id,
+            created_by_user_id=current_user_id,
             merchant_uid=merchant_uid,
             import_code=str(import_code),
             status=str(status_value),
@@ -2473,6 +2577,19 @@ async def kaspi_sync_now(
             extra={"company_id": company_id, "merchant_uid": merchant_uid, "request_id": request_id},
         )
 
+        goods_import_result = {
+            "ok": True,
+            "status": "success",
+            "import_id": str(record.id),
+            "import_code": str(import_code),
+            "import_status": record.status,
+        }
+        offers_feed_result = {
+            "ok": True,
+            "status": "success",
+            "generated_at": generated_at.isoformat(),
+        }
+
         return KaspiSyncNowOut(
             ok=True,
             company_id=company_id,
@@ -2481,7 +2598,9 @@ async def kaspi_sync_now(
             goods_import_id=str(record.id),
             goods_import_code=str(import_code),
             goods_import_status=record.status,
+            goods_import_result=goods_import_result,
             feed_last_generated_at=generated_at,
+            offers_feed_result=offers_feed_result,
         )
     finally:
         await _release_sync_now_lock(session, company_id=company_id, merchant_uid=merchant_uid)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -663,6 +663,11 @@ class Settings(BaseSettings):
     KASPI_MERCHANT_ID: str | None = Field(
         default=None, description="Kaspi merchant ID", validation_alias="KASPI_MERCHANT_ID"
     )
+    KASPI_API_TOKEN: str | None = Field(
+        default=None,
+        description="Kaspi API token",
+        validation_alias=AliasChoices("KASPI_API_TOKEN", "KASPI_TOKEN", "KASPI_SHOP_TOKEN"),
+    )
     KASPI_API_KEY: str | None = Field(default=None, description="Kaspi API key", validation_alias="KASPI_API_KEY")
     KASPI_API_URL: str = Field(default="https://api.kaspi.kz", description="Kaspi API URL")
 
@@ -715,6 +720,21 @@ class Settings(BaseSettings):
     KASPI_HTTP_TIMEOUT_SEC: int = Field(default=60, description="HTTP timeout to Kaspi (seconds)")
     KASPI_HTTP_RETRIES: int = Field(default=3, description="HTTP retries to Kaspi")
     KASPI_HTTP_RETRY_BACKOFF_SEC: float = Field(default=1.5, description="HTTP retry backoff base")
+
+    # Orders API timeouts (fast-fail)
+    KASPI_ORDERS_TIMEOUT_SEC: float = Field(
+        default=8,
+        description="Kaspi orders read/write/pool timeout (seconds)",
+        validation_alias=AliasChoices("KASPI_ORDERS_TIMEOUT_SEC", "KASPI_ORDERS_TIMEOUT"),
+    )
+    KASPI_ORDERS_CONNECT_TIMEOUT_SEC: float = Field(
+        default=3,
+        description="Kaspi orders connect timeout (seconds)",
+        validation_alias=AliasChoices(
+            "KASPI_ORDERS_CONNECT_TIMEOUT_SEC",
+            "KASPI_ORDERS_CONNECT_TIMEOUT",
+        ),
+    )
 
     # Пути для интеграции с Bridge/outbox и для генерации фидов
     KASPI_BRIDGE_OUTBOX: str | None = Field(

--- a/app/services/kaspi_service.py
+++ b/app/services/kaspi_service.py
@@ -92,7 +92,15 @@ class _RetryingAsyncClient:
     Поддерживает async context manager (`async with`) для корректного закрытия соединений.
     """
 
-    def __init__(self, *, timeout: float = 30.0, retries: int = 2, backoff_base: float = 0.5):
+    def __init__(
+        self,
+        *,
+        timeout: float | httpx.Timeout = 30.0,
+        retries: int = 2,
+        backoff_base: float = 0.5,
+    ):
+        if isinstance(timeout, int | float):
+            timeout = httpx.Timeout(timeout)
         self._client = httpx.AsyncClient(timeout=timeout)
         self._retries = max(0, retries)
         self._base = backoff_base
@@ -168,9 +176,15 @@ class KaspiService:
 
     # ---------------------- helpers ---------------------- #
 
-    def _client(self) -> _RetryingAsyncClient:
+    def _client(self, *, timeout: float | httpx.Timeout | None = None) -> _RetryingAsyncClient:
         # Единые сетевые настройки
-        return _RetryingAsyncClient(timeout=30.0, retries=2, backoff_base=0.5)
+        effective_timeout = 30.0 if timeout is None else timeout
+        return _RetryingAsyncClient(timeout=effective_timeout, retries=2, backoff_base=0.5)
+
+    def _orders_timeout(self) -> httpx.Timeout:
+        connect = float(getattr(settings, "KASPI_ORDERS_CONNECT_TIMEOUT_SEC", 3) or 3)
+        rw_pool = float(getattr(settings, "KASPI_ORDERS_TIMEOUT_SEC", 8) or 8)
+        return httpx.Timeout(connect=connect, read=rw_pool, write=rw_pool, pool=rw_pool)
 
     def _url(self, path: str) -> str:
         if not path.startswith("/"):
@@ -207,7 +221,7 @@ class KaspiService:
         if status:
             params["status"] = status
 
-        async with self._client() as client:
+        async with self._client(timeout=self._orders_timeout()) as client:
             try:
                 if _diag_enabled():
                     logger.info(
@@ -543,8 +557,100 @@ class KaspiService:
                 request_id,
                 duration_ms,
             )
-            raise
-        except asyncio.TimeoutError:
+            return {
+                "ok": False,
+                "status": "locked",
+                "code": "locked",
+                "message": "kaspi orders sync locked",
+                "company_id": company_id,
+                "duration_ms": duration_ms,
+            }
+        except httpx.TimeoutException as exc:
+            duration_ms = int((perf_counter() - started_at) * 1000)
+            req = None
+            try:
+                req = exc.request
+            except Exception:
+                req = None
+            url = getattr(req, "url", None)
+            error_message = f"{exc.__class__.__name__} {url}" if url is not None else f"{exc.__class__.__name__}"
+
+            await self.record_sync_error(
+                db,
+                company_id=company_id,
+                code="kaspi_timeout",
+                message=error_message,
+                occurred_at=_utcnow(),
+                attempt_at=attempt_at,
+                duration_ms=duration_ms,
+                fetched=fetched,
+                inserted=inserted,
+                updated=updated,
+            )
+            logger.error(
+                "Kaspi orders sync timeout: company_id=%s request_id=%s duration_ms=%s",
+                company_id,
+                request_id,
+                duration_ms,
+            )
+            return {
+                "ok": False,
+                "status": "timeout",
+                "code": "timeout",
+                "message": "kaspi orders sync timeout",
+                "company_id": company_id,
+                "duration_ms": duration_ms,
+            }
+        except httpx.HTTPStatusError as exc:
+            duration_ms = int((perf_counter() - started_at) * 1000)
+            status_code = getattr(getattr(exc, "response", None), "status_code", None)
+            retry_after = self.get_retry_after_seconds(exc)
+
+            if status_code == 429:
+                await self.record_sync_error(
+                    db,
+                    company_id=company_id,
+                    code="rate_limited",
+                    message="kaspi rate limited",
+                    occurred_at=_utcnow(),
+                    attempt_at=attempt_at,
+                    duration_ms=duration_ms,
+                    fetched=fetched,
+                    inserted=inserted,
+                    updated=updated,
+                )
+                return {
+                    "ok": False,
+                    "status": "rate_limited",
+                    "code": "rate_limited",
+                    "message": "kaspi rate limited",
+                    "company_id": company_id,
+                    "duration_ms": duration_ms,
+                    "retry_after": retry_after,
+                }
+
+            error_code = "upstream_unavailable" if status_code and status_code >= 500 else "internal_error"
+            await self.record_sync_error(
+                db,
+                company_id=company_id,
+                code=error_code,
+                message=safe_error_message(exc),
+                occurred_at=_utcnow(),
+                attempt_at=attempt_at,
+                duration_ms=duration_ms,
+                fetched=fetched,
+                inserted=inserted,
+                updated=updated,
+            )
+            return {
+                "ok": False,
+                "status": "failed",
+                "code": error_code,
+                "message": "kaspi orders sync failed",
+                "company_id": company_id,
+                "duration_ms": duration_ms,
+            }
+        except (TimeoutError, asyncio.TimeoutError):
             duration_ms = int((perf_counter() - started_at) * 1000)
 
             # Critical fix: explicit rollback before creating fresh session to avoid deadlock
@@ -569,15 +675,39 @@ class KaspiService:
                 request_id,
                 duration_ms,
             )
-            raise
+            return {
+                "ok": False,
+                "status": "timeout",
+                "code": "timeout",
+                "message": "kaspi orders sync timeout",
+                "company_id": company_id,
+                "duration_ms": duration_ms,
+            }
         except Exception as exc:
             duration_ms = int((perf_counter() - started_at) * 1000)
             error_code = self.classify_sync_error(exc)
+            error_message = safe_error_message(exc)
+
+            if isinstance(exc, httpx.ConnectTimeout):
+                error_code = "connect_timeout"
+            elif isinstance(exc, httpx.ReadTimeout):
+                error_code = "read_timeout"
+            elif isinstance(exc, httpx.TimeoutException):
+                error_code = "timeout"
+
+            if isinstance(exc, httpx.TimeoutException):
+                req = getattr(exc, "request", None)
+                url = getattr(req, "url", None)
+                if url is not None:
+                    error_message = f"{exc.__class__.__name__} {url}"
+                else:
+                    error_message = f"{exc.__class__.__name__}"
+
             await self.record_sync_error(
                 db,
                 company_id=company_id,
                 code=error_code,
-                message=safe_error_message(exc),
+                message=error_message,
                 occurred_at=_utcnow(),
                 attempt_at=attempt_at,
                 duration_ms=duration_ms,
@@ -591,9 +721,18 @@ class KaspiService:
                 request_id,
                 duration_ms,
             )
-            raise
+            return {
+                "ok": False,
+                "status": "failed",
+                "code": error_code or "failed",
+                "message": "kaspi orders sync failed",
+                "company_id": company_id,
+                "duration_ms": duration_ms,
+            }
 
         summary = {
+            "ok": True,
+            "status": "success",
             "company_id": company_id,
             "fetched": fetched,
             "inserted": inserted,
@@ -798,8 +937,6 @@ class KaspiService:
     ) -> dict[str, Any] | list[dict[str, Any]]:
         attempts = 3
         delays = [0.2, 0.5, 1.0]
-        fetch_timeout = float(getattr(settings, "KASPI_HTTP_TIMEOUT_SEC", 60))
-
         for attempt in range(attempts):
             try:
                 if _diag_enabled():
@@ -809,18 +946,15 @@ class KaspiService:
                         page,
                         status,
                         attempt + 1,
-                        fetch_timeout,
+                        self._orders_timeout(),
                         perf_counter(),
                     )
-                result = await asyncio.wait_for(
-                    self.get_orders(
-                        date_from=date_from,
-                        date_to=date_to,
-                        status=status,
-                        page=page,
-                        page_size=page_size,
-                    ),
-                    timeout=fetch_timeout,
+                result = await self.get_orders(
+                    date_from=date_from,
+                    date_to=date_to,
+                    status=status,
+                    page=page,
+                    page_size=page_size,
                 )
                 if _diag_enabled():
                     logger.info(

--- a/tests/app/core/test_config.py
+++ b/tests/app/core/test_config.py
@@ -77,6 +77,12 @@ class TestSettings:
         assert hasattr(test_settings, "SCHEDULER_TIMEZONE")
         assert isinstance(test_settings.SCHEDULER_TIMEZONE, str)
 
+    def test_kaspi_api_token_from_env(self, monkeypatch):
+        """Test KASPI_API_TOKEN reads from env."""
+        monkeypatch.setenv("KASPI_API_TOKEN", "token-123")
+        test_settings = Settings()
+        assert test_settings.KASPI_API_TOKEN == "token-123"
+
 
 class TestGlobalSettings:
     """Test global settings instance."""

--- a/tests/app/test_kaspi_service_sync_orders.py
+++ b/tests/app/test_kaspi_service_sync_orders.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.services.kaspi_service import KaspiService
+
+
+@pytest.mark.asyncio
+async def test_kaspi_service_sync_orders_timeout_returns_result(async_db_session, monkeypatch):
+    service = KaspiService(api_key="token", base_url="https://kaspi.kz")
+    service._sync_timeout_seconds = 0.01
+
+    async def _iter_orders_pages(*args, **kwargs):
+        await asyncio.sleep(0.05)
+        if False:
+            yield []
+
+    monkeypatch.setattr(service, "_iter_orders_pages", _iter_orders_pages)
+
+    result = await service.sync_orders(
+        db=async_db_session,
+        company_id=1001,
+        request_id="req-1",
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "timeout"

--- a/tests/app/test_kaspi_sync_now.py
+++ b/tests/app/test_kaspi_sync_now.py
@@ -103,3 +103,129 @@ async def test_kaspi_sync_now_order_flow(
     assert data["ok"] is True
     assert data["goods_import_code"] == "IC-1"
     assert order == ["orders", "goods_import", "goods_refresh", "feed"]
+
+
+@pytest.mark.asyncio
+async def test_kaspi_sync_now_orders_timeout_returns_200(
+    async_client,
+    async_db_session,
+    monkeypatch,
+    company_a_admin_headers,
+):
+    await _ensure_company(async_db_session, 1001, "store-a")
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    offer = KaspiOffer(
+        company_id=1001,
+        merchant_uid="M1",
+        sku="S1",
+        title="Item 1",
+        price=1000,
+    )
+    async_db_session.add(offer)
+    await async_db_session.commit()
+
+    from app.api.v1 import kaspi as kaspi_module
+
+    async def _lock_true(*args, **kwargs):
+        return True
+
+    async def _unlock(*args, **kwargs):
+        return None
+
+    async def _sync_orders(*args, **kwargs):
+        raise TimeoutError("timeout")
+
+    async def _submit_import(*args, **kwargs):
+        return {"code": "IC-1", "status": "UPLOADED"}
+
+    async def _get_status(*args, **kwargs):
+        return {"status": "UPLOADED"}
+
+    def _build_xml(*args, **kwargs):
+        return "<xml/>"
+
+    monkeypatch.setattr(kaspi_module, "_try_sync_now_lock", _lock_true)
+    monkeypatch.setattr(kaspi_module, "_release_sync_now_lock", _unlock)
+    monkeypatch.setattr(kaspi_module.KaspiService, "sync_orders", _sync_orders)
+    monkeypatch.setattr(kaspi_module.KaspiGoodsImportClient, "submit_import", _submit_import)
+    monkeypatch.setattr(kaspi_module.KaspiGoodsImportClient, "get_status", _get_status)
+    monkeypatch.setattr(kaspi_module, "_build_kaspi_offers_xml", _build_xml)
+
+    resp = await async_client.post(
+        "/api/v1/kaspi/sync/now",
+        headers=company_a_admin_headers,
+        json={"merchant_uid": "M1"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["orders_sync"]["status"] == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_kaspi_sync_now_orders_read_timeout_code(
+    async_client,
+    async_db_session,
+    monkeypatch,
+    company_a_admin_headers,
+):
+    await _ensure_company(async_db_session, 1001, "store-a")
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    offer = KaspiOffer(
+        company_id=1001,
+        merchant_uid="M1",
+        sku="S1",
+        title="Item 1",
+        price=1000,
+    )
+    async_db_session.add(offer)
+    await async_db_session.commit()
+
+    import httpx
+
+    from app.api.v1 import kaspi as kaspi_module
+
+    async def _lock_true(*args, **kwargs):
+        return True
+
+    async def _unlock(*args, **kwargs):
+        return None
+
+    async def _sync_orders(*args, **kwargs):
+        request = httpx.Request("GET", "https://kaspi.kz/shop/api/v2/orders")
+        raise httpx.ReadTimeout("read timeout", request=request)
+
+    async def _submit_import(*args, **kwargs):
+        return {"code": "IC-1", "status": "UPLOADED"}
+
+    async def _get_status(*args, **kwargs):
+        return {"status": "UPLOADED"}
+
+    def _build_xml(*args, **kwargs):
+        return "<xml/>"
+
+    monkeypatch.setattr(kaspi_module, "_try_sync_now_lock", _lock_true)
+    monkeypatch.setattr(kaspi_module, "_release_sync_now_lock", _unlock)
+    monkeypatch.setattr(kaspi_module.KaspiService, "sync_orders", _sync_orders)
+    monkeypatch.setattr(kaspi_module.KaspiGoodsImportClient, "submit_import", _submit_import)
+    monkeypatch.setattr(kaspi_module.KaspiGoodsImportClient, "get_status", _get_status)
+    monkeypatch.setattr(kaspi_module, "_build_kaspi_offers_xml", _build_xml)
+
+    resp = await async_client.post(
+        "/api/v1/kaspi/sync/now",
+        headers=company_a_admin_headers,
+        json={"merchant_uid": "M1"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["orders_sync"]["code"] == "read_timeout"


### PR DESCRIPTION
Normalize Kaspi orders sync result contract and HTTP status mapping (423/429/502/504/500). Add fast Orders timeouts, config env, and tests for sync-now and legacy dict results.