### PR TITLE
ci: run only on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main, dev, "release/**"]
+    branches:
+      - main
   pull_request:
-    branches: [main, dev, "release/**"]
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Restrict CI workflow triggers to main branch only (push + PR).