### PR TITLE
Subscriptions: canonical plan_id + Kaspi gating

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -2209,6 +2209,29 @@ Timeout could cancel/rollback the main sync transaction, causing `kaspi_order_sy
 - Working tree: only journal updates plus an untracked local artifact (`kaspi_catalog_template.csv`).
 - No staged code changes pending beyond this journal append.
 
+## [2026-02-02] Kaspi subscription gating matrix
+
+### Changed
+- Expanded subscription feature matrix: trial blocks sync-now; basic includes Kaspi feed uploads and autosync.
+- Added subscription matrix tests covering goods imports, feed uploads, autosync status, and sync-now across trial/basic/pro.
+
+### Verification
+- `python -m ruff format app tests`
+- `python -m ruff check app tests`
+- `python -m pytest -q tests/app/test_kaspi_subscription_matrix.py`
+
+## [2026-02-02] Kaspi RBAC-first subscription gating
+
+### Changed
+- Ensured RBAC runs before subscription gating for Kaspi feed uploads and sync-now.
+- Added sync-now subscription setup (basic/pro) in tests and a trial plan 402 assertion.
+
+### Verification
+- `python -m ruff format app tests`
+- `python -m ruff check app tests`
+- `python -m pytest -q tests/app/test_kaspi_feed_uploads.py tests/app/test_kaspi_sync_now.py`
+- `scripts/prod-gate.ps1`
+
 ## [2026-02-02] Subscription feature matrix for Kaspi operations (WIP)
 
 ### Added
@@ -2222,3 +2245,14 @@ Timeout could cancel/rollback the main sync transaction, causing `kaspi_order_sy
 
 ### Next
 - Apply enforcement to concrete Kaspi endpoints (feed uploads / autosync / sync-now / goods imports) and expand tests to cover each endpoint.
+
+## [2026-02-02] Kaspi subscription gating matrix (addendum)
+
+### Changed
+- Expanded subscription feature matrix: trial blocks sync-now; basic includes Kaspi feed uploads and autosync.
+- Expanded subscription matrix tests for goods imports, feed uploads, autosync status, and sync-now across trial/basic/pro.
+
+### Verification
+- `python -m ruff format app tests`
+- `python -m ruff check app tests`
+- `python -m pytest -q tests/app/test_kaspi_subscription_matrix.py`

--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -2162,6 +2162,49 @@ Timeout could cancel/rollback the main sync transaction, causing `kaspi_order_sy
 - PR #142 (4e622d8): campaigns hardening. Files: app/api/v1/campaigns.py, app/schemas/campaign.py, migrations/versions/20260129_campaigns_tenant_title_unique.py, tests/app/test_campaigns_hardening.py.
 - PR #143 (e9ccf75): analytics hardening. Files: app/api/v1/analytics.py, tests/app/test_analytics_hardening.py.
 - PR #144 (87500fd): invoices MVP core. Files: app/api/v1/invoices.py, app/core/dependencies.py, app/models/billing.py, migrations/versions/20260129_invoices_mvp_core.py, tests/app/test_invoices_mvp_core.py.
+
 - PR #145 (05487a9): .env.example prod keys. Files: .env.example, tests/test_env_example.py, PROJECT_JOURNAL.md.
 - PR #146 (81014d8): unified error contract (F2). Files: app/core/exceptions.py, app/main.py, tests/test_error_contract.py, PROJECT_JOURNAL.md.
 - PR #147 (aced20e): deploy guide (F3). Files: docs/DEPLOYMENT.md, tests/test_deploy_guide.py, PROJECT_JOURNAL.md.
+
+## [2026-02-02] 30-day summary
+
+### Context
+- Time window: 2026-01-03 → 2026-02-02 (last 30 days).
+- Evidence commands executed (sanitized):
+  - `git status -sb`
+  - `git log --since="30 days ago" --date=iso --pretty=format:"%h %ad %s" --name-status`
+  - `git shortlog -sn --since="30 days ago"`
+  - `git diff --stat`
+- Working tree snapshot: `PROJECT_JOURNAL.md` modified (append-only entry), untracked `kaspi_catalog_template.csv`.
+
+### Highlights
+
+**Core/Auth**
+- 86f35af (2026-01-16): removed debug leaks in OTP/DB/config; tightened security and logging.
+- 5168ce9 (2026-01-16): invitations + password reset tokens; new employee role and OTP TTL; tests added.
+- 2926f64 (2026-01-15): async token auth DB path + unified OTP verify attempts.
+
+**Kaspi**
+- 7031dd5 (2026-01-10): autosync scheduler + endpoints + tests; later hardened with status/runner guards.
+- 4815c83 / d03fa91 (2026-01-17): catalog import MVP + UX endpoints (batches/errors/offers/template).
+- c3ea329 (2026-01-17): feed export MVP (XML) + download endpoint and tests.
+
+**Billing / Subscriptions**
+- 35f9090 (2026-01-03): tenant-scoped billing (subscriptions/invoices) + isolation tests.
+- 01cdebc / 3106213 (2026-01-04): removed platform overrides for company scoping; tenant-safety guards.
+
+**Docs / Tooling / Tests**
+- 2f087a2 (2026-02-02): DB backup/restore tools (`tools/backup_db.ps1`, `tools/restore_db.ps1`) + docs.
+- 95be10b (2026-02-02): upgrade/rollback playbook (`docs/UPGRADE_PLAYBOOK.md`).
+- 3857e9e (2026-02-02): prod-gate adds `ruff format --check`.
+
+### Risks / Follow-ups
+- Open tasks around subscription enforcement and Kaspi feature gating continue to evolve; verify endpoint guards per milestone E.
+- Catalog template UX: OpenAPI currently exposes `/api/v1/kaspi/catalog/import/template.csv`; unified format endpoint remains optional/partial.
+- Catalog template verification: OpenAPI exposes `/api/v1/kaspi/catalog/import/template.csv` (auth required); `/api/v1/kaspi/catalog/template` is absent; 404 was wrong path; 401 was unauthenticated call; verified 200 with Bearer token.
+
+### Current status snapshot
+- Branch: `feat/subscriptions-next-v1`.
+- Working tree: only journal updates plus an untracked local artifact (`kaspi_catalog_template.csv`).
+- No staged code changes pending beyond this journal append.

--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -206,7 +206,7 @@
 ## [2026-01-04] Tenant company scoping helper + query guardrails
 
 ### Added
-- Shared tenant company resolver in pp/core/security.py to enforce company_id from auth claims and centralize platform-admin override rules.
+- Shared tenant company resolver in  pp/core/security.py to enforce company_id from auth claims and centralize platform-admin override rules.
 - Regression tests covering company_id query behavior for wallet/payments (same-tenant allowed, cross-tenant forbidden) in 	ests/app/api/test_wallet_payments_tenant.py.
 
 ### Changed
@@ -889,7 +889,7 @@ Commits (per git show):
 ## [2026-01-04] Tenant company scoping helper + query guardrails
 
 ### Added
-- Shared tenant company resolver in pp/core/security.py to enforce company_id from auth claims and centralize platform-admin override rules.
+- Shared tenant company resolver in  pp/core/security.py to enforce company_id from auth claims and centralize platform-admin override rules.
 - Regression tests covering company_id query behavior for wallet/payments (same-tenant allowed, cross-tenant forbidden) in 	ests/app/api/test_wallet_payments_tenant.py.
 
 ### Changed
@@ -2208,3 +2208,17 @@ Timeout could cancel/rollback the main sync transaction, causing `kaspi_order_sy
 - Branch: `feat/subscriptions-next-v1`.
 - Working tree: only journal updates plus an untracked local artifact (`kaspi_catalog_template.csv`).
 - No staged code changes pending beyond this journal append.
+
+## [2026-02-02] Subscription feature matrix for Kaspi operations (WIP)
+
+### Added
+- Subscription feature keys and plan matrix (trial/basic/pro) in `app/core/subscriptions/features.py`.
+- Initial tests for subscription gating on Kaspi operations in `tests/app/test_kaspi_subscription_matrix.py`.
+
+### Verified
+- python -m ruff format app tests
+- python -m ruff check app tests
+- python -m pytest -q tests/app/test_kaspi_subscription_matrix.py
+
+### Next
+- Apply enforcement to concrete Kaspi endpoints (feed uploads / autosync / sync-now / goods imports) and expand tests to cover each endpoint.

--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -158,6 +158,18 @@ def _require_admin(current_user: User) -> None:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
 
 
+def require_admin_then_feature(feature: str) -> Any:
+    async def _dep(
+        current_user: User = Depends(get_current_user),  # noqa: B008
+        db: AsyncSession = Depends(get_async_db),  # noqa: B008
+    ) -> User:
+        _require_admin(current_user)
+        await require_feature(feature)(current_user=current_user, db=db)
+        return current_user
+
+    return _dep
+
+
 def _load_company_settings(company: Company | None) -> dict[str, Any]:
     if not company or not company.settings:
         return {}
@@ -2571,11 +2583,9 @@ async def kaspi_sync_now(
     body: KaspiSyncNowIn,
     timeout_sec: float = Query(SYNC_NOW_TIMEOUT_SEC, ge=0.1, le=60.0),
     hard: int = Query(0, ge=0, le=1),
-    current_user: User = Depends(require_feature(FEATURE_KASPI_SYNC_NOW)),
+    current_user: User = Depends(require_admin_then_feature(FEATURE_KASPI_SYNC_NOW)),
     session: AsyncSession = Depends(get_async_db),
 ):
-    _require_admin(current_user)
-
     insp = sa_inspect(current_user)
     current_user_id = insp.identity[0] if insp.identity else int(current_user.id)
 
@@ -4132,11 +4142,9 @@ async def kaspi_feed_exports_list(
 async def kaspi_feed_upload_create(
     request: Request,
     body: KaspiFeedUploadIn,
-    current_user: User = Depends(require_feature(FEATURE_KASPI_FEED_UPLOADS)),
+    current_user: User = Depends(require_admin_then_feature(FEATURE_KASPI_FEED_UPLOADS)),
     session: AsyncSession = Depends(get_async_db),
 ):
-    _require_admin(current_user)
-
     merchant_uid = (body.merchant_uid or "").strip()
     if not merchant_uid:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="missing_merchant_uid")
@@ -4341,10 +4349,9 @@ async def kaspi_feed_upload_create(
 async def kaspi_feed_uploads_list(
     limit: int = 50,
     offset: int = 0,
-    current_user: User = Depends(require_feature(FEATURE_KASPI_FEED_UPLOADS)),
+    current_user: User = Depends(require_admin_then_feature(FEATURE_KASPI_FEED_UPLOADS)),
     session: AsyncSession = Depends(get_async_db),
 ):
-    _require_admin(current_user)
     company_id = _resolve_company_id(current_user)
 
     limit = max(1, min(limit, 200))
@@ -4368,10 +4375,9 @@ async def kaspi_feed_uploads_list(
 )
 async def kaspi_feed_upload_get(
     upload_id: UUID,
-    current_user: User = Depends(require_feature(FEATURE_KASPI_FEED_UPLOADS)),
+    current_user: User = Depends(require_admin_then_feature(FEATURE_KASPI_FEED_UPLOADS)),
     session: AsyncSession = Depends(get_async_db),
 ):
-    _require_admin(current_user)
     company_id = _resolve_company_id(current_user)
 
     record = (
@@ -4399,10 +4405,9 @@ async def kaspi_feed_upload_get(
 async def kaspi_feed_upload_refresh(
     request: Request,
     upload_id: UUID,
-    current_user: User = Depends(require_feature(FEATURE_KASPI_FEED_UPLOADS)),
+    current_user: User = Depends(require_admin_then_feature(FEATURE_KASPI_FEED_UPLOADS)),
     session: AsyncSession = Depends(get_async_db),
 ):
-    _require_admin(current_user)
     company_id = _resolve_company_id(current_user)
 
     request_id = getattr(getattr(request, "state", None), "request_id", None) or request.headers.get("X-Request-ID")
@@ -4518,7 +4523,7 @@ async def kaspi_feed_upload_refresh(
 async def kaspi_feed_upload_refresh_compat(
     request: Request,
     upload_id: UUID,
-    current_user: User = Depends(require_feature(FEATURE_KASPI_FEED_UPLOADS)),
+    current_user: User = Depends(require_admin_then_feature(FEATURE_KASPI_FEED_UPLOADS)),
     session: AsyncSession = Depends(get_async_db),
 ):
     return await kaspi_feed_upload_refresh(
@@ -4537,10 +4542,9 @@ async def kaspi_feed_upload_refresh_compat(
 async def kaspi_feed_upload_publish(
     request: Request,
     upload_id: UUID,
-    current_user: User = Depends(require_feature(FEATURE_KASPI_FEED_UPLOADS)),
+    current_user: User = Depends(require_admin_then_feature(FEATURE_KASPI_FEED_UPLOADS)),
     session: AsyncSession = Depends(get_async_db),
 ):
-    _require_admin(current_user)
     company_id = _resolve_company_id(current_user)
     request_id = getattr(getattr(request, "state", None), "request_id", None) or request.headers.get("X-Request-ID")
 

--- a/app/api/v1/subscriptions.py
+++ b/app/api/v1/subscriptions.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from pydantic import BaseModel, ConfigDict, Field, condecimal, constr
+from pydantic import BaseModel, ConfigDict, Field, computed_field, condecimal, constr, field_serializer
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,6 +20,7 @@ from app.core.security import (
     is_token_revoked,
     resolve_tenant_company_id,
 )
+from app.core.subscriptions.plan_catalog import get_plan_display_name, normalize_plan_id
 from app.models.billing import BillingPayment, Subscription
 from app.models.company import Company
 from app.models.user import User
@@ -82,6 +83,15 @@ class SubscriptionOut(BaseModel):
     deleted_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)
+
+    @field_serializer("plan")
+    def _serialize_plan(self, plan: str) -> str:
+        return get_plan_display_name(plan)
+
+    @computed_field(return_type=str)
+    @property
+    def plan_id(self) -> str:
+        return normalize_plan_id(self.plan, default=self.plan) or (self.plan or "")
 
 
 class PaymentOut(BaseModel):
@@ -245,7 +255,8 @@ async def list_subscriptions(
     if status_filter:
         stmt = stmt.where(Subscription.status == status_filter)
     if plan:
-        stmt = stmt.where(Subscription.plan == plan)
+        normalized_plan = normalize_plan_id(plan, default=plan)
+        stmt = stmt.where(Subscription.plan == normalized_plan)
     if from_date:
         stmt = stmt.where(Subscription.next_billing_date >= from_date)
     if to_date:
@@ -314,9 +325,10 @@ async def create_subscription(
 
         now = utc_now()
         period_end = next_billing_from(now, payload.billing_cycle)
+        normalized_plan = normalize_plan_id(payload.plan, default=payload.plan)
         sub = Subscription(
             company_id=resolved_company_id,
-            plan=payload.plan,
+            plan=normalized_plan,
             status="trial" if payload.trial_days > 0 else "active",
             billing_cycle=payload.billing_cycle,
             price=Decimal(payload.price),
@@ -355,7 +367,7 @@ async def update_subscription(
 
     try:
         if payload.plan is not None:
-            sub.plan = payload.plan
+            sub.plan = normalize_plan_id(payload.plan, default=payload.plan)
         if payload.billing_cycle is not None:
             sub.billing_cycle = payload.billing_cycle
             sub.next_billing_date = next_billing_from(utc_now(), sub.billing_cycle)

--- a/app/core/subscriptions/features.py
+++ b/app/core/subscriptions/features.py
@@ -16,11 +16,11 @@ from app.services.subscriptions import get_company_subscription, is_subscription
 
 logger = get_logger(__name__)
 
-FEATURE_KASPI_ORDERS_LIST = "kaspi_orders_list"
-FEATURE_KASPI_SYNC_NOW = "kaspi_sync_now"
-FEATURE_KASPI_GOODS_IMPORTS = "kaspi_goods_imports"
-FEATURE_KASPI_FEED_UPLOADS = "kaspi_feed_uploads"
-FEATURE_KASPI_AUTOSYNC = "kaspi_autosync"
+FEATURE_KASPI_ORDERS_LIST = "kaspi.orders_list"
+FEATURE_KASPI_SYNC_NOW = "kaspi.sync_now"
+FEATURE_KASPI_GOODS_IMPORTS = "kaspi.goods_imports"
+FEATURE_KASPI_FEED_UPLOADS = "kaspi.feed_uploads"
+FEATURE_KASPI_AUTOSYNC = "kaspi.autosync"
 
 _FEATURE_MATRIX: dict[str, set[str]] = {
     "trial": {
@@ -81,7 +81,7 @@ def require_feature(feature: str) -> Any:
             raise AuthorizationError(
                 "subscription_required",
                 code="subscription_required",
-                http_status=403,
+                http_status=402,
                 extra={"feature": feature, "plan": plan, "company_id": company_id},
             )
         return current_user

--- a/app/core/subscriptions/features.py
+++ b/app/core/subscriptions/features.py
@@ -11,6 +11,7 @@ from app.core.db import get_async_db
 from app.core.exceptions import AuthorizationError
 from app.core.logging import get_logger
 from app.core.security import get_current_user, resolve_tenant_company_id
+from app.core.subscriptions.plan_catalog import normalize_plan_id
 from app.models.company import Company
 from app.services.subscriptions import get_company_subscription, is_subscription_active
 
@@ -23,14 +24,15 @@ FEATURE_KASPI_FEED_UPLOADS = "kaspi.feed_uploads"
 FEATURE_KASPI_AUTOSYNC = "kaspi.autosync"
 
 _FEATURE_MATRIX: dict[str, set[str]] = {
-    "trial": {
+    "start": {
         FEATURE_KASPI_ORDERS_LIST,
-        FEATURE_KASPI_SYNC_NOW,
     },
-    "basic": {
+    "business": {
         FEATURE_KASPI_ORDERS_LIST,
         FEATURE_KASPI_SYNC_NOW,
         FEATURE_KASPI_GOODS_IMPORTS,
+        FEATURE_KASPI_FEED_UPLOADS,
+        FEATURE_KASPI_AUTOSYNC,
     },
     "pro": {
         FEATURE_KASPI_ORDERS_LIST,
@@ -41,28 +43,15 @@ _FEATURE_MATRIX: dict[str, set[str]] = {
     },
 }
 
-_PLAN_ALIASES = {
-    "start": "trial",
-    "trial": "trial",
-    "basic": "basic",
-    "pro": "pro",
-    "business": "pro",
-}
-
-
-def _normalize_plan(plan: str | None) -> str:
-    raw = (plan or "").strip().lower()
-    return _PLAN_ALIASES.get(raw, "trial")
-
 
 async def _resolve_plan(db: AsyncSession, company_id: int) -> str:
     subscription = await get_company_subscription(db, company_id)
     if subscription and is_subscription_active(subscription):
-        return _normalize_plan(getattr(subscription, "plan", None))
+        return normalize_plan_id(getattr(subscription, "plan", None)) or "start"
 
     res = await db.execute(select(Company.subscription_plan).where(Company.id == company_id))
     plan = res.scalar_one_or_none()
-    return _normalize_plan(plan)
+    return normalize_plan_id(plan) or "start"
 
 
 def _has_feature(plan: str, feature: str) -> bool:
@@ -90,7 +79,7 @@ def require_feature(feature: str) -> Any:
 
 
 def get_plan_features(plan: str) -> Iterable[str]:
-    return _FEATURE_MATRIX.get(_normalize_plan(plan), set())
+    return _FEATURE_MATRIX.get(normalize_plan_id(plan) or "start", set())
 
 
 __all__ = [

--- a/app/core/subscriptions/plan_catalog.py
+++ b/app/core/subscriptions/plan_catalog.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class PlanCatalogEntry:
+    plan_id: str
+    display_name: str
+    price: Decimal
+    currency: str = "KZT"
+
+
+PLAN_CATALOG: dict[str, PlanCatalogEntry] = {
+    "start": PlanCatalogEntry(plan_id="start", display_name="Start", price=Decimal("0.00")),
+    "business": PlanCatalogEntry(plan_id="business", display_name="Business", price=Decimal("0.00")),
+    "pro": PlanCatalogEntry(plan_id="pro", display_name="Pro", price=Decimal("0.00")),
+}
+
+PLAN_ALIASES: dict[str, str] = {
+    "start": "start",
+    "trial": "start",
+    "basic": "business",
+    "business": "business",
+    "pro": "pro",
+}
+
+
+def normalize_plan_id(raw: str | None, *, default: str | None = "start") -> str | None:
+    key = (raw or "").strip().lower()
+    if not key:
+        return default
+    if key in PLAN_ALIASES:
+        return PLAN_ALIASES[key]
+    if key in PLAN_CATALOG:
+        return key
+    return default
+
+
+def is_canonical_plan_id(plan_id: str | None) -> bool:
+    return (plan_id or "") in PLAN_CATALOG
+
+
+def get_plan(plan_id: str | None, *, default: str | None = "start") -> PlanCatalogEntry | None:
+    normalized = normalize_plan_id(plan_id, default=default)
+    if normalized is None:
+        return None
+    return PLAN_CATALOG.get(normalized)
+
+
+def get_plan_display_name(plan_id: str | None, *, default: str | None = "start") -> str:
+    plan = get_plan(plan_id, default=default)
+    if plan is None:
+        return (plan_id or "").strip() or "Start"
+    return plan.display_name
+
+
+def iter_plan_ids() -> Iterable[str]:
+    return PLAN_CATALOG.keys()
+
+
+__all__ = [
+    "PlanCatalogEntry",
+    "PLAN_CATALOG",
+    "PLAN_ALIASES",
+    "normalize_plan_id",
+    "is_canonical_plan_id",
+    "get_plan",
+    "get_plan_display_name",
+    "iter_plan_ids",
+]

--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import async_session_maker
 from app.core.logging import get_logger
+from app.core.subscriptions.plan_catalog import get_plan_display_name, normalize_plan_id
 from app.models import AuditLog, Company, OtpAttempt, Product, ProductStock, User
 from app.services import EmailService, KaspiService
 from app.utils.idempotency import cleanup_idempotency_records
@@ -312,7 +313,7 @@ class TaskManager:
                         await email_service.send_subscription_notification(
                             to_email=admin.email,
                             company_name=company.name,
-                            plan=company.subscription_plan,
+                            plan=get_plan_display_name(normalize_plan_id(company.subscription_plan) or "start"),
                             expires_at=company.subscription_expires_at,
                         )
 

--- a/tests/app/test_analytics_hardening.py
+++ b/tests/app/test_analytics_hardening.py
@@ -8,6 +8,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.subscriptions.plan_catalog import normalize_plan_id
 from app.models.billing import Subscription
 from app.models.company import Company
 from app.models.order import Order, OrderStatus
@@ -65,7 +66,7 @@ async def test_analytics_subscription_inactive_blocked(
 
     sub = Subscription(
         company_id=company.id,
-        plan="start",
+        plan=normalize_plan_id("start") or "trial",
         status="canceled",
         billing_cycle="monthly",
         price=Decimal("0.00"),

--- a/tests/app/test_campaigns_hardening.py
+++ b/tests/app/test_campaigns_hardening.py
@@ -8,6 +8,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.subscriptions.plan_catalog import normalize_plan_id
 from app.models.billing import Subscription
 from app.models.company import Company
 
@@ -130,7 +131,7 @@ async def test_campaign_subscription_inactive_blocks_access(
 
     sub = Subscription(
         company_id=company.id,
-        plan="start",
+        plan=normalize_plan_id("start") or "trial",
         status="canceled",
         billing_cycle="monthly",
         price=Decimal("0.00"),

--- a/tests/app/test_invoices_mvp_core.py
+++ b/tests/app/test_invoices_mvp_core.py
@@ -8,6 +8,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.subscriptions.plan_catalog import normalize_plan_id
 from app.models.billing import Invoice, Subscription, WalletBalance, WalletTransaction
 from app.models.company import Company
 
@@ -162,7 +163,7 @@ async def test_invoices_subscription_inactive_blocked(
 
     sub = Subscription(
         company_id=company.id,
-        plan="start",
+        plan=normalize_plan_id("start") or "trial",
         status="canceled",
         billing_cycle="monthly",
         price=Decimal("0.00"),

--- a/tests/app/test_kaspi_feed_uploads.py
+++ b/tests/app/test_kaspi_feed_uploads.py
@@ -8,6 +8,7 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import select
 
+from app.core.subscriptions.plan_catalog import normalize_plan_id
 from app.models.billing import Subscription
 from app.models.company import Company
 from app.models.integration_event import IntegrationEvent
@@ -82,7 +83,7 @@ async def _ensure_subscription_plan(async_db_session, company_id: int, plan: str
     if sub is None:
         sub = Subscription(
             company_id=company_id,
-            plan=plan,
+            plan=normalize_plan_id(plan) or "trial",
             status="active",
             billing_cycle="monthly",
             price=Decimal("0.00"),
@@ -94,7 +95,7 @@ async def _ensure_subscription_plan(async_db_session, company_id: int, plan: str
         )
         async_db_session.add(sub)
     else:
-        sub.plan = plan
+        sub.plan = normalize_plan_id(plan) or "trial"
         sub.status = "active"
     await async_db_session.commit()
 

--- a/tests/app/test_kaspi_goods_imports.py
+++ b/tests/app/test_kaspi_goods_imports.py
@@ -6,6 +6,7 @@ import pytest
 import pytest_asyncio
 import sqlalchemy as sa
 
+from app.core.subscriptions.plan_catalog import normalize_plan_id
 from app.models.billing import Subscription
 from app.models.company import Company
 from app.models.kaspi_goods_import import KaspiGoodsImport
@@ -81,7 +82,7 @@ async def _ensure_subscription_plan(async_db_session, company_id: int, plan: str
     if sub is None:
         sub = Subscription(
             company_id=company_id,
-            plan=plan,
+            plan=normalize_plan_id(plan) or "trial",
             status="active",
             billing_cycle="monthly",
             price=Decimal("0.00"),
@@ -93,7 +94,7 @@ async def _ensure_subscription_plan(async_db_session, company_id: int, plan: str
         )
         async_db_session.add(sub)
     else:
-        sub.plan = plan
+        sub.plan = normalize_plan_id(plan) or "trial"
         sub.status = "active"
     await async_db_session.commit()
 

--- a/tests/app/test_kaspi_subscription_matrix.py
+++ b/tests/app/test_kaspi_subscription_matrix.py
@@ -4,8 +4,11 @@ from decimal import Decimal
 import pytest
 from sqlalchemy import select
 
+from app.core.subscriptions.plan_catalog import normalize_plan_id
 from app.models.billing import Subscription
 from app.models.company import Company
+from app.models.kaspi_offer import KaspiOffer
+from app.models.marketplace import KaspiStoreToken
 
 pytestmark = pytest.mark.asyncio
 
@@ -24,7 +27,7 @@ async def _set_plan(async_db_session, company_id: int, plan: str) -> None:
     if sub is None:
         sub = Subscription(
             company_id=company_id,
-            plan=plan,
+            plan=normalize_plan_id(plan) or "trial",
             status="active",
             billing_cycle="monthly",
             price=Decimal("0.00"),
@@ -36,64 +39,136 @@ async def _set_plan(async_db_session, company_id: int, plan: str) -> None:
         )
         async_db_session.add(sub)
     else:
-        sub.plan = plan
+        sub.plan = normalize_plan_id(plan) or "trial"
         sub.status = "active"
     await async_db_session.commit()
 
 
-async def test_kaspi_subscription_trial_blocks_goods_imports(
+def _assert_subscription_required(resp) -> None:
+    assert resp.status_code == 402
+    payload = resp.json()
+    assert payload.get("detail") == "subscription_required"
+    assert payload.get("code") == "subscription_required"
+    assert payload.get("request_id")
+
+
+async def _prepare_sync_now(async_db_session, monkeypatch, company_id: int, merchant_uid: str) -> None:
+    from app.api.v1 import kaspi as kaspi_module
+
+    company = await async_db_session.get(Company, company_id)
+    if not company:
+        company = Company(id=company_id, name=f"Company {company_id}")
+        async_db_session.add(company)
+    company.kaspi_store_id = "store-a"
+    await async_db_session.commit()
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+
+    offer = KaspiOffer(
+        company_id=company_id,
+        merchant_uid=merchant_uid,
+        sku="S1",
+        title="Item 1",
+        price=1000,
+    )
+    async_db_session.add(offer)
+    await async_db_session.commit()
+
+    async def _lock_true(*args, **kwargs):
+        return True
+
+    async def _unlock(*args, **kwargs):
+        return None
+
+    async def _sync_orders(*args, **kwargs):
+        return {"ok": True}
+
+    async def _submit_import(*args, **kwargs):
+        return {"code": "IC-1", "status": "UPLOADED"}
+
+    async def _get_status(*args, **kwargs):
+        return {"status": "UPLOADED"}
+
+    def _build_xml(*args, **kwargs):
+        return "<xml/>"
+
+    monkeypatch.setattr(kaspi_module, "_try_sync_now_lock", _lock_true)
+    monkeypatch.setattr(kaspi_module, "_release_sync_now_lock", _unlock)
+    monkeypatch.setattr(kaspi_module.KaspiService, "sync_orders", _sync_orders)
+    monkeypatch.setattr(kaspi_module.KaspiGoodsImportClient, "submit_import", _submit_import)
+    monkeypatch.setattr(kaspi_module.KaspiGoodsImportClient, "get_status", _get_status)
+    monkeypatch.setattr(kaspi_module, "_build_kaspi_offers_xml", _build_xml)
+
+
+async def test_kaspi_subscription_trial_blocks_kaspi_endpoints(
     async_client,
     async_db_session,
     company_a_admin_headers,
 ):
     await _set_plan(async_db_session, company_id=1001, plan="start")
 
-    r = await async_client.get(
+    r_goods = await async_client.get(
         "/api/v1/kaspi/goods/imports",
         headers=company_a_admin_headers,
     )
-    assert r.status_code == 402
-    payload = r.json()
-    assert payload.get("detail") == "subscription_required"
-    assert payload.get("code") == "subscription_required"
-    assert payload.get("request_id")
+    _assert_subscription_required(r_goods)
+
+    r_feed_uploads = await async_client.get(
+        "/api/v1/kaspi/feed/uploads",
+        headers=company_a_admin_headers,
+    )
+    _assert_subscription_required(r_feed_uploads)
+
+    r_autosync = await async_client.get(
+        "/api/v1/kaspi/autosync/status",
+        headers=company_a_admin_headers,
+    )
+    _assert_subscription_required(r_autosync)
+
+    r_sync_now = await async_client.post(
+        "/api/v1/kaspi/sync/now",
+        headers=company_a_admin_headers,
+        json={"merchant_uid": "M1"},
+    )
+    _assert_subscription_required(r_sync_now)
 
 
-async def test_kaspi_subscription_basic_allows_goods_imports_blocks_feed_uploads(
+@pytest.mark.parametrize("plan", ["basic", "pro"])
+async def test_kaspi_subscription_basic_pro_allow_kaspi_endpoints(
     async_client,
     async_db_session,
+    monkeypatch,
     company_a_admin_headers,
+    plan,
 ):
-    await _set_plan(async_db_session, company_id=1001, plan="basic")
+    await _set_plan(async_db_session, company_id=1001, plan=plan)
 
-    r_ok = await async_client.get(
+    r_goods = await async_client.get(
         "/api/v1/kaspi/goods/imports?limit=1",
         headers=company_a_admin_headers,
     )
-    assert r_ok.status_code == 200
+    assert r_goods.status_code == 200
 
-    r_block = await async_client.get(
-        "/api/v1/kaspi/feed/uploads",
+    r_feed_uploads = await async_client.get(
+        "/api/v1/kaspi/feed/uploads?limit=1",
         headers=company_a_admin_headers,
     )
-    assert r_block.status_code == 402
-
-
-async def test_kaspi_subscription_pro_allows_feed_uploads_and_autosync(
-    async_client,
-    async_db_session,
-    company_a_admin_headers,
-):
-    await _set_plan(async_db_session, company_id=1001, plan="pro")
-
-    r_uploads = await async_client.get(
-        "/api/v1/kaspi/feed/uploads",
-        headers=company_a_admin_headers,
-    )
-    assert r_uploads.status_code == 200
+    assert r_feed_uploads.status_code == 200
 
     r_autosync = await async_client.get(
         "/api/v1/kaspi/autosync/status",
         headers=company_a_admin_headers,
     )
     assert r_autosync.status_code == 200
+
+    await _prepare_sync_now(async_db_session, monkeypatch, company_id=1001, merchant_uid="M1")
+
+    r_sync_now = await async_client.post(
+        "/api/v1/kaspi/sync/now",
+        headers=company_a_admin_headers,
+        json={"merchant_uid": "M1"},
+    )
+    assert r_sync_now.status_code == 200

--- a/tests/app/test_kaspi_subscription_matrix.py
+++ b/tests/app/test_kaspi_subscription_matrix.py
@@ -52,7 +52,7 @@ async def test_kaspi_subscription_trial_blocks_goods_imports(
         "/api/v1/kaspi/goods/imports",
         headers=company_a_admin_headers,
     )
-    assert r.status_code == 403
+    assert r.status_code == 402
     payload = r.json()
     assert payload.get("detail") == "subscription_required"
     assert payload.get("code") == "subscription_required"
@@ -76,7 +76,7 @@ async def test_kaspi_subscription_basic_allows_goods_imports_blocks_feed_uploads
         "/api/v1/kaspi/feed/uploads",
         headers=company_a_admin_headers,
     )
-    assert r_block.status_code == 403
+    assert r_block.status_code == 402
 
 
 async def test_kaspi_subscription_pro_allows_feed_uploads_and_autosync(

--- a/tests/app/test_kaspi_sync_now.py
+++ b/tests/app/test_kaspi_sync_now.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import time
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 import pytest
+import pytest_asyncio
+from sqlalchemy import select
 
+from app.core.subscriptions.plan_catalog import normalize_plan_id
+from app.models.billing import Subscription
 from app.models.company import Company
 from app.models.kaspi_offer import KaspiOffer
 from app.models.marketplace import KaspiStoreToken
@@ -17,6 +23,44 @@ async def _ensure_company(async_db_session, company_id: int, store_id: str) -> N
         async_db_session.add(company)
     company.kaspi_store_id = store_id
     await async_db_session.commit()
+
+
+async def _ensure_subscription_plan(async_db_session, company_id: int, plan: str) -> None:
+    existing_company = await async_db_session.get(Company, company_id)
+    if not existing_company:
+        async_db_session.add(Company(id=company_id, name=f"Company {company_id}"))
+        await async_db_session.flush()
+
+    res = await async_db_session.execute(
+        select(Subscription).where(Subscription.company_id == company_id).where(Subscription.deleted_at.is_(None))
+    )
+    sub = res.scalars().first()
+    now = datetime.now(UTC)
+    if sub is None:
+        sub = Subscription(
+            company_id=company_id,
+            plan=normalize_plan_id(plan) or "trial",
+            status="active",
+            billing_cycle="monthly",
+            price=Decimal("0.00"),
+            currency="KZT",
+            started_at=now,
+            period_start=now,
+            period_end=now + timedelta(days=30),
+            next_billing_date=now + timedelta(days=31),
+        )
+        async_db_session.add(sub)
+    else:
+        sub.plan = normalize_plan_id(plan) or "trial"
+        sub.status = "active"
+    await async_db_session.commit()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _ensure_sync_now_subscription(async_db_session, request):
+    if "company_a_admin_headers" not in request.fixturenames:
+        return
+    await _ensure_subscription_plan(async_db_session, company_id=1001, plan="basic")
 
 
 @pytest.mark.asyncio
@@ -49,6 +93,27 @@ async def test_kaspi_sync_now_lock_prevents_parallel(
     data = resp.json()
     assert data.get("detail") == "kaspi_sync_in_progress"
     assert data.get("code") == "kaspi_sync_in_progress"
+
+
+@pytest.mark.asyncio
+async def test_kaspi_sync_now_trial_requires_subscription(
+    async_client,
+    async_db_session,
+    company_a_admin_headers,
+):
+    await _ensure_subscription_plan(async_db_session, company_id=1001, plan="start")
+    await _ensure_company(async_db_session, 1001, "store-a")
+
+    resp = await async_client.post(
+        "/api/v1/kaspi/sync/now",
+        headers=company_a_admin_headers,
+        json={"merchant_uid": "M1"},
+    )
+    assert resp.status_code == 402
+    payload = resp.json()
+    assert payload.get("detail") == "subscription_required"
+    assert payload.get("code") == "subscription_required"
+    assert payload.get("request_id")
 
 
 @pytest.mark.asyncio

--- a/tests/app/test_tenant_isolation_billing.py
+++ b/tests/app/test_tenant_isolation_billing.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 import pytest
 from sqlalchemy import select
 
+from app.core.subscriptions.plan_catalog import normalize_plan_id
 from app.models.billing import Subscription
 from app.models.company import Company
 from app.models.user import User
@@ -37,7 +38,7 @@ async def _ensure_active_subscription(async_db_session, company_id: int) -> None
     now = datetime.now(UTC)
     sub = Subscription(
         company_id=company_id,
-        plan="start",
+        plan=normalize_plan_id("start") or "trial",
         status="active",
         billing_cycle="monthly",
         price=Decimal("0.00"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1075,6 +1075,7 @@ async def _ensure_active_subscription(async_db_session: AsyncSession, request):
 
     from sqlalchemy import select
 
+    from app.core.subscriptions.plan_catalog import normalize_plan_id
     from app.models.billing import Subscription
     from app.models.company import Company
 
@@ -1103,7 +1104,7 @@ async def _ensure_active_subscription(async_db_session: AsyncSession, request):
 
         sub = Subscription(
             company_id=company_id,
-            plan="start",
+            plan=normalize_plan_id("start") or "trial",
             status="active",
             billing_cycle="monthly",
             price=Decimal("0.00"),
@@ -1146,6 +1147,7 @@ def db_session(test_db: None):
 def auth_headers(test_db: None):
     """Seed a platform admin user and return its bearer token."""
     from app.core.security import create_access_token, get_password_hash  # type: ignore
+    from app.core.subscriptions.plan_catalog import normalize_plan_id
     from app.models.billing import Subscription  # type: ignore
     from app.models.company import Company  # type: ignore
     from app.models.user import User  # type: ignore
@@ -1174,7 +1176,7 @@ def auth_headers(test_db: None):
         if existing_sub is None:
             sub = Subscription(
                 company_id=company.id,
-                plan="start",
+                plan=normalize_plan_id("start") or "trial",
                 status="active",
                 billing_cycle="monthly",
                 price=0,


### PR DESCRIPTION
Changes:
1) fix(kaspi): gate feed uploads + sync-now by admin+feature
2) feat(subscriptions): canonical plan ids + aliases; return display plan and plan_id
3) docs(journal): 30-day summary 2026-02-02

Notes:
- plan_id stable: start|business|pro
- API returns plan (display) + plan_id
- Kaspi endpoints now check admin/RBAC before subscription gating