### PR TITLE
Subscriptions: plans catalog endpoint

### DIFF
--- a/app/api/v1/subscriptions.py
+++ b/app/api/v1/subscriptions.py
@@ -20,7 +20,11 @@ from app.core.security import (
     is_token_revoked,
     resolve_tenant_company_id,
 )
-from app.core.subscriptions.plan_catalog import get_plan_display_name, normalize_plan_id
+from app.core.subscriptions.plan_catalog import (
+    get_plan_display_name,
+    list_plans,
+    normalize_plan_id,
+)
 from app.models.billing import BillingPayment, Subscription
 from app.models.company import Company
 from app.models.user import User
@@ -105,6 +109,14 @@ class PaymentOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class PlanCatalogOut(BaseModel):
+    plan_id: str
+    plan: str
+    currency: str
+    monthly_price: Decimal
+    yearly_price: Decimal
+
+
 # ====== Утилиты доступа/времени ======
 def utc_now() -> datetime:
     return datetime.now(UTC)
@@ -145,6 +157,11 @@ def ensure_company_access(user, company: Company) -> None:
     }:
         return
     raise HTTPException(status_code=404, detail="Company not found")
+
+
+def ensure_platform_admin(user: User) -> None:
+    if getattr(user, "role", None) not in {"platform_admin", "superadmin"}:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
 
 
 async def _get_subscription_scoped(
@@ -229,6 +246,14 @@ async def _auth_user(
     if not user:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
     return user
+
+
+@router.get("/plans", response_model=list[PlanCatalogOut])
+async def list_plan_catalog(
+    user: User = Depends(_auth_user),
+):
+    ensure_platform_admin(user)
+    return list_plans()
 
 
 # ====== Эндпоинты ======

--- a/app/core/subscriptions/plan_catalog.py
+++ b/app/core/subscriptions/plan_catalog.py
@@ -61,6 +61,25 @@ def iter_plan_ids() -> Iterable[str]:
     return PLAN_CATALOG.keys()
 
 
+def list_plans() -> list[dict[str, Decimal | str]]:
+    ordered = ["start", "business", "pro"]
+    items: list[dict[str, Decimal | str]] = []
+    for plan_id in ordered:
+        plan = PLAN_CATALOG[plan_id]
+        monthly_price = plan.price
+        yearly_price = plan.price * Decimal("12")
+        items.append(
+            {
+                "plan_id": plan.plan_id,
+                "plan": plan.display_name,
+                "currency": plan.currency,
+                "monthly_price": monthly_price,
+                "yearly_price": yearly_price,
+            }
+        )
+    return items
+
+
 __all__ = [
     "PlanCatalogEntry",
     "PLAN_CATALOG",
@@ -70,4 +89,5 @@ __all__ = [
     "get_plan",
     "get_plan_display_name",
     "iter_plan_ids",
+    "list_plans",
 ]

--- a/tests/app/api/test_subscription_plans_catalog_api.py
+++ b/tests/app/api/test_subscription_plans_catalog_api.py
@@ -1,0 +1,18 @@
+import pytest
+
+BASE = "/api/v1/subscriptions/plans"
+
+
+@pytest.mark.asyncio
+async def test_subscription_plans_catalog_admin_ok(client, auth_headers):
+    resp = await client.get(BASE, headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [item["plan_id"] for item in data] == ["start", "business", "pro"]
+    assert [item["plan"] for item in data] == ["Start", "Business", "Pro"]
+
+
+@pytest.mark.asyncio
+async def test_subscription_plans_catalog_non_admin_forbidden(client, company_a_admin_headers):
+    resp = await client.get(BASE, headers=company_a_admin_headers)
+    assert resp.status_code == 403


### PR DESCRIPTION
Expose /api/v1/subscriptions/plans (admin-only) from plan_catalog single source of truth.