### PR TITLE
Kaspi: orders list endpoint (D2)

### DIFF
--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -50,7 +50,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from openpyxl import Workbook, load_workbook
 from pydantic import BaseModel, ConfigDict, Field, field_validator
-from sqlalchemy import bindparam, text
+from sqlalchemy import bindparam, select, text
 from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -80,7 +80,7 @@ from app.models.kaspi_mc_session import KaspiMcSession
 from app.models.kaspi_offer import KaspiOffer
 from app.models.kaspi_order_sync_state import KaspiOrderSyncState
 from app.models.marketplace import KaspiStoreToken
-from app.models.order import OrderStatus
+from app.models.order import Order, OrderSource, OrderStatus
 from app.models.user import User
 from app.schemas.kaspi import (
     ImportRequest,
@@ -1083,25 +1083,37 @@ async def kaspi_health(store: str):
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 
 
+class KaspiOrderEntryOut(BaseModel):
+    id: int
+    sku: str
+    name: str
+    quantity: int
+    unit_price: Decimal
+    total_price: Decimal
+
+
 class KaspiOrderListItemOut(BaseModel):
-    order_id: str
-    code: str | None = None
-    creation_date: datetime | None = None
-    state: str | None = None
-    total_price: Decimal | None = None
-    customer: dict[str, Any] | None = None
-    entries: list[dict[str, Any]] | None = None
+    id: int
+    external_id: str | None = None
+    order_number: str
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    total_amount: Decimal
+    currency: str
+    customer_name: str | None = None
+    customer_phone: str | None = None
+
+
+class KaspiOrderDetailOut(KaspiOrderListItemOut):
+    items: list[KaspiOrderEntryOut]
 
 
 class KaspiOrdersListOut(BaseModel):
-    ok: bool
-    merchant_uid: str
-    state: str | None = None
+    items: list[KaspiOrderListItemOut]
     page: int
     limit: int
-    count: int
-    data: list[KaspiOrderListItemOut]
-    request_id: str
+    total: int
 
 
 def _parse_iso_dt(value: str) -> datetime:
@@ -1138,30 +1150,68 @@ def _status_to_str(value: OrderStatus | str | None) -> str:
     return str(value)
 
 
+def _normalize_db_dt(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(tz=UTC).replace(tzinfo=None)
+
+
+def _order_to_list_item(order: Order) -> KaspiOrderListItemOut:
+    return KaspiOrderListItemOut(
+        id=order.id,
+        external_id=order.external_id,
+        order_number=order.order_number,
+        status=_status_to_str(order.status),
+        created_at=order.created_at,
+        updated_at=order.updated_at,
+        total_amount=Decimal(order.total_amount or 0),
+        currency=order.currency,
+        customer_name=order.customer_name,
+        customer_phone=order.customer_phone,
+    )
+
+
+def _order_to_detail(order: Order) -> KaspiOrderDetailOut:
+    items = [
+        KaspiOrderEntryOut(
+            id=item.id,
+            sku=item.sku,
+            name=item.name,
+            quantity=int(item.quantity or 0),
+            unit_price=Decimal(item.unit_price or 0),
+            total_price=Decimal(item.total_price or 0),
+        )
+        for item in (order.items or [])
+    ]
+    base = _order_to_list_item(order)
+    return KaspiOrderDetailOut(**base.model_dump(), items=items)
+
+
 @router.get(
     "/orders",
     response_model=KaspiOrdersListOut,
-    summary="Kaspi orders list (remote)",
+    summary="Kaspi orders list (local)",
 )
 async def kaspi_orders_list(
     request: Request,
-    merchant_uid: str = Query(..., min_length=1, alias="merchantUid"),
-    state: str | None = Query("NEW"),
-    date_from: str | None = Query(None),
-    date_to: str | None = Query(None),
-    days_back: int | None = Query(14, ge=1, le=14),
-    page: int = Query(0, ge=0),
-    limit: int = Query(50, ge=1, le=100),
-    include_entries: bool = Query(True),
-    current_user: User = Depends(require_feature(FEATURE_KASPI_ORDERS_LIST)),
+    merchant_uid: str | None = Query(None, min_length=1, alias="merchantUid"),
+    state: str | None = Query(None),
+    created_from: str | None = Query(None),
+    created_to: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    limit: int = Query(50, ge=1, le=200),
+    current_user: User = Depends(require_admin_then_feature(FEATURE_KASPI_ORDERS_LIST)),
     session: AsyncSession = Depends(get_async_db),
 ):
     company_id = _resolve_company_id(current_user)
     request_id = getattr(getattr(request, "state", None), "request_id", None)
     rid = request_id or request.headers.get("X-Request-ID") or str(uuid4())
-
-    if not merchant_uid.isdigit():
-        payload = {"detail": "invalid_merchant_uid", "code": "invalid_merchant_uid", "request_id": rid}
+    if not merchant_uid:
+        company = await session.get(Company, company_id)
+        # Default store: company.kaspi_store_id (single-store assumption).
+        merchant_uid = (company.kaspi_store_id or "").strip() if company else ""
+    if not merchant_uid:
+        payload = {"detail": "merchant_uid_required", "code": "merchant_uid_required", "request_id": rid}
         return JSONResponse(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             content=payload,
@@ -1184,10 +1234,11 @@ async def kaspi_orders_list(
             headers={"X-Request-ID": rid},
         )
 
-    if date_from and date_to:
+    dt_from = None
+    dt_to = None
+    if created_from:
         try:
-            dt_from = _parse_iso_dt(date_from)
-            dt_to = _parse_iso_dt(date_to)
+            dt_from = _normalize_db_dt(_parse_iso_dt(created_from))
         except HTTPException:
             payload = {"detail": "invalid_datetime", "code": "invalid_datetime", "request_id": rid}
             return JSONResponse(
@@ -1195,59 +1246,67 @@ async def kaspi_orders_list(
                 content=payload,
                 headers={"X-Request-ID": rid},
             )
-    else:
-        days = days_back or 14
-        if days > 14:
-            payload = {"detail": "days_back_too_large", "code": "days_back_too_large", "request_id": rid}
+    if created_to:
+        try:
+            dt_to = _normalize_db_dt(_parse_iso_dt(created_to))
+        except HTTPException:
+            payload = {"detail": "invalid_datetime", "code": "invalid_datetime", "request_id": rid}
             return JSONResponse(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_400_BAD_REQUEST,
                 content=payload,
                 headers={"X-Request-ID": rid},
             )
-        dt_to = datetime.now(tz=UTC)
-        dt_from = dt_to - timedelta(days=days)
 
-    try:
-        _store_name, token = await _resolve_kaspi_token(session, company_id)
-    except HTTPException as exc:
-        if exc.status_code in {status.HTTP_404_NOT_FOUND, status.HTTP_409_CONFLICT}:
-            payload = {"detail": "kaspi_not_configured", "code": "kaspi_not_configured", "request_id": rid}
-            return JSONResponse(
-                status_code=status.HTTP_409_CONFLICT,
-                content=payload,
-                headers={"X-Request-ID": rid},
-            )
-        raise
-
-    svc = KaspiService()
-    result = await svc.list_orders(
-        token=token,
-        merchant_uid=merchant_uid,
-        state=state,
-        date_from_ms=_to_ms(dt_from),
-        date_to_ms=_to_ms(dt_to),
-        page=page,
-        limit=limit,
-        include_entries=include_entries,
-        request_id=rid,
+    stmt = select(Order).where(
+        Order.company_id == company_id,
+        Order.source == OrderSource.KASPI,
     )
-    if not result.get("ok"):
-        code = result.get("code") or "upstream_error"
-        detail = result.get("detail") or "kaspi_upstream_error"
-        status_code = result.get("status_code") or status.HTTP_502_BAD_GATEWAY
-        payload = {"detail": detail, "code": code, "request_id": rid}
-        return JSONResponse(status_code=status_code, content=payload, headers={"X-Request-ID": rid})
+    if state:
+        stmt = stmt.where(Order.status == _status_to_str(state))
+    if dt_from:
+        stmt = stmt.where(Order.created_at >= dt_from)
+    if dt_to:
+        stmt = stmt.where(Order.created_at <= dt_to)
+
+    total = (await session.scalar(select(sa.func.count()).select_from(stmt.subquery()))) or 0
+
+    offset = (page - 1) * limit
+    rows = (await session.execute(stmt.order_by(Order.created_at.desc()).limit(limit).offset(offset))).scalars().all()
 
     return KaspiOrdersListOut(
-        ok=True,
-        merchant_uid=merchant_uid,
-        state=state,
+        items=[_order_to_list_item(order) for order in rows],
         page=page,
         limit=limit,
-        count=len(result.get("data") or []),
-        data=result.get("data") or [],
-        request_id=rid,
+        total=int(total),
     )
+
+
+@router.get(
+    "/orders/{order_id}",
+    response_model=KaspiOrderDetailOut,
+    summary="Kaspi order detail (local)",
+)
+async def kaspi_order_detail(
+    order_id: int,
+    request: Request,
+    current_user: User = Depends(require_admin_then_feature(FEATURE_KASPI_ORDERS_LIST)),
+    session: AsyncSession = Depends(get_async_db),
+):
+    company_id = _resolve_company_id(current_user)
+    request_id = getattr(getattr(request, "state", None), "request_id", None)
+    rid = request_id or request.headers.get("X-Request-ID") or str(uuid4())
+
+    order = await session.get(Order, order_id)
+    if not order or order.company_id != company_id or order.source != OrderSource.KASPI:
+        payload = {"detail": "order_not_found", "code": "order_not_found", "request_id": rid}
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=payload,
+            headers={"X-Request-ID": rid},
+        )
+
+    await session.refresh(order, attribute_names=["items"])
+    return _order_to_detail(order)
 
 
 @router.post(

--- a/tests/app/test_kaspi_orders_list_d2.py
+++ b/tests/app/test_kaspi_orders_list_d2.py
@@ -1,69 +1,53 @@
-from datetime import UTC, datetime
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 import pytest
 
 from app.models.kaspi_offer import KaspiOffer
-from app.services.kaspi_service import KaspiService
+from app.models.order import Order, OrderItem, OrderSource, OrderStatus
 
 pytestmark = pytest.mark.asyncio
 
 
-class _FakeResponse:
-    def __init__(self, status_code: int, payload: dict):
-        self.status_code = status_code
-        self._payload = payload
-
-    def json(self):
-        return self._payload
-
-    def raise_for_status(self):
-        if self.status_code >= 400:
-            raise RuntimeError("bad response")
-
-
-class _FakeAsyncClient:
-    def __init__(self, response: _FakeResponse, capture: dict):
-        self._response = response
-        self._capture = capture
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        return False
-
-    async def get(self, url, headers=None, params=None):
-        self._capture["url"] = url
-        self._capture["headers"] = headers or {}
-        self._capture["params"] = params or {}
-        return self._response
-
-
-async def _create_offer(session, *, company_id: int, merchant_uid: str):
-    offer = KaspiOffer(company_id=company_id, merchant_uid=merchant_uid, sku="SKU", title="Item", price=1000)
+async def _create_offer(session, *, company_id: int, merchant_uid: str, sku: str) -> None:
+    offer = KaspiOffer(company_id=company_id, merchant_uid=merchant_uid, sku=sku, title="Item", price=1000)
     session.add(offer)
     await session.commit()
 
 
+def _make_order(*, company_id: int, ext_id: str, created_at: datetime, status: OrderStatus) -> Order:
+    return Order(
+        company_id=company_id,
+        order_number=f"KASPI-{company_id}-{ext_id}",
+        external_id=ext_id,
+        source=OrderSource.KASPI,
+        status=status,
+        customer_name="Alice",
+        customer_phone="+70000000000",
+        total_amount=Decimal("1000.00"),
+        currency="KZT",
+        created_at=created_at.replace(tzinfo=None),
+        updated_at=created_at.replace(tzinfo=None),
+    )
+
+
 async def test_kaspi_orders_list_requires_auth(async_client):
     resp = await async_client.get("/api/v1/kaspi/orders?merchantUid=123")
-    assert resp.status_code in {401, 403}
+    assert resp.status_code == 401
 
 
-async def test_kaspi_orders_list_tenant_isolation(
-    async_client,
-    async_db_session,
-    monkeypatch,
-    company_a_admin_headers,
-):
-    from app.api.v1 import kaspi as kaspi_module
+async def test_kaspi_orders_list_non_admin_forbidden(async_client, company_a_manager_headers):
+    resp = await async_client.get("/api/v1/kaspi/orders?merchantUid=123", headers=company_a_manager_headers)
+    assert resp.status_code == 403
 
-    await _create_offer(async_db_session, company_id=2001, merchant_uid="999")
 
-    async def _resolve_token(session, company_id: int):
-        return "store-a", "token-a"
-
-    monkeypatch.setattr(kaspi_module, "_resolve_kaspi_token", _resolve_token)
+async def test_kaspi_orders_list_tenant_isolation(async_client, async_db_session, company_a_admin_headers):
+    await _create_offer(async_db_session, company_id=2001, merchant_uid="999", sku="SKU-ISO")
+    order = _make_order(company_id=2001, ext_id="o1", created_at=datetime.now(UTC), status=OrderStatus.PENDING)
+    async_db_session.add(order)
+    await async_db_session.commit()
 
     resp = await async_client.get(
         "/api/v1/kaspi/orders?merchantUid=999",
@@ -74,111 +58,70 @@ async def test_kaspi_orders_list_tenant_isolation(
     assert data["code"] == "merchant_not_found"
 
 
-async def test_kaspi_orders_list_validation(
-    async_client,
-    async_db_session,
-    monkeypatch,
-    company_a_admin_headers,
-):
-    from app.api.v1 import kaspi as kaspi_module
-
-    await _create_offer(async_db_session, company_id=1001, merchant_uid="123")
-
-    async def _resolve_token(session, company_id: int):
-        return "store-a", "token-a"
-
-    monkeypatch.setattr(kaspi_module, "_resolve_kaspi_token", _resolve_token)
+async def test_kaspi_orders_list_pagination(async_client, async_db_session, company_a_admin_headers):
+    await _create_offer(async_db_session, company_id=1001, merchant_uid="123", sku="SKU-PAGE")
+    now = datetime.utcnow()
+    async_db_session.add_all(
+        [
+            _make_order(company_id=1001, ext_id="o1", created_at=now - timedelta(days=1), status=OrderStatus.PENDING),
+            _make_order(company_id=1001, ext_id="o2", created_at=now - timedelta(hours=12), status=OrderStatus.PENDING),
+            _make_order(company_id=1001, ext_id="o3", created_at=now - timedelta(hours=1), status=OrderStatus.PENDING),
+        ]
+    )
+    await async_db_session.commit()
 
     resp = await async_client.get(
-        "/api/v1/kaspi/orders?merchantUid=ABC",
-        headers=company_a_admin_headers,
-    )
-    assert resp.status_code == 422
-
-    resp2 = await async_client.get(
-        "/api/v1/kaspi/orders?merchantUid=123&days_back=20",
-        headers=company_a_admin_headers,
-    )
-    assert resp2.status_code == 422
-
-
-async def test_kaspi_orders_list_happy_path(
-    async_client,
-    async_db_session,
-    monkeypatch,
-    company_a_admin_headers,
-):
-    from app.api.v1 import kaspi as kaspi_module
-
-    await _create_offer(async_db_session, company_id=1001, merchant_uid="123")
-
-    async def _resolve_token(session, company_id: int):
-        return "store-a", "token-a"
-
-    async def _list_orders(self, **kwargs):
-        return {
-            "ok": True,
-            "data": [
-                {
-                    "order_id": "o1",
-                    "state": "NEW",
-                    "creation_date": datetime(2025, 1, 1, tzinfo=UTC),
-                    "total_price": 1000,
-                    "customer": {"name": "Alice"},
-                    "entries": [{"sku": "S1"}],
-                }
-            ],
-        }
-
-    monkeypatch.setattr(kaspi_module, "_resolve_kaspi_token", _resolve_token)
-    monkeypatch.setattr(KaspiService, "list_orders", _list_orders)
-
-    resp = await async_client.get(
-        "/api/v1/kaspi/orders?merchantUid=123&state=NEW&page=0&limit=2",
+        "/api/v1/kaspi/orders?merchantUid=123&page=1&limit=2",
         headers=company_a_admin_headers,
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert data["ok"] is True
-    assert data["count"] == 1
-    assert data["data"][0]["order_id"] == "o1"
+    assert data["total"] == 3
+    assert data["page"] == 1
+    assert data["limit"] == 2
+    assert len(data["items"]) == 2
 
 
-async def test_kaspi_orders_list_service_params(monkeypatch):
-    capture: dict = {}
-    payload = {
-        "data": [
-            {
-                "id": "o1",
-                "attributes": {
-                    "state": "NEW",
-                    "creationDate": 1700000000000,
-                    "totalPrice": 1000,
-                },
-            }
-        ],
-    }
-
-    monkeypatch.setattr(
-        "app.services.kaspi_service.httpx.AsyncClient",
-        lambda *args, **kwargs: _FakeAsyncClient(_FakeResponse(200, payload), capture),
+async def test_kaspi_orders_list_filters(async_client, async_db_session, company_a_admin_headers):
+    await _create_offer(async_db_session, company_id=1001, merchant_uid="123", sku="SKU-FILTER")
+    base = datetime(2026, 2, 1)
+    async_db_session.add_all(
+        [
+            _make_order(company_id=1001, ext_id="a1", created_at=base, status=OrderStatus.PENDING),
+            _make_order(company_id=1001, ext_id="a2", created_at=base + timedelta(hours=1), status=OrderStatus.SHIPPED),
+        ]
     )
+    await async_db_session.commit()
 
-    svc = KaspiService()
-    out = await svc.list_orders(
-        token="token",
-        merchant_uid="123",
-        state="NEW",
-        date_from_ms=1700000000000,
-        date_to_ms=1700003600000,
-        page=0,
-        limit=50,
-        include_entries=True,
-        request_id="rid",
+    resp = await async_client.get(
+        "/api/v1/kaspi/orders?merchantUid=123&state=shipped&created_from=2026-02-01T00:30:00Z&created_to=2026-02-01T02:00:00Z",
+        headers=company_a_admin_headers,
     )
-    assert out["ok"] is True
-    assert capture["params"]["filter[orders][merchantUid]"] == "123"
-    assert capture["params"]["filter[orders][creationDate][$ge]"] == 1700000000000
-    assert capture["params"]["filter[orders][creationDate][$le]"] == 1700003600000
-    assert capture["params"]["filter[orders][state]"] == "NEW"
-    assert capture["params"]["include[orders]"] == "entries"
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["items"][0]["external_id"] == "a2"
+
+
+async def test_kaspi_orders_detail_includes_items(async_client, async_db_session, company_a_admin_headers):
+    await _create_offer(async_db_session, company_id=1001, merchant_uid="123", sku="SKU-DETAIL")
+    order = _make_order(company_id=1001, ext_id="d1", created_at=datetime.utcnow(), status=OrderStatus.PAID)
+    async_db_session.add(order)
+    await async_db_session.flush()
+    item = OrderItem(
+        order_id=order.id,
+        sku="SKU-1",
+        name="Item 1",
+        quantity=2,
+        unit_price=Decimal("500.00"),
+        total_price=Decimal("1000.00"),
+        cost_price=Decimal("100.00"),
+    )
+    async_db_session.add(item)
+    await async_db_session.commit()
+
+    resp = await async_client.get(f"/api/v1/kaspi/orders/{order.id}", headers=company_a_admin_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == order.id
+    assert data["items"][0]["sku"] == "SKU-1"


### PR DESCRIPTION
Add DB-backed GET /api/v1/kaspi/orders (+ optional detail), paging/filters, tenant isolation tests, RBAC-before-feature gating.