### PR TITLE
Subscriptions: feature matrix + Kaspi enforcement (Milestone E)

### DIFF
--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -2410,11 +2410,9 @@ async def kaspi_goods_import_result(
 )
 async def kaspi_goods_import_create(
     body: KaspiGoodsImportCreateIn,
-    current_user: User = Depends(require_feature(FEATURE_KASPI_GOODS_IMPORTS)),
+    current_user: User = Depends(require_admin_then_feature(FEATURE_KASPI_GOODS_IMPORTS)),
     session: AsyncSession = Depends(get_async_db),
 ):
-    _require_admin(current_user)
-
     merchant_uid = (body.merchant_uid or "").strip()
     if not merchant_uid:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="missing_merchant_uid")
@@ -2505,10 +2503,9 @@ async def kaspi_goods_import_create(
 async def kaspi_goods_import_list(
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
-    current_user: User = Depends(require_feature(FEATURE_KASPI_GOODS_IMPORTS)),
+    current_user: User = Depends(require_admin_then_feature(FEATURE_KASPI_GOODS_IMPORTS)),
     session: AsyncSession = Depends(get_async_db),
 ):
-    _require_admin(current_user)
     company_id = _resolve_company_id(current_user)
 
     result = await session.execute(
@@ -2529,10 +2526,9 @@ async def kaspi_goods_import_list(
 )
 async def kaspi_goods_import_get(
     import_id: str,
-    current_user: User = Depends(require_feature(FEATURE_KASPI_GOODS_IMPORTS)),
+    current_user: User = Depends(require_admin_then_feature(FEATURE_KASPI_GOODS_IMPORTS)),
     session: AsyncSession = Depends(get_async_db),
 ):
-    _require_admin(current_user)
     company_id = _resolve_company_id(current_user)
 
     record = (
@@ -2560,10 +2556,9 @@ async def kaspi_goods_import_get(
 async def kaspi_goods_import_refresh(
     import_id: str,
     request: Request,
-    current_user: User = Depends(require_feature(FEATURE_KASPI_GOODS_IMPORTS)),
+    current_user: User = Depends(require_admin_then_feature(FEATURE_KASPI_GOODS_IMPORTS)),
     session: AsyncSession = Depends(get_async_db),
 ):
-    _require_admin(current_user)
     company_id = _resolve_company_id(current_user)
 
     record = (

--- a/app/core/subscriptions/features.py
+++ b/app/core/subscriptions/features.py
@@ -11,6 +11,7 @@ from app.core.db import get_async_db
 from app.core.exceptions import AuthorizationError
 from app.core.logging import get_logger
 from app.core.security import get_current_user, resolve_tenant_company_id
+from app.core.subscriptions.plan_catalog import get_plan_features as _catalog_plan_features
 from app.core.subscriptions.plan_catalog import normalize_plan_id
 from app.models.company import Company
 from app.services.subscriptions import get_company_subscription, is_subscription_active
@@ -22,26 +23,6 @@ FEATURE_KASPI_SYNC_NOW = "kaspi.sync_now"
 FEATURE_KASPI_GOODS_IMPORTS = "kaspi.goods_imports"
 FEATURE_KASPI_FEED_UPLOADS = "kaspi.feed_uploads"
 FEATURE_KASPI_AUTOSYNC = "kaspi.autosync"
-
-_FEATURE_MATRIX: dict[str, set[str]] = {
-    "start": {
-        FEATURE_KASPI_ORDERS_LIST,
-    },
-    "business": {
-        FEATURE_KASPI_ORDERS_LIST,
-        FEATURE_KASPI_SYNC_NOW,
-        FEATURE_KASPI_GOODS_IMPORTS,
-        FEATURE_KASPI_FEED_UPLOADS,
-        FEATURE_KASPI_AUTOSYNC,
-    },
-    "pro": {
-        FEATURE_KASPI_ORDERS_LIST,
-        FEATURE_KASPI_SYNC_NOW,
-        FEATURE_KASPI_GOODS_IMPORTS,
-        FEATURE_KASPI_FEED_UPLOADS,
-        FEATURE_KASPI_AUTOSYNC,
-    },
-}
 
 
 async def _resolve_plan(db: AsyncSession, company_id: int) -> str:
@@ -55,7 +36,7 @@ async def _resolve_plan(db: AsyncSession, company_id: int) -> str:
 
 
 def _has_feature(plan: str, feature: str) -> bool:
-    return feature in _FEATURE_MATRIX.get(plan, set())
+    return feature in _catalog_plan_features(plan)
 
 
 def require_feature(feature: str) -> Any:
@@ -79,7 +60,7 @@ def require_feature(feature: str) -> Any:
 
 
 def get_plan_features(plan: str) -> Iterable[str]:
-    return _FEATURE_MATRIX.get(normalize_plan_id(plan) or "start", set())
+    return _catalog_plan_features(normalize_plan_id(plan) or "start")
 
 
 __all__ = [

--- a/app/core/subscriptions/plan_catalog.py
+++ b/app/core/subscriptions/plan_catalog.py
@@ -27,6 +27,26 @@ PLAN_ALIASES: dict[str, str] = {
     "pro": "pro",
 }
 
+FEATURE_MATRIX: dict[str, set[str]] = {
+    "start": {
+        "kaspi.orders_list",
+    },
+    "business": {
+        "kaspi.orders_list",
+        "kaspi.sync_now",
+        "kaspi.goods_imports",
+        "kaspi.feed_uploads",
+        "kaspi.autosync",
+    },
+    "pro": {
+        "kaspi.orders_list",
+        "kaspi.sync_now",
+        "kaspi.goods_imports",
+        "kaspi.feed_uploads",
+        "kaspi.autosync",
+    },
+}
+
 
 def normalize_plan_id(raw: str | None, *, default: str | None = "start") -> str | None:
     key = (raw or "").strip().lower()
@@ -80,14 +100,21 @@ def list_plans() -> list[dict[str, Decimal | str]]:
     return items
 
 
+def get_plan_features(plan_id: str | None) -> set[str]:
+    normalized = normalize_plan_id(plan_id) or "start"
+    return FEATURE_MATRIX.get(normalized, set())
+
+
 __all__ = [
     "PlanCatalogEntry",
     "PLAN_CATALOG",
     "PLAN_ALIASES",
+    "FEATURE_MATRIX",
     "normalize_plan_id",
     "is_canonical_plan_id",
     "get_plan",
     "get_plan_display_name",
     "iter_plan_ids",
     "list_plans",
+    "get_plan_features",
 ]

--- a/tests/app/test_kaspi_subscription_enforcement_e.py
+++ b/tests/app/test_kaspi_subscription_enforcement_e.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.billing import Subscription
+from app.models.company import Company
+from app.models.kaspi_offer import KaspiOffer
+from app.models.marketplace import KaspiStoreToken
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _set_plan(async_db_session, company_id: int, plan: str) -> None:
+    company = await async_db_session.get(Company, company_id)
+    if not company:
+        company = Company(id=company_id, name=f"Company {company_id}")
+        async_db_session.add(company)
+        await async_db_session.flush()
+
+    res = await async_db_session.execute(
+        select(Subscription).where(Subscription.company_id == company_id).where(Subscription.deleted_at.is_(None))
+    )
+    sub = res.scalars().first()
+    now = datetime.now(UTC)
+    if sub is None:
+        sub = Subscription(
+            company_id=company_id,
+            plan=plan,
+            status="active",
+            billing_cycle="monthly",
+            price=Decimal("0.00"),
+            currency="KZT",
+            started_at=now,
+            period_start=now,
+            period_end=now + timedelta(days=30),
+            next_billing_date=now + timedelta(days=31),
+        )
+        async_db_session.add(sub)
+    else:
+        sub.plan = plan
+        sub.status = "active"
+    await async_db_session.commit()
+
+
+async def _ensure_company(async_db_session, company_id: int, store_id: str) -> None:
+    company = await async_db_session.get(Company, company_id)
+    if not company:
+        company = Company(id=company_id, name=f"Company {company_id}")
+        async_db_session.add(company)
+    company.kaspi_store_id = store_id
+    await async_db_session.commit()
+
+
+async def _ensure_offer(async_db_session, company_id: int, merchant_uid: str) -> None:
+    offer = KaspiOffer(company_id=company_id, merchant_uid=merchant_uid, sku="SKU-1", title="Item", price=1000)
+    async_db_session.add(offer)
+    await async_db_session.commit()
+
+
+@pytest.mark.parametrize(
+    "method,path,payload",
+    [
+        ("post", "/api/v1/kaspi/sync/now", {"merchant_uid": "M1"}),
+        ("post", "/api/v1/kaspi/feed/uploads", {"merchant_uid": "M1", "source": "public_token"}),
+        ("post", "/api/v1/kaspi/feed/uploads/11111111-1111-1111-1111-111111111111/refresh", None),
+        ("post", "/api/v1/kaspi/feed/uploads/11111111-1111-1111-1111-111111111111/publish", None),
+        ("post", "/api/v1/kaspi/goods/imports", {"merchant_uid": "M1"}),
+        ("post", "/api/v1/kaspi/goods/imports/111/refresh", None),
+    ],
+)
+async def test_kaspi_enforcement_non_admin_forbidden(async_client, company_a_manager_headers, method, path, payload):
+    request = getattr(async_client, method)
+    resp = await request(path, headers=company_a_manager_headers, json=payload)
+    assert resp.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "method,path,payload",
+    [
+        ("post", "/api/v1/kaspi/sync/now", {"merchant_uid": "M1"}),
+        ("post", "/api/v1/kaspi/feed/uploads", {"merchant_uid": "M1", "source": "public_token"}),
+        ("post", "/api/v1/kaspi/feed/uploads/11111111-1111-1111-1111-111111111111/refresh", None),
+        ("post", "/api/v1/kaspi/feed/uploads/11111111-1111-1111-1111-111111111111/publish", None),
+        ("post", "/api/v1/kaspi/goods/imports", {"merchant_uid": "M1"}),
+        ("post", "/api/v1/kaspi/goods/imports/111/refresh", None),
+    ],
+)
+async def test_kaspi_enforcement_admin_missing_feature(
+    async_client, async_db_session, company_a_admin_headers, method, path, payload
+):
+    await _set_plan(async_db_session, company_id=1001, plan="start")
+    request = getattr(async_client, method)
+    resp = await request(path, headers=company_a_admin_headers, json=payload)
+    assert resp.status_code == 402
+    data = resp.json()
+    assert data.get("detail") == "subscription_required"
+    assert data.get("code") == "subscription_required"
+    assert data.get("request_id")
+
+
+async def test_kaspi_enforcement_admin_allowed_plan_goods_imports_list(
+    async_client,
+    async_db_session,
+    company_a_admin_headers,
+):
+    await _set_plan(async_db_session, company_id=1001, plan="business")
+    resp = await async_client.get("/api/v1/kaspi/goods/imports", headers=company_a_admin_headers)
+    assert resp.status_code == 200
+
+
+async def test_kaspi_enforcement_admin_allowed_plan_sync_now(
+    async_client,
+    async_db_session,
+    monkeypatch,
+    company_a_admin_headers,
+):
+    from app.api.v1 import kaspi as kaspi_module
+
+    await _set_plan(async_db_session, company_id=1001, plan="business")
+    await _ensure_company(async_db_session, company_id=1001, store_id="store-a")
+    await _ensure_offer(async_db_session, company_id=1001, merchant_uid="M123")
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    async def _lock_true(*args, **kwargs):
+        return True
+
+    async def _unlock(*args, **kwargs):
+        return None
+
+    async def _sync_orders(*args, **kwargs):
+        return {"ok": True}
+
+    async def _submit_import(*args, **kwargs):
+        return {"code": "IC-1", "status": "UPLOADED"}
+
+    async def _get_status(*args, **kwargs):
+        return {"status": "UPLOADED"}
+
+    def _build_xml(*args, **kwargs):
+        return "<xml/>"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+    monkeypatch.setattr(kaspi_module, "_try_sync_now_lock", _lock_true)
+    monkeypatch.setattr(kaspi_module, "_release_sync_now_lock", _unlock)
+    monkeypatch.setattr(kaspi_module.KaspiService, "sync_orders", _sync_orders)
+    monkeypatch.setattr(kaspi_module.KaspiGoodsImportClient, "submit_import", _submit_import)
+    monkeypatch.setattr(kaspi_module.KaspiGoodsImportClient, "get_status", _get_status)
+    monkeypatch.setattr(kaspi_module, "_build_kaspi_offers_xml", _build_xml)
+
+    resp = await async_client.post(
+        "/api/v1/kaspi/sync/now",
+        headers=company_a_admin_headers,
+        json={"merchant_uid": "M123"},
+    )
+    assert resp.status_code == 200
+
+
+async def test_kaspi_enforcement_admin_allowed_plan_feed_uploads(
+    async_client,
+    async_db_session,
+    monkeypatch,
+    company_a_admin_headers,
+):
+    from app.api.v1 import kaspi as kaspi_module
+
+    await _set_plan(async_db_session, company_id=1001, plan="business")
+    await _ensure_company(async_db_session, company_id=1001, store_id="store-a")
+    await _ensure_offer(async_db_session, company_id=1001, merchant_uid="M123")
+
+    class _FakeKaspiAdapter:
+        def feed_upload(self, *args, **kwargs):
+            return {"importCode": "IC-FEED-1", "status": "received"}
+
+        def feed_import_status(self, *args, **kwargs):
+            return {"importCode": "IC-FEED-1", "status": "done"}
+
+    async def _get_token(session, store_name: str):
+        return "token-a"
+
+    monkeypatch.setattr(KaspiStoreToken, "get_token", _get_token)
+    monkeypatch.setattr(kaspi_module, "KaspiAdapter", lambda: _FakeKaspiAdapter())
+
+    create_resp = await async_client.post(
+        "/api/v1/kaspi/feed/uploads",
+        headers=company_a_admin_headers,
+        json={"merchant_uid": "M123", "source": "public_token"},
+    )
+    assert create_resp.status_code == 200
+    upload_id = create_resp.json()["id"]
+
+    refresh_resp = await async_client.post(
+        f"/api/v1/kaspi/feed/uploads/{upload_id}/refresh",
+        headers=company_a_admin_headers,
+    )
+    assert refresh_resp.status_code == 200
+
+    publish_resp = await async_client.post(
+        f"/api/v1/kaspi/feed/uploads/{upload_id}/publish",
+        headers=company_a_admin_headers,
+    )
+    assert publish_resp.status_code == 200


### PR DESCRIPTION
Centralize feature matrix in plan_catalog and enforce RBAC-before-feature gating across Kaspi endpoints (sync now, feed uploads, goods imports, orders list, autosync). Add enforcement tests.