### PR TITLE
Kaspi: orders list D2 + superuser allowlist bypass

### DIFF
--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -58,7 +58,7 @@ from app.core.config import settings
 from app.core.db import get_async_db  # noqa — для совместимости импорт-алиас
 from app.core.errors import safe_error_message
 from app.core.logging import get_logger
-from app.core.security import get_current_user, resolve_tenant_company_id
+from app.core.security import get_current_user, is_superuser, resolve_tenant_company_id
 from app.core.subscriptions import (
     FEATURE_KASPI_AUTOSYNC,
     FEATURE_KASPI_FEED_UPLOADS,
@@ -154,7 +154,7 @@ def _resolve_company_id(current_user: User) -> int:
 
 
 def _require_admin(current_user: User) -> None:
-    if not (current_user.is_superuser or current_user.role == "admin"):
+    if not (is_superuser(current_user) or current_user.role == "admin"):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -480,6 +480,11 @@ class Settings(BaseSettings):
     PASSWORD_MIN_LENGTH: int = Field(
         default=8, description="Password min length", validation_alias="PASSWORD_MIN_LENGTH"
     )
+    SUPERUSER_ALLOWLIST: list[str] = Field(
+        default_factory=list,
+        description="Comma-separated superuser allowlist identifiers",
+        validation_alias="SUPERUSER_ALLOWLIST",
+    )
 
     # ---- БД
     DATABASE_URL: str | None = Field(
@@ -839,6 +844,17 @@ class Settings(BaseSettings):
     @field_validator("BACKEND_CORS_ORIGINS", mode="before")
     def _bcors(cls, v: Any) -> Any:
         return _parse_list_like(v)
+
+    @field_validator("SUPERUSER_ALLOWLIST", mode="before")
+    def _superuser_allowlist(cls, v: Any) -> Any:
+        if v is None:
+            return []
+        if isinstance(v, list | tuple | set):
+            return [str(item).strip() for item in v if str(item).strip()]
+        parsed = _parse_list_like(v)
+        if isinstance(parsed, list):
+            return [str(item).strip() for item in parsed if str(item).strip()]
+        return [str(parsed).strip()] if str(parsed).strip() else []
 
     @field_validator("SMTP_FROM_EMAIL", mode="before")
     def empty_email_is_none(cls, v: Any) -> Any:

--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -442,8 +442,11 @@ async def require_active_subscription(
     if current_user is None:
         return None
 
-    from app.core.security import resolve_tenant_company_id  # type: ignore
+    from app.core.security import is_superuser, resolve_tenant_company_id  # type: ignore
     from app.services.subscriptions import get_company_subscription, is_subscription_active  # type: ignore
+
+    if is_superuser(current_user):
+        return current_user
 
     company_id = resolve_tenant_company_id(current_user, not_found_detail="Company not set")
     subscription = await get_company_subscription(db, company_id)

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -899,6 +899,24 @@ if _HAS_FASTAPI:
         except Exception:
             return ""
 
+    def is_superuser(user: User | None) -> bool:
+        if user is None:
+            return False
+        if bool(getattr(user, "is_superuser", False)):
+            return True
+        allowlist = getattr(settings, "SUPERUSER_ALLOWLIST", None) or []
+        normalized = {str(item).strip() for item in allowlist if str(item).strip()}
+        if not normalized:
+            return False
+        user_id = str(getattr(user, "id", "") or "").strip()
+        if user_id and user_id in normalized:
+            return True
+        for attr in ("email", "username", "phone"):
+            value = str(getattr(user, attr, "") or "").strip()
+            if value and value in normalized:
+                return True
+        return False
+
     def is_platform_admin(user: User | None) -> bool:
         try:
             return str(getattr(user, "role", "") or "").lower() == "platform_admin"

--- a/app/core/subscriptions/features.py
+++ b/app/core/subscriptions/features.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.db import get_async_db
 from app.core.exceptions import AuthorizationError
 from app.core.logging import get_logger
-from app.core.security import get_current_user, resolve_tenant_company_id
+from app.core.security import get_current_user, is_superuser, resolve_tenant_company_id
 from app.core.subscriptions.plan_catalog import get_plan_features as _catalog_plan_features
 from app.core.subscriptions.plan_catalog import normalize_plan_id
 from app.models.company import Company
@@ -70,6 +70,8 @@ def require_feature(feature: str) -> Any:
         current_user=Depends(get_current_user),  # noqa: B008
         db: AsyncSession = Depends(get_async_db),  # noqa: B008
     ) -> Any:
+        if is_superuser(current_user):
+            return current_user
         company_id = resolve_tenant_company_id(current_user, not_found_detail="Company not set")
         plan = await _resolve_plan(db, company_id)
         if not _has_feature(plan, feature):

--- a/tests/app/test_superuser_allowlist.py
+++ b/tests/app/test_superuser_allowlist.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+
+from app.core import config
+from app.core import security as security_module
+from app.models.billing import Subscription
+from app.models.company import Company
+from app.models.user import User
+
+pytestmark = pytest.mark.asyncio
+
+
+def _refresh_settings(monkeypatch) -> None:
+    config.get_settings.cache_clear()  # type: ignore[attr-defined]
+    refreshed = config.get_settings()
+    monkeypatch.setattr(config, "settings", refreshed, raising=False)
+    monkeypatch.setattr(security_module, "settings", refreshed, raising=False)
+
+
+async def _ensure_start_plan(async_db_session, company_id: int) -> None:
+    company = await async_db_session.get(Company, company_id)
+    if company is None:
+        company = Company(id=company_id, name=f"Company {company_id}")
+        async_db_session.add(company)
+        await async_db_session.flush()
+    company.subscription_plan = "start"
+    await async_db_session.execute(sa.delete(Subscription).where(Subscription.company_id == company_id))
+    await async_db_session.commit()
+
+
+async def test_superuser_allowlist_bypasses_feature_and_admin(
+    async_client,
+    async_db_session,
+    monkeypatch,
+    company_a_manager_headers,
+):
+    await _ensure_start_plan(async_db_session, company_id=1001)
+
+    res = await async_db_session.execute(sa.select(User).where(User.phone == "+70000010002"))
+    user = res.scalars().first()
+    assert user is not None
+
+    monkeypatch.delenv("SUPERUSER_ALLOWLIST", raising=False)
+    _refresh_settings(monkeypatch)
+
+    resp_forbidden = await async_client.get("/api/v1/kaspi/orders", headers=company_a_manager_headers)
+    assert resp_forbidden.status_code == 403
+
+    resp_subscription = await async_client.get("/api/v1/kaspi/autosync/status", headers=company_a_manager_headers)
+    assert resp_subscription.status_code == 402
+    payload = resp_subscription.json()
+    assert payload.get("detail") == "subscription_required"
+
+    monkeypatch.setenv("SUPERUSER_ALLOWLIST", str(user.id))
+    _refresh_settings(monkeypatch)
+
+    resp_orders = await async_client.get("/api/v1/kaspi/orders", headers=company_a_manager_headers)
+    assert resp_orders.status_code == 200
+
+    resp_autosync = await async_client.get("/api/v1/kaspi/autosync/status", headers=company_a_manager_headers)
+    assert resp_autosync.status_code == 200
+
+    monkeypatch.delenv("SUPERUSER_ALLOWLIST", raising=False)
+    _refresh_settings(monkeypatch)
+
+
+async def test_kaspi_sync_now_subscription_required_for_normal_user(
+    async_client,
+    async_db_session,
+    monkeypatch,
+    company_a_admin_headers,
+):
+    await _ensure_start_plan(async_db_session, company_id=1001)
+
+    monkeypatch.delenv("SUPERUSER_ALLOWLIST", raising=False)
+    _refresh_settings(monkeypatch)
+
+    resp = await async_client.post(
+        "/api/v1/kaspi/sync/now",
+        headers=company_a_admin_headers,
+        json={"merchant_uid": "M1"},
+    )
+    assert resp.status_code == 402
+    payload = resp.json()
+    assert payload.get("detail") == "subscription_required"
+    assert payload.get("code") == "subscription_required"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,9 @@ except Exception:
 # Р’СЃСЋРґСѓ UTF-8 (С†РµРЅС‚СЂР°Р»РёР·РѕРІР°РЅРЅРѕ)
 os.environ.setdefault("PYTHONIOENCODING", "UTF-8")
 
+# Ensure host SUPERUSER_ALLOWLIST does not leak into test runs
+os.environ.pop("SUPERUSER_ALLOWLIST", None)
+
 # Disable rate limiting in tests by default (can be overridden explicitly)
 os.environ.setdefault("RATE_LIMIT_ENABLED", "0")
 os.environ.setdefault("TESTING", "1")


### PR DESCRIPTION
Includes: D2 orders list tenant isolation + enum-safe status filtering + regression tests; SUPERUSER_ALLOWLIST bypass for subscription/feature gates + tests; conftest isolation from host env.