### PR TITLE
Fail-fast secrets in production (SECRET_KEY validation)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -389,6 +389,9 @@ def run_startup_side_effects(s: Settings | None = None) -> None:
     if should_disable_startup_hooks():
         return
 
+    if s.is_production:
+        validate_prod_secrets(s)
+
     try:
         if s.EAGER_SIDE_EFFECTS:
             s.ensure_dirs()
@@ -401,6 +404,8 @@ def run_startup_side_effects(s: Settings | None = None) -> None:
             s.init_sentry()
             s.init_opentelemetry()
     except Exception:
+        if s.is_production:
+            raise
         pass
 
     if s.is_development and (s.STARTUP_LOG_SUMMARY or s.DEBUG_CONFIG_DUMP):
@@ -991,15 +996,15 @@ class Settings(BaseSettings):
                 logging.getLogger(__name__).warning(f"Directory not writable: {p}")
 
     def check_secret_key(self) -> None:
-        localish = _is_local_env(self.ENVIRONMENT, bool(self.DEBUG))
-        if not localish:
-            if not self.SECRET_KEY or self.SECRET_KEY.strip().lower() in {
-                "changeme",
-                "secret",
-                "password",
-            }:
-                raise ValueError("Set a secure SECRET_KEY in non-local environments!")
-
+        if not self.is_production:
+            return
+        value = (self.SECRET_KEY or "").strip()
+        if not value:
+            raise ValueError("Set a secure SECRET_KEY in production!")
+        if value.lower() in {"changeme", "secret", "password"}:
+            raise ValueError("Set a secure SECRET_KEY in production!")
+        if len(value) < 32:
+            raise ValueError("SECRET_KEY must be at least 32 characters in production!")
     def _is_postgres_url(self, url: str) -> bool:
         try:
             parsed = urlparse(url)
@@ -1997,6 +2002,12 @@ def get_settings() -> Settings:
     return s
 
 
+def validate_prod_secrets(s: Settings | None = None) -> None:
+    s = s or get_settings()
+    if s.is_production:
+        s.check_secret_key()
+
+
 settings = get_settings()
 
 __all__ = [
@@ -2005,6 +2016,7 @@ __all__ = [
     "settings",
     "should_disable_startup_hooks",
     "run_startup_side_effects",
+    "validate_prod_secrets",
     "db_url_fingerprint",
     "db_connection_fingerprint",
     "JSONAPI_MIME",

--- a/app/main.py
+++ b/app/main.py
@@ -27,7 +27,7 @@ from starlette.staticfiles import StaticFiles
 
 from app.api.routes import mount_v1
 from app.core import config as core_config
-from app.core.config import run_startup_side_effects, settings, should_disable_startup_hooks
+from app.core.config import run_startup_side_effects, settings, should_disable_startup_hooks, validate_prod_secrets
 from app.core.exceptions import register_exception_handlers
 
 try:
@@ -892,6 +892,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # type: ignore[overrid
     # ---- Startup
     _configure_base_logging()
     logger.info("Application startup… env=%s version=%s", settings.ENVIRONMENT, settings.VERSION)
+    try:
+        validate_prod_secrets(settings)
+    except Exception as e:
+        logger.error("startup secret validation failed: %s", e)
+        raise
     disable_hooks = should_disable_startup_hooks()
     if disable_hooks:
         logger.info("Startup hooks disabled (tests/CI flag)")

--- a/tests/test_startup_fails_on_insecure_secret_in_prod.py
+++ b/tests/test_startup_fails_on_insecure_secret_in_prod.py
@@ -1,0 +1,48 @@
+import pytest
+
+import app.core.config as config
+import app.main as main_module
+from app.main import create_app
+
+
+@pytest.mark.asyncio
+async def test_startup_fails_on_insecure_secret_in_prod(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("DEBUG", "0")
+    monkeypatch.setenv("SECRET_KEY", "changeme")
+    monkeypatch.setenv("DISABLE_APP_STARTUP_HOOKS", "1")
+
+    config.get_settings.cache_clear()
+    new_settings = config.get_settings()
+    monkeypatch.setattr(config, "settings", new_settings, raising=False)
+    monkeypatch.setattr(main_module, "settings", new_settings, raising=False)
+    monkeypatch.setattr(config.settings, "ENVIRONMENT", "production", raising=False)
+    monkeypatch.setattr(config.settings, "DEBUG", False, raising=False)
+    monkeypatch.setattr(config.settings, "SECRET_KEY", "changeme", raising=False)
+
+    app = create_app()
+
+    with pytest.raises(ValueError):
+        async with app.router.lifespan_context(app):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_startup_allows_secure_secret_in_prod(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("DEBUG", "0")
+    monkeypatch.setenv("SECRET_KEY", "x" * 48)
+    monkeypatch.setenv("DISABLE_APP_STARTUP_HOOKS", "1")
+
+    config.get_settings.cache_clear()
+    new_settings = config.get_settings()
+    monkeypatch.setattr(config, "settings", new_settings, raising=False)
+    monkeypatch.setattr(main_module, "settings", new_settings, raising=False)
+    monkeypatch.setattr(config.settings, "ENVIRONMENT", "production", raising=False)
+    monkeypatch.setattr(config.settings, "DEBUG", False, raising=False)
+    monkeypatch.setattr(config.settings, "SECRET_KEY", "x" * 48, raising=False)
+
+    app = create_app()
+
+    async with app.router.lifespan_context(app):
+        pass


### PR DESCRIPTION
What
- Add production-only SECRET_KEY validation (non-empty, not changeme, minimum length).
- Enforce fail-fast during app startup/lifespan without leaking secrets.
- Add tests for prod startup failure/success with settings cache refresh.

Why
- Prevent insecure production deployments that silently run with weak defaults.