### PR TITLE
Idempotency: tenant-scoped PostgreSQL backend (with compat deps)

### DIFF
--- a/app/api/admin/integrations.py
+++ b/app/api/admin/integrations.py
@@ -309,7 +309,7 @@ async def set_active_provider(
     await ProviderRegistry.notify_change(active.domain, active.version or 1)
 
     if idem_key:
-        await set_idempotency_result(idem_key, status_code=200, ttl_seconds=None)  # type: ignore[arg-type]
+        await set_idempotency_result(idem_key, status_code=200, ttl_seconds=None, request=request)
 
     return ActiveProviderOut(
         domain=active.domain,
@@ -415,7 +415,7 @@ async def set_provider_config(
         actor_email=getattr(admin, "email", None),
     )
     if idem_key:
-        await set_idempotency_result(idem_key, status_code=200, ttl_seconds=None)  # type: ignore[arg-type]
+        await set_idempotency_result(idem_key, status_code=200, ttl_seconds=None, request=request)
     cfg = await ProviderConfigService.get_redacted_config(db, domain=item.domain, provider=item.provider)
     return ProviderConfigOut(
         domain=item.domain,
@@ -540,7 +540,7 @@ async def set_messaging_config(
         actor_email=getattr(admin, "email", None),
     )
     if idem_key:
-        await set_idempotency_result(idem_key, status_code=200, ttl_seconds=None)  # type: ignore[arg-type]
+        await set_idempotency_result(idem_key, status_code=200, ttl_seconds=None, request=request)
     cfg = await ProviderConfigService.get_redacted_config(db, domain=item.domain, provider=item.provider)
     return ProviderConfigOut(
         domain=item.domain,
@@ -655,7 +655,7 @@ async def set_payment_config(
         actor_user_id=getattr(admin, "id", None),
     )
     if idem_key:
-        await set_idempotency_result(idem_key, status_code=200, ttl_seconds=None)  # type: ignore[arg-type]
+        await set_idempotency_result(idem_key, status_code=200, ttl_seconds=None, request=request)
     cfg = await ProviderConfigService.get_redacted_config(db, domain=item.domain, provider=item.provider)
     return ProviderConfigOut(
         domain=item.domain,

--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -8,7 +8,7 @@ Enterprise-grade FastAPI dependencies:
 - Audit logging hooks
 - Rate limiting: Redis token-bucket (Lua) -> in-memory sliding window fallback
 - Pagination
-- Idempotency via Idempotency-Key (Redis -> memory)
+- Idempotency via Idempotency-Key (PostgreSQL)
 - Client context (ip, ua, request/trace/span ids)
 
 ENV (optional):
@@ -26,7 +26,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from fastapi import Depends, HTTPException, Request, Response
+from fastapi import Depends, HTTPException, Request, Response, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 
@@ -585,19 +585,135 @@ auth_rate_limit_dep = auth_rate_limit
 api_rate_limit_dep = api_rate_limit
 
 # ------------------------------------------------------------------------------
-# Idempotency via Idempotency-Key
+# Idempotency via Idempotency-Key (PostgreSQL)
 # ------------------------------------------------------------------------------
 _idem_cfg = getattr(settings, "idempotency_settings", {}) or {}
-_idem_prefix = _idem_cfg.get("prefix", getattr(settings, "IDEMPOTENCY_CACHE_PREFIX", "idemp"))
 _idem_default_ttl = _int_setting(_idem_cfg.get("default_ttl", getattr(settings, "IDEMPOTENCY_DEFAULT_TTL", 900)), 900)
 
-_idempotency_enforcer = IdempotencyEnforcer(
-    redis=get_redis(), prefix=_idem_prefix, default_ttl=_idem_default_ttl, env=_env_tag
-)
+_idempotency_enforcer = IdempotencyEnforcer(default_ttl=_idem_default_ttl, env=_env_tag)
 
-ensure_idempotency = _idempotency_enforcer.dependency()
-ensure_idempotency_replay = _idempotency_enforcer.dependency(allow_replay=True)
-set_idempotency_result = _idempotency_enforcer.set_result
+
+async def _get_idempotency_db():
+    if not get_async_db:
+        raise RuntimeError("Async DB session is required for idempotency")
+    async for db in get_async_db():
+        yield db
+
+
+def _resolve_idempotency_scope(current_user: Any | None, key: str) -> tuple[int | None, str]:
+    if current_user is None:
+        return None, key
+
+    try:
+        from app.core.security import resolve_tenant_company_id  # type: ignore
+
+        company_id = resolve_tenant_company_id(current_user, not_found_detail="Company not set")
+        return int(company_id), key
+    except Exception:
+        pass
+
+    user_id = getattr(current_user, "id", None)
+    if user_id:
+        return 0, f"user:{int(user_id)}:{key}"
+    return None, key
+
+
+async def _apply_idempotency(
+    request: Request,
+    response: Response,
+    current_user: Any | None,
+    db,
+    *,
+    allow_replay: bool,
+):
+    method = request.method.upper()
+    if method not in ("POST", "PUT", "PATCH"):
+        return True
+
+    raw_key = request.headers.get("Idempotency-Key")
+    if not raw_key:
+        return True
+
+    ttl_header = request.headers.get("Idempotency-TTL")
+    try:
+        ttl_seconds = int(ttl_header) if ttl_header else _idem_default_ttl
+    except Exception:
+        ttl_seconds = _idem_default_ttl
+
+    company_id, scoped_key = _resolve_idempotency_scope(current_user, raw_key)
+    if company_id is None:
+        return True
+
+    try:
+        allowed, processed_status = await _idempotency_enforcer.reserve(
+            db, company_id=company_id, key=scoped_key, ttl_seconds=ttl_seconds
+        )
+    except Exception as exc:
+        log.error("Idempotency DB error", extra={"error": str(exc)})
+        raise HTTPException(status_code=503, detail="Idempotency storage unavailable")
+
+    if not allowed:
+        if processed_status is not None and allow_replay:
+            request.state.idempotency_key = scoped_key
+            request.state.idempotency_ttl = ttl_seconds
+            request.state.idempotency_company_id = company_id
+            response.headers["Idempotency-Key"] = raw_key
+            response.status_code = processed_status
+            return True
+        detail = "Request already processed" if processed_status is not None else "Request is being processed"
+        raise HTTPException(status.HTTP_409_CONFLICT, detail)
+
+    request.state.idempotency_key = scoped_key
+    request.state.idempotency_ttl = ttl_seconds
+    request.state.idempotency_company_id = company_id
+    response.headers["Idempotency-Key"] = raw_key
+    return True
+
+
+async def ensure_idempotency(
+    request: Request,
+    response: Response,
+    current_user: Any | None = Depends(get_current_user_optional),
+    db=Depends(_get_idempotency_db, use_cache=False),
+):
+    return await _apply_idempotency(request, response, current_user, db, allow_replay=False)
+
+
+async def ensure_idempotency_replay(
+    request: Request,
+    response: Response,
+    current_user: Any | None = Depends(get_current_user_optional),
+    db=Depends(_get_idempotency_db, use_cache=False),
+):
+    return await _apply_idempotency(request, response, current_user, db, allow_replay=True)
+
+
+async def set_idempotency_result(
+    key: str,
+    *,
+    status_code: int,
+    ttl_seconds: int | None = None,
+    request: Request | None = None,
+    company_id: int | None = None,
+):
+    scoped_company_id = company_id
+    scoped_key = key
+    if request is not None:
+        scoped_key = getattr(getattr(request, "state", None), "idempotency_key", scoped_key)
+        scoped_company_id = getattr(getattr(request, "state", None), "idempotency_company_id", scoped_company_id)
+
+    if scoped_company_id is None:
+        return
+
+    async for db in _get_idempotency_db():
+        await _idempotency_enforcer.set_result(
+            db,
+            company_id=int(scoped_company_id),
+            key=scoped_key,
+            status_code=int(status_code),
+            ttl_seconds=ttl_seconds,
+        )
+        return
 
 
 # ------------------------------------------------------------------------------

--- a/app/core/idempotency.py
+++ b/app/core/idempotency.py
@@ -2,15 +2,21 @@ from __future__ import annotations
 
 import logging
 import time
+from datetime import datetime, timedelta
 from typing import Optional
 
 from fastapi import HTTPException, Request, Response, status
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.idempotency_key import IdempotencyKey
 
 log = logging.getLogger(__name__)
 
 
 class IdempotencyEnforcer:
-    """Idempotency helper with Redis backend and memory fallback."""
+    """Idempotency helper backed by PostgreSQL."""
 
     def __init__(
         self,
@@ -25,24 +31,111 @@ class IdempotencyEnforcer:
         self.env = env or "dev"
         self._mem: dict[str, tuple[int, float]] = {}
 
-    def _key(self, key: str) -> str:
-        return f"{self.env}:{self.prefix}:{key}"
-
-    async def _reserve(self, key: str, ttl_seconds: int) -> tuple[bool, Optional[int]]:
+    async def reserve(
+        self,
+        db: AsyncSession,
+        company_id: int,
+        key: str,
+        ttl_seconds: int,
+    ) -> tuple[bool, Optional[int]]:
         ttl = max(1, int(ttl_seconds))
-        if self.redis is not None:
-            try:
-                redis_key = self._key(key)
-                set_ok = await self.redis.set(redis_key, "processing", ex=ttl, nx=True)  # type: ignore[attr-defined]
-                if set_ok:
-                    return True, None
-                status_text = await self.redis.get(redis_key)  # type: ignore[attr-defined]
-                if status_text and str(status_text).isdigit():
-                    return False, int(status_text)
-                return False, None
-            except Exception as exc:  # pragma: no cover - fallback path
-                log.warning("Idempotency Redis error; falling back to memory", extra={"error": str(exc)})
+        now = datetime.utcnow()
+        expires_at = now + timedelta(seconds=ttl)
 
+        inserted = await self._insert_processing(db, company_id, key, expires_at)
+        if inserted:
+            await db.commit()
+            return True, None
+
+        existing = await self._get_existing(db, company_id, key)
+        if existing and existing.expires_at and existing.expires_at <= now:
+            await db.execute(
+                delete(IdempotencyKey).where(
+                    IdempotencyKey.company_id == company_id,
+                    IdempotencyKey.key == key,
+                )
+            )
+            await db.commit()
+            inserted = await self._insert_processing(db, company_id, key, expires_at)
+            if inserted:
+                await db.commit()
+                return True, None
+            existing = await self._get_existing(db, company_id, key)
+
+        if not existing:
+            return True, None
+
+        status_code = existing.status_code
+        return False, int(status_code) if status_code is not None else None
+
+    async def set_result(self, *args, **kwargs) -> None:
+        if args and isinstance(args[0], AsyncSession):
+            db = args[0]
+            company_id = kwargs.get("company_id")
+            key = kwargs.get("key")
+            status_code = kwargs.get("status_code")
+            ttl_seconds = kwargs.get("ttl_seconds")
+            if company_id is None or key is None or status_code is None:
+                return
+            ttl = max(1, int(ttl_seconds or self.default_ttl))
+            now = datetime.utcnow()
+            expires_at = now + timedelta(seconds=ttl)
+            stmt = (
+                pg_insert(IdempotencyKey)
+                .values(
+                    company_id=int(company_id),
+                    key=str(key),
+                    status_code=int(status_code),
+                    expires_at=expires_at,
+                )
+                .on_conflict_do_update(
+                    index_elements=["company_id", "key"],
+                    set_={
+                        "status_code": int(status_code),
+                        "expires_at": expires_at,
+                        "updated_at": now,
+                    },
+                )
+            )
+            await db.execute(stmt)
+            await db.commit()
+            return
+
+        key = args[0] if args else kwargs.get("key")
+        status_code = args[1] if len(args) > 1 else kwargs.get("status_code")
+        ttl_seconds = kwargs.get("ttl_seconds")
+        if key is None or status_code is None:
+            return
+        await self._set_result_mem(str(key), int(status_code), ttl_seconds=ttl_seconds)
+
+    async def _insert_processing(
+        self,
+        db: AsyncSession,
+        company_id: int,
+        key: str,
+        expires_at: datetime,
+    ) -> bool:
+        stmt = (
+            pg_insert(IdempotencyKey)
+            .values(
+                company_id=company_id,
+                key=key,
+                status_code=None,
+                expires_at=expires_at,
+            )
+            .on_conflict_do_nothing(index_elements=["company_id", "key"])
+        )
+        res = await db.execute(stmt)
+        return bool(res.rowcount and res.rowcount > 0)
+
+    async def _get_existing(self, db: AsyncSession, company_id: int, key: str) -> IdempotencyKey | None:
+        res = await db.execute(
+            select(IdempotencyKey).where(IdempotencyKey.company_id == company_id, IdempotencyKey.key == key)
+        )
+        return res.scalar_one_or_none()
+
+    async def _reserve_mem(self, key: str, ttl_seconds: int) -> tuple[bool, Optional[int]]:
+        ttl = max(1, int(ttl_seconds))
         now = time.time()
         rec = self._mem.get(key)
         if rec:
@@ -53,15 +146,9 @@ class IdempotencyEnforcer:
         self._mem[key] = (102, now + ttl)
         return True, None
 
-    async def set_result(self, key: str, status_code: int, ttl_seconds: Optional[int] = None) -> None:
+    async def _set_result_mem(self, key: str, status_code: int, ttl_seconds: Optional[int] = None) -> None:
         ttl = max(1, int(ttl_seconds or self.default_ttl))
-        if self.redis is not None:
-            try:
-                await self.redis.set(self._key(key), str(status_code), ex=ttl)  # type: ignore[attr-defined]
-                return
-            except Exception:  # pragma: no cover - fallback path
-                pass
-        self._mem[key] = (status_code, time.time() + ttl)
+        self._mem[key] = (int(status_code), time.time() + ttl)
 
     def dependency(self, allow_replay: bool = False):
         async def dep(request: Request, response: Response):
@@ -79,16 +166,15 @@ class IdempotencyEnforcer:
             except Exception:
                 ttl_seconds = self.default_ttl
 
-            allowed, processed_status = await self._reserve(key, ttl_seconds)
+            allowed, processed_status = await self._reserve_mem(key, ttl_seconds)
             if not allowed:
                 if processed_status is not None and allow_replay:
-                    # Request was already processed; allow handler to proceed and return same status
                     request.state.idempotency_key = key
                     request.state.idempotency_ttl = ttl_seconds
                     response.headers["Idempotency-Key"] = key
                     response.status_code = processed_status
                     return True
-                detail = "Request already processed" if processed_status else "Request is being processed"
+                detail = "Request already processed" if processed_status is not None else "Request is being processed"
                 raise HTTPException(status.HTTP_409_CONFLICT, detail)
 
             request.state.idempotency_key = key
@@ -99,8 +185,20 @@ class IdempotencyEnforcer:
         return dep
 
 
-def ensure_idempotency_dep(enforcer: IdempotencyEnforcer):
-    return enforcer.dependency()
+def ensure_idempotency_dep(enforcer: IdempotencyEnforcer | None = None, *args, **kwargs):
+    if enforcer is not None:
+        return enforcer.dependency(*args, **kwargs)
+    from app.core.dependencies import ensure_idempotency  # lazy import to avoid cycles
+
+    return ensure_idempotency(*args, **kwargs)
 
 
-__all__ = ["IdempotencyEnforcer", "ensure_idempotency_dep"]
+def ensure_idempotency_replay_dep(enforcer: IdempotencyEnforcer | None = None, *args, **kwargs):
+    if enforcer is not None:
+        return enforcer.dependency(allow_replay=True)
+    from app.core.dependencies import ensure_idempotency_replay  # lazy import to avoid cycles
+
+    return ensure_idempotency_replay(*args, **kwargs)
+
+
+__all__ = ["IdempotencyEnforcer", "ensure_idempotency_dep", "ensure_idempotency_replay_dep"]

--- a/app/models/idempotency_key.py
+++ b/app/models/idempotency_key.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import BaseModel
+
+
+class IdempotencyKey(BaseModel):
+    """Persistent idempotency key storage (tenant-scoped)."""
+
+    __tablename__ = "idempotency_keys"
+    __table_args__ = (
+        UniqueConstraint("company_id", "key", name="uq__idempotency_keys__company_id__key"),
+    )
+
+    company_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    key: Mapped[str] = mapped_column(String(length=200), nullable=False)
+    status_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, index=True)

--- a/migrations/versions/20260205_idempotency_keys.py
+++ b/migrations/versions/20260205_idempotency_keys.py
@@ -1,0 +1,67 @@
+"""idempotency keys table
+
+Revision ID: 20260205_idempotency_keys
+Revises: 20260203_subscription_overrides
+Create Date: 2026-02-05
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20260205_idempotency_keys"
+down_revision = "20260203_subscription_overrides"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "idempotency_keys",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("company_id", sa.Integer(), nullable=False),
+        sa.Column("key", sa.String(length=200), nullable=False),
+        sa.Column("status_code", sa.Integer(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        schema="public",
+    )
+    op.create_index(
+        "ix__idempotency_keys__company_id",
+        "idempotency_keys",
+        ["company_id"],
+        schema="public",
+    )
+    op.create_index(
+        "ix__idempotency_keys__expires_at",
+        "idempotency_keys",
+        ["expires_at"],
+        schema="public",
+    )
+    op.create_unique_constraint(
+        "uq__idempotency_keys__company_id__key",
+        "idempotency_keys",
+        ["company_id", "key"],
+        schema="public",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq__idempotency_keys__company_id__key",
+        "idempotency_keys",
+        type_="unique",
+        schema="public",
+    )
+    op.drop_index(
+        "ix__idempotency_keys__expires_at",
+        table_name="idempotency_keys",
+        schema="public",
+    )
+    op.drop_index(
+        "ix__idempotency_keys__company_id",
+        table_name="idempotency_keys",
+        schema="public",
+    )
+    op.drop_table("idempotency_keys", schema="public")

--- a/tests/app/test_idempotency_postgres.py
+++ b/tests/app/test_idempotency_postgres.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.idempotency import IdempotencyEnforcer
+
+
+@pytest.mark.asyncio
+async def test_idempotency_reserve_and_replay(async_db_session: AsyncSession):
+    enforcer = IdempotencyEnforcer(default_ttl=60)
+
+    allowed, status = await enforcer.reserve(
+        async_db_session, company_id=1, key="abc", ttl_seconds=60
+    )
+    assert allowed is True
+    assert status is None
+
+    allowed, status = await enforcer.reserve(
+        async_db_session, company_id=1, key="abc", ttl_seconds=60
+    )
+    assert allowed is False
+    assert status is None
+
+    await enforcer.set_result(async_db_session, company_id=1, key="abc", status_code=200, ttl_seconds=60)
+
+    allowed, status = await enforcer.reserve(
+        async_db_session, company_id=1, key="abc", ttl_seconds=60
+    )
+    assert allowed is False
+    assert status == 200
+
+
+@pytest.mark.asyncio
+async def test_idempotency_tenant_scoped(async_db_session: AsyncSession):
+    enforcer = IdempotencyEnforcer(default_ttl=60)
+
+    allowed, _ = await enforcer.reserve(
+        async_db_session, company_id=1, key="shared", ttl_seconds=60
+    )
+    assert allowed is True
+
+    allowed, status = await enforcer.reserve(
+        async_db_session, company_id=2, key="shared", ttl_seconds=60
+    )
+    assert allowed is True
+    assert status is None


### PR DESCRIPTION
What
- Add IdempotencyKey table/model (tenant-scoped) and migration.
- Enforce idempotency via PostgreSQL in dependencies (POST/PUT/PATCH).
- Store result status_code for replay mode.
- Restore backward-compatible ensure_idempotency_dep via lazy wrappers to avoid cycles.
- Update admin integrations to pass request into set_idempotency_result for proper scoping.

Tests
- pytest -q (all green)