### PR TITLE
Prod safety: stub providers fail in prod + PII masking (decoupled noop providers)

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -28,7 +28,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field
 from sqlalchemy import select, update
@@ -63,6 +63,7 @@ from app.core.security import (
     revoke_token,
     verify_password,
 )
+from app.integrations.errors import ProviderNotConfiguredError
 from app.integrations.ports.otp import OtpProvider
 from app.models.company import Company
 from app.models.invitation import InvitationToken, PasswordResetToken
@@ -779,6 +780,8 @@ async def request_otp(
         )
         provider_name = (send_result or {}).get("provider") or getattr(otp_service, "name", None)
         provider_version = (send_result or {}).get("version") or getattr(otp_service, "version", None)
+    except ProviderNotConfiguredError as exc:
+        raise HTTPException(status_code=503, detail=exc.code)
     except Exception as exc:
         provider_name = getattr(otp_service, "name", None) or "noop"
         provider_version = getattr(otp_service, "version", None)
@@ -1104,6 +1107,8 @@ async def phone_change_request(
         )
         provider_name = (send_result or {}).get("provider") or getattr(otp_service, "name", None)
         provider_version = (send_result or {}).get("version") or getattr(otp_service, "version", None)
+    except ProviderNotConfiguredError as exc:
+        raise HTTPException(status_code=503, detail=exc.code)
     except Exception as exc:
         provider_name = getattr(otp_service, "name", None) or "noop"
         provider_version = getattr(otp_service, "version", None)

--- a/app/api/v1/payments.py
+++ b/app/api/v1/payments.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_async_db
 from app.core.security import get_current_user, require_manager, resolve_tenant_company_id
+from app.integrations.errors import ProviderNotConfiguredError
 from app.models.user import User
 from app.services.payment_providers import PaymentProviderResolver
 from app.storage.payments_sql import PaymentIntentsStorageSQL, PaymentsStorageSQL
@@ -27,6 +28,8 @@ async def _auth_user(current_user: User = Depends(get_current_user)) -> User:
 async def _get_payment_storage(db: AsyncSession) -> PaymentsStorageSQL:
     try:
         return PaymentsStorageSQL(db)
+    except ProviderNotConfiguredError as exc:
+        raise HTTPException(status_code=503, detail=exc.code)
     except HTTPException:
         raise
     except Exception as e:
@@ -37,6 +40,8 @@ async def _get_payment_storage(db: AsyncSession) -> PaymentsStorageSQL:
 async def _get_wallet_storage(db: AsyncSession) -> WalletStorageSQL:
     try:
         return WalletStorageSQL(db)
+    except ProviderNotConfiguredError as exc:
+        raise HTTPException(status_code=503, detail=exc.code)
     except HTTPException:
         raise
     except Exception as e:
@@ -47,6 +52,8 @@ async def _get_wallet_storage(db: AsyncSession) -> WalletStorageSQL:
 async def _get_intents_storage(db: AsyncSession) -> PaymentIntentsStorageSQL:
     try:
         return PaymentIntentsStorageSQL(db)
+    except ProviderNotConfiguredError as exc:
+        raise HTTPException(status_code=503, detail=exc.code)
     except HTTPException:
         raise
     except Exception as e:
@@ -373,6 +380,9 @@ async def create_payment_intent(
             metadata=row.get("metadata", {}),
             created_at=row["created_at"],
         )
+    except ProviderNotConfiguredError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=503, detail=exc.code)
     except HTTPException:
         raise
     except Exception as e:

--- a/app/integrations/errors.py
+++ b/app/integrations/errors.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+
+class ProviderNotConfiguredError(RuntimeError):
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(code)
+
+
+__all__ = ["ProviderNotConfiguredError"]

--- a/app/integrations/providers/noop/messaging.py
+++ b/app/integrations/providers/noop/messaging.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from typing import Any
 
+from fastapi import HTTPException, status
+
+from app.core.config import settings
+from app.core.logging import get_logger
 from app.integrations.ports.messaging import MessagingProvider
+
+
+log = get_logger(__name__)
 
 
 class NoOpMessagingProvider(MessagingProvider):
@@ -22,6 +29,9 @@ class NoOpMessagingProvider(MessagingProvider):
         text: str,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        if settings.is_production:
+            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "messaging_provider_not_configured")
+        log.warning("Using noop messaging provider (non-production)")
         return {
             "status": "noop",
             "provider": self.name,

--- a/app/integrations/providers/noop/messaging.py
+++ b/app/integrations/providers/noop/messaging.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import HTTPException, status
-
 from app.core.config import settings
 from app.core.logging import get_logger
+from app.integrations.errors import ProviderNotConfiguredError
 from app.integrations.ports.messaging import MessagingProvider
 
 
@@ -30,7 +29,7 @@ class NoOpMessagingProvider(MessagingProvider):
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         if settings.is_production:
-            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "messaging_provider_not_configured")
+            raise ProviderNotConfiguredError("messaging_provider_not_configured")
         log.warning("Using noop messaging provider (non-production)")
         return {
             "status": "noop",

--- a/app/integrations/providers/noop/otp.py
+++ b/app/integrations/providers/noop/otp.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import HTTPException, status
-
 from app.core.config import settings
 from app.core.logging import get_logger
+from app.integrations.errors import ProviderNotConfiguredError
 from app.integrations.ports.otp import OtpProvider
 
 
@@ -31,7 +30,7 @@ class NoOpOtpProvider(OtpProvider):
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         if settings.is_production:
-            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "otp_provider_not_configured")
+            raise ProviderNotConfiguredError("otp_provider_not_configured")
         log.warning("Using noop OTP provider (non-production)")
         return {
             "status": "noop",
@@ -51,7 +50,7 @@ class NoOpOtpProvider(OtpProvider):
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         if settings.is_production:
-            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "otp_provider_not_configured")
+            raise ProviderNotConfiguredError("otp_provider_not_configured")
         log.warning("Using noop OTP provider (non-production)")
         return {
             "status": "noop",

--- a/app/integrations/providers/noop/otp.py
+++ b/app/integrations/providers/noop/otp.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from typing import Any
 
+from fastapi import HTTPException, status
+
+from app.core.config import settings
+from app.core.logging import get_logger
 from app.integrations.ports.otp import OtpProvider
+
+
+log = get_logger(__name__)
 
 
 class NoOpOtpProvider(OtpProvider):
@@ -23,6 +30,9 @@ class NoOpOtpProvider(OtpProvider):
         ttl_seconds: int,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        if settings.is_production:
+            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "otp_provider_not_configured")
+        log.warning("Using noop OTP provider (non-production)")
         return {
             "status": "noop",
             "provider": self.name,
@@ -40,6 +50,9 @@ class NoOpOtpProvider(OtpProvider):
         code: str,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        if settings.is_production:
+            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "otp_provider_not_configured")
+        log.warning("Using noop OTP provider (non-production)")
         return {
             "status": "noop",
             "provider": self.name,

--- a/app/integrations/providers/noop/payments.py
+++ b/app/integrations/providers/noop/payments.py
@@ -4,10 +4,9 @@ from decimal import Decimal
 from typing import Any
 from uuid import uuid4
 
-from fastapi import HTTPException, status
-
 from app.core.config import settings
 from app.core.logging import get_logger
+from app.integrations.errors import ProviderNotConfiguredError
 from app.integrations.ports.payments import PaymentGateway, PaymentIntent
 
 
@@ -37,7 +36,7 @@ class NoOpPaymentGateway(PaymentGateway):
 
     async def healthcheck(self) -> dict[str, Any]:
         if settings.is_production:
-            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "payment_provider_not_configured")
+            raise ProviderNotConfiguredError("payment_provider_not_configured")
         log.warning("Using noop payment gateway (non-production)")
         return {
             "status": "ok",
@@ -53,7 +52,7 @@ class NoOpPaymentGateway(PaymentGateway):
         metadata: dict[str, Any] | None = None,
     ) -> PaymentIntent:
         if settings.is_production:
-            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "payment_provider_not_configured")
+            raise ProviderNotConfiguredError("payment_provider_not_configured")
         log.warning("Using noop payment gateway (non-production)")
         intent_id = uuid4().hex
         return PaymentIntent(
@@ -76,7 +75,7 @@ class NoOpPaymentGateway(PaymentGateway):
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         if settings.is_production:
-            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "payment_provider_not_configured")
+            raise ProviderNotConfiguredError("payment_provider_not_configured")
         log.warning("Using noop payment gateway (non-production)")
         return {
             "status": "noop",

--- a/app/integrations/providers/noop/payments.py
+++ b/app/integrations/providers/noop/payments.py
@@ -4,7 +4,14 @@ from decimal import Decimal
 from typing import Any
 from uuid import uuid4
 
+from fastapi import HTTPException, status
+
+from app.core.config import settings
+from app.core.logging import get_logger
 from app.integrations.ports.payments import PaymentGateway, PaymentIntent
+
+
+log = get_logger(__name__)
 
 
 class NoOpPaymentGateway(PaymentGateway):
@@ -29,6 +36,9 @@ class NoOpPaymentGateway(PaymentGateway):
         return self.version
 
     async def healthcheck(self) -> dict[str, Any]:
+        if settings.is_production:
+            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "payment_provider_not_configured")
+        log.warning("Using noop payment gateway (non-production)")
         return {
             "status": "ok",
             "provider": self.name,
@@ -42,6 +52,9 @@ class NoOpPaymentGateway(PaymentGateway):
         customer_id: str,
         metadata: dict[str, Any] | None = None,
     ) -> PaymentIntent:
+        if settings.is_production:
+            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "payment_provider_not_configured")
+        log.warning("Using noop payment gateway (non-production)")
         intent_id = uuid4().hex
         return PaymentIntent(
             id=intent_id,
@@ -62,6 +75,9 @@ class NoOpPaymentGateway(PaymentGateway):
         reason: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        if settings.is_production:
+            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "payment_provider_not_configured")
+        log.warning("Using noop payment gateway (non-production)")
         return {
             "status": "noop",
             "provider": self.name,

--- a/app/services/background_tasks.py
+++ b/app/services/background_tasks.py
@@ -5,23 +5,13 @@ Background task services using Celery for async operations.
 from __future__ import annotations
 
 import os
-import re
-
 from celery import Celery
 
 from app.core.config import settings
 from app.core.logging import get_logger
+from app.utils.pii import mask_email, mask_phone
 
 logger = get_logger(__name__)
-
-
-def _mask_phone(value: str) -> str:
-    digits = re.sub(r"\D", "", value or "")
-    if not digits:
-        return ""
-    if len(digits) <= 4:
-        return "*" * len(digits)
-    return "*" * (len(digits) - 2) + digits[-2:]
 
 
 def _should_log_otp_debug() -> bool:
@@ -54,8 +44,12 @@ celery_app.conf.update(
 def send_sms_otp(phone: str, code: str) -> bool:
     """Send SMS OTP code using Mobizon API."""
     try:
+        if settings.is_production:
+            logger.warning("OTP provider not configured; refusing to send in production")
+            return False
+        logger.warning("Using stub OTP sender (non-production)")
         # TODO: Implement actual Mobizon API call
-        logger.info(f"Sending OTP to {_mask_phone(phone)}")
+        logger.info("Sending OTP to %s", mask_phone(phone))
 
         # Simulate API call delay
         import time
@@ -63,11 +57,11 @@ def send_sms_otp(phone: str, code: str) -> bool:
         time.sleep(1)
 
         if _should_log_otp_debug():
-            logger.info(f"OTP requested for phone {_mask_phone(phone)}")
+            logger.info("OTP requested for phone %s", mask_phone(phone))
 
         return True
     except Exception as e:
-        logger.error(f"Failed to send OTP to {phone}: {e}")
+        logger.error("Failed to send OTP to %s: %s", mask_phone(phone), e)
         return False
 
 
@@ -75,8 +69,12 @@ def send_sms_otp(phone: str, code: str) -> bool:
 def send_email_notification(email: str, subject: str, body: str) -> bool:
     """Send email notification."""
     try:
+        if settings.is_production:
+            logger.warning("Email provider not configured; refusing to send in production")
+            return False
+        logger.warning("Using stub email sender (non-production)")
         # TODO: Implement email sending
-        logger.info(f"Sending email to {email}: {subject}")
+        logger.info("Sending email to %s: %s", mask_email(email), subject)
 
         # Simulate email sending
         import time
@@ -85,7 +83,7 @@ def send_email_notification(email: str, subject: str, body: str) -> bool:
 
         return True
     except Exception as e:
-        logger.error(f"Failed to send email to {email}: {e}")
+        logger.error("Failed to send email to %s: %s", mask_email(email), e)
         return False
 
 
@@ -93,6 +91,10 @@ def send_email_notification(email: str, subject: str, body: str) -> bool:
 def process_image_upload(image_url: str, product_id: int) -> dict:
     """Process image upload to Cloudinary."""
     try:
+        if settings.is_production:
+            logger.warning("Media provider not configured; refusing to process in production")
+            return {"error": "media_provider_not_configured"}
+        logger.warning("Using stub media processor (non-production)")
         # TODO: Implement Cloudinary upload
         logger.info(f"Processing image upload for product {product_id}")
 
@@ -135,6 +137,10 @@ def sync_product_to_kaspi(product_id: int) -> bool:
 def process_payment_webhook(webhook_data: dict) -> bool:
     """Process payment webhook from TipTop Pay."""
     try:
+        if settings.is_production:
+            logger.warning("Payment provider not configured; refusing to process in production")
+            return False
+        logger.warning("Using stub payment processor (non-production)")
         # TODO: Implement payment processing
         logger.info(f"Processing payment webhook: {webhook_data.get('invoice_id')}")
 
@@ -153,6 +159,10 @@ def process_payment_webhook(webhook_data: dict) -> bool:
 def generate_daily_report() -> dict:
     """Generate daily sales report."""
     try:
+        if settings.is_production:
+            logger.warning("Report generator not configured; refusing to generate in production")
+            return {"error": "report_provider_not_configured"}
+        logger.warning("Using stub report generator (non-production)")
         logger.info("Generating daily report")
 
         # TODO: Implement report generation

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -13,6 +13,7 @@ from jinja2 import Environment, FileSystemLoader
 
 from app.core.config import settings
 from app.core.logging import get_logger
+from app.utils.pii import mask_email
 from app.models import Company, Order
 
 logger = get_logger(__name__)
@@ -88,11 +89,11 @@ class EmailService:
                 server.login(self.smtp_user, self.smtp_password)
                 server.send_message(msg, to_addrs=recipients)
 
-            logger.info(f"Email sent successfully to {to_email}")
+            logger.info("Email sent successfully to %s", mask_email(to_email))
             return True
 
         except Exception as e:
-            logger.error(f"Failed to send email to {to_email}: {e}")
+            logger.error("Failed to send email to %s: %s", mask_email(to_email), e)
             return False
 
     async def send_order_confirmation(self, to_email: str, order: Order, company: Company) -> bool:

--- a/app/utils/pii.py
+++ b/app/utils/pii.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import re
+
+
+def mask_phone(value: str) -> str:
+    raw = value or ""
+    digits = re.sub(r"\D", "", raw)
+    if not digits:
+        return ""
+    if len(digits) <= 4:
+        return "*" * len(digits)
+    prefix_len = 2 if len(digits) >= 6 else 1
+    suffix_len = 4 if len(digits) >= 6 else 2
+    prefix = digits[:prefix_len]
+    suffix = digits[-suffix_len:]
+    masked = prefix + ("*" * max(1, len(digits) - prefix_len - suffix_len)) + suffix
+    if raw.strip().startswith("+"):
+        return f"+{masked}"
+    return masked
+
+
+def mask_email(value: str) -> str:
+    v = (value or "").strip()
+    if not v or "@" not in v:
+        return "***"
+    local, domain = v.split("@", 1)
+    if not local:
+        return f"***@{domain}"
+    head = local[0]
+    return f"{head}***@{domain}"
+
+
+__all__ = ["mask_phone", "mask_email"]

--- a/tests/test_prod_safety_integrations.py
+++ b/tests/test_prod_safety_integrations.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from app.core.config import settings
+from app.services import background_tasks
+from app.utils.pii import mask_email, mask_phone
+
+
+def test_stub_tasks_fail_in_prod_without_provider(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    monkeypatch.setattr(time, "sleep", lambda *_args, **_kwargs: None)
+
+    assert background_tasks.send_sms_otp("+77001234567", "1234") is False
+    assert background_tasks.send_email_notification("user@example.com", "Sub", "Body") is False
+    assert background_tasks.process_image_upload("https://example.com/a.jpg", 1)["error"] == "media_provider_not_configured"
+    assert background_tasks.process_payment_webhook({"invoice_id": "inv-1"}) is False
+    assert background_tasks.generate_daily_report()["error"] == "report_provider_not_configured"
+
+
+def test_sms_otp_logs_masked_phone(monkeypatch, caplog):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development")
+    monkeypatch.setattr(time, "sleep", lambda *_args, **_kwargs: None)
+    caplog.set_level("INFO")
+
+    phone = "+77001234567"
+    background_tasks.send_sms_otp(phone, "1234")
+
+    assert phone not in caplog.text
+    assert mask_phone(phone) in caplog.text
+
+
+def test_email_logs_masked_email(monkeypatch, caplog):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development")
+    monkeypatch.setattr(time, "sleep", lambda *_args, **_kwargs: None)
+    caplog.set_level("INFO")
+
+    email = "user@example.com"
+    background_tasks.send_email_notification(email, "Hello", "Body")
+
+    assert email not in caplog.text
+    assert mask_email(email) in caplog.text

--- a/tests/test_prod_safety_integrations.py
+++ b/tests/test_prod_safety_integrations.py
@@ -6,6 +6,9 @@ import pytest
 
 from app.core.config import settings
 from app.services import background_tasks
+from app.core.provider_registry import ProviderRegistry
+from app.services.otp_providers import OtpProviderResolver
+from app.services.payment_providers import PaymentProviderResolver
 from app.utils.pii import mask_email, mask_phone
 
 
@@ -42,3 +45,68 @@ def test_email_logs_masked_email(monkeypatch, caplog):
 
     assert email not in caplog.text
     assert mask_email(email) in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_request_otp_returns_503_in_prod(async_client, monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    OtpProviderResolver.reset_cache()
+
+    async def _no_provider(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(ProviderRegistry, "get_active_provider", _no_provider)
+
+    resp = await async_client.post(
+        "/api/v1/auth/request-otp",
+        json={"phone": "+77001234567", "purpose": "login"},
+    )
+
+    assert resp.status_code == 503, resp.text
+    assert resp.json().get("detail") == "otp_provider_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_request_otp_noop_in_dev(async_client, monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development")
+    OtpProviderResolver.reset_cache()
+
+    async def _no_provider(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(ProviderRegistry, "get_active_provider", _no_provider)
+
+    resp = await async_client.post(
+        "/api/v1/auth/request-otp",
+        json={"phone": "+77001234567", "purpose": "login"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json().get("data") or {}
+    assert data.get("provider") in {None, "noop"} or data.get("provider") == "noop"
+    assert "dev_code" in data
+
+
+@pytest.mark.asyncio
+async def test_payment_intent_returns_503_in_prod(async_client, company_a_manager_headers, monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    PaymentProviderResolver.reset_cache()
+
+    async def _no_provider(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(ProviderRegistry, "get_active_provider", _no_provider)
+
+    resp = await async_client.post(
+        "/api/v1/payments/intents",
+        headers=company_a_manager_headers,
+        json={
+            "amount": "10.00",
+            "currency": "KZT",
+            "customer_id": "cust-1",
+            "metadata": {},
+        },
+    )
+
+    assert resp.status_code == 503, resp.text
+    assert resp.json().get("detail") == "payment_provider_not_configured"


### PR DESCRIPTION
What
- Remove FastAPI coupling from noop providers; raise domain ProviderNotConfiguredError.
- Map ProviderNotConfiguredError to HTTP 503 at API boundary (auth/payments).
- Keep non-prod warnings and PII-masked logging.
- Tests cover prod 503 + non-prod noop behavior.

Tests
- pytest -q (green)