### PR TITLE
Ops: readiness strict in production + /env URL redaction

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -274,6 +274,12 @@ def _server_timing_value(ms: int) -> str:
 
 
 _SECRET_KEYS = ("SECRET", "PASSWORD", "TOKEN", "KEY", "PASS", "PRIVATE", "CREDENTIAL", "AUTH")
+_REDACT_KEYS_EXACT = {
+    "DATABASE_URL",
+    "DB_URL",
+    "REDIS_URL",
+    "SQLALCHEMY_DATABASE_URI",
+}
 
 
 def _redact(value: Any) -> Any:
@@ -293,7 +299,8 @@ def _redact(value: Any) -> Any:
 def _redact_dict(d: dict[str, Any]) -> dict[str, Any]:
     out: dict[str, Any] = {}
     for k, v in d.items():
-        if any(part in str(k).upper() for part in _SECRET_KEYS):
+        key_upper = str(k).upper()
+        if key_upper in _REDACT_KEYS_EXACT or any(part in key_upper for part in _SECRET_KEYS):
             out[k] = _redact(v)
         else:
             out[k] = v
@@ -1482,7 +1489,8 @@ def _create_app() -> FastAPI:
 
     @app.get("/ready", response_model=None)
     async def readiness() -> JSONResponse:
-        if os.getenv("PYTEST_CURRENT_TEST") or os.getenv("TESTING"):
+        strict = _env_truthy(os.getenv("READINESS_STRICT", "1" if settings.is_production else "0"))
+        if (os.getenv("PYTEST_CURRENT_TEST") or os.getenv("TESTING")) and not strict:
             return JSONResponse(status_code=200, content={"ready": True, "checks": {}})
         require_redis = _env_truthy(os.getenv("READINESS_REQUIRE_REDIS", "0"))
         require_smtp = _env_truthy(os.getenv("READINESS_REQUIRE_SMTP", "0"))
@@ -1567,7 +1575,6 @@ def _create_app() -> FastAPI:
             "build_info": _build_info(),
         }
 
-        strict = _env_truthy(os.getenv("READINESS_STRICT", "0"))
         status_code = 200 if (ok or not strict) else 503
         return JSONResponse(status_code=status_code, content=payload)
 

--- a/tests/test_health_and_ready.py
+++ b/tests/test_health_and_ready.py
@@ -1,5 +1,8 @@
 import pytest
 
+from app import main as main_mod
+from app.core.config import settings
+
 
 @pytest.mark.asyncio
 async def test_health_ok(client):
@@ -15,6 +18,22 @@ async def test_ready_relaxed_200(client, monkeypatch):
     r = await client.get("/ready")
     assert r.status_code == 200
     assert "ready" in r.json()
+
+
+@pytest.mark.asyncio
+async def test_ready_strict_db_down_returns_503(client, monkeypatch):
+    monkeypatch.setenv("READINESS_STRICT", "1")
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    monkeypatch.setattr(settings, "DATABASE_URL", "postgresql://user:pass@localhost:5432/smartsell")
+
+    async def _fail_pg(*_args, **_kwargs):
+        return False, "db_down", {}
+
+    monkeypatch.setattr(main_mod, "_pg_probe", _fail_pg)
+
+    r = await client.get("/ready")
+    assert r.status_code == 503
+    assert r.json().get("postgres", {}).get("ok") is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_prod_safety_integrations.py
+++ b/tests/test_prod_safety_integrations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 
 import pytest
+import json
 
 from app.core.config import settings
 from app.services import background_tasks
@@ -45,6 +46,20 @@ def test_email_logs_masked_email(monkeypatch, caplog):
 
     assert email not in caplog.text
     assert mask_email(email) in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_env_endpoint_redacts_database_url(async_client, monkeypatch):
+    monkeypatch.setenv("ALLOW_ENV_ENDPOINT", "1")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@localhost:5432/smartsell")
+
+    resp = await async_client.get("/env")
+    assert resp.status_code == 200
+
+    payload = resp.json()
+    raw = "postgresql://user:pass@localhost:5432/smartsell"
+    assert raw not in json.dumps(payload)
+    assert payload.get("env", {}).get("DATABASE_URL") not in (None, raw)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
What
- Default readiness strict mode in production; allow enabling strict checks in tests when configured.
- Redact DATABASE_URL/DB_URL/REDIS_URL/SQLALCHEMY_DATABASE_URI in /env output.
- Add tests: readiness strict DB-down + env URL redaction.

Tests
- pytest -q (green)