### PR TITLE
Auth abuse hardening P1: OTP per-phone + login per-identifier throttling

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -40,6 +40,7 @@ from app.core.config import settings
 from app.core.db import get_async_db
 from app.core.dependencies import (
     auth_rate_limit,
+    enforce_rate_limit,
     get_client_info,
     get_current_user,
     get_otp_service,
@@ -167,6 +168,38 @@ def _looks_like_email(value: str) -> bool:
 
 def _normalize_purpose(v: str | None) -> str:
     return (v or "").strip().lower() or "login"
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        raw = os.getenv(name)
+        return int(raw) if raw is not None else int(default)
+    except Exception:
+        return int(default)
+
+
+async def _enforce_otp_phone_rate_limit(phone: str) -> None:
+    if not phone:
+        return
+    await enforce_rate_limit(
+        tag="otp_phone",
+        ident=f"otp:phone:{phone}",
+        max_requests=_env_int("OTP_PHONE_RATE_LIMIT", 5),
+        window_seconds=_env_int("OTP_PHONE_RATE_WINDOW", 60),
+        detail="otp_phone_rate_limited",
+    )
+
+
+async def _enforce_login_identifier_rate_limit(identifier: str) -> None:
+    if not identifier:
+        return
+    await enforce_rate_limit(
+        tag="login_ident",
+        ident=f"login:identifier:{identifier}",
+        max_requests=_env_int("LOGIN_IDENTIFIER_RATE_LIMIT", 10),
+        window_seconds=_env_int("LOGIN_IDENTIFIER_RATE_WINDOW", 60),
+        detail="login_rate_limited",
+    )
 
 
 def _gen_otp_code(length: int = OTP_CODE_LEN) -> str:
@@ -439,6 +472,9 @@ async def login(login_data: UserLogin, request: Request, db: AsyncSession = Depe
     email = identifier.lower() if is_email else ""
     otp_code = (login_data.otp_code or "").strip()
     via_otp = bool(otp_code)
+
+    identifier_norm = email or phone or identifier.lower()
+    await _enforce_login_identifier_rate_limit(identifier_norm)
 
     user = await (_get_user_by_email(db, email) if is_email else _get_user_by_phone(db, phone))
 
@@ -721,6 +757,8 @@ async def request_otp(
     """
     phone = _normalize_phone(otp_request.phone)
     purpose = _normalize_purpose(otp_request.purpose)
+
+    await _enforce_otp_phone_rate_limit(phone)
 
     now = _utcnow_naive()
     ttl = timedelta(minutes=OTP_TTL_MINUTES)
@@ -1076,6 +1114,8 @@ async def phone_change_request(
 ):
     phone = _normalize_phone(payload.new_phone)
     variants = _phone_variants(phone)
+
+    await _enforce_otp_phone_rate_limit(phone)
 
     if any(v == current_user.phone for v in variants):
         raise SmartSellValidationError("Phone is unchanged", "PHONE_UNCHANGED")

--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -563,6 +563,27 @@ def rate_limit(max_requests: int = 100, window_seconds: int = 60, tag: str = "ap
     return _wrapped
 
 
+async def enforce_rate_limit(
+    *,
+    tag: str,
+    ident: str,
+    max_requests: int,
+    window_seconds: int,
+    detail: str,
+):
+    if not _RATE_ENABLED or not _rate_limiter:
+        return True
+    allowed, retry = await _rate_limiter.allow(tag, ident, max_requests, window_seconds)
+    if not allowed:
+        headers = {
+            "Retry-After": str(retry),
+            "X-RateLimit-Limit": str(max_requests),
+            "X-RateLimit-Window": str(window_seconds),
+        }
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=detail, headers=headers)
+    return True
+
+
 _auth_rl = _limit_dep("auth", _AUTH_RATE_LIMIT, _AUTH_RATE_WINDOW)
 _api_rl = _limit_dep("api", _API_RATE_LIMIT, _API_RATE_WINDOW)
 _otp_rl = _limit_dep("otp", _OTP_RATE_LIMIT, _OTP_RATE_WINDOW)
@@ -787,6 +808,7 @@ __all__ = [
     "otp_rate_limit",
     "auth_rate_limit_dep",  # keep aliases
     "api_rate_limit_dep",
+    "enforce_rate_limit",
     # pagination
     "Pagination",
     "get_pagination",

--- a/tests/test_auth_abuse_limits.py
+++ b/tests/test_auth_abuse_limits.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core import dependencies as deps
+from app.core.rate_limiter import RateLimiter
+
+
+@pytest.mark.asyncio
+async def test_otp_per_phone_rate_limit(async_client, monkeypatch):
+    monkeypatch.setenv("OTP_PHONE_RATE_LIMIT", "2")
+    monkeypatch.setenv("OTP_PHONE_RATE_WINDOW", "60")
+    monkeypatch.setattr(deps, "_RATE_ENABLED", True)
+    monkeypatch.setattr(deps, "_rate_limiter", RateLimiter(redis=None, env="test", prefix="rl"))
+
+    payload = {"phone": "+77001234567", "purpose": "login"}
+
+    r1 = await async_client.post("/api/v1/auth/request-otp", json=payload)
+    r2 = await async_client.post("/api/v1/auth/request-otp", json=payload)
+    r3 = await async_client.post("/api/v1/auth/request-otp", json=payload)
+
+    assert r1.status_code in {200, 400, 409}
+    assert r2.status_code in {200, 400, 409}
+    assert r3.status_code == 429
+    assert r3.json().get("detail") == "otp_phone_rate_limited"
+
+
+@pytest.mark.asyncio
+async def test_login_identifier_rate_limit(async_client, monkeypatch):
+    monkeypatch.setenv("LOGIN_IDENTIFIER_RATE_LIMIT", "2")
+    monkeypatch.setenv("LOGIN_IDENTIFIER_RATE_WINDOW", "60")
+    monkeypatch.setattr(deps, "_RATE_ENABLED", True)
+    monkeypatch.setattr(deps, "_rate_limiter", RateLimiter(redis=None, env="test", prefix="rl"))
+
+    payload = {"identifier": "user@example.com", "password": "bad"}
+
+    r1 = await async_client.post("/api/v1/auth/login", json=payload)
+    r2 = await async_client.post("/api/v1/auth/login", json=payload)
+    r3 = await async_client.post("/api/v1/auth/login", json=payload)
+
+    assert r1.status_code in {401, 403, 422}
+    assert r2.status_code in {401, 403, 422}
+    assert r3.status_code == 429
+    assert r3.json().get("detail") == "login_rate_limited"


### PR DESCRIPTION
What
- Add per-phone rate limit for /auth/request-otp + phone change OTP.
- Add per-identifier rate limit for login.
- Introduce reusable enforce_rate_limit helper using existing limiter infra.
- Add tests covering 429 behavior.

Tests
- pytest -q (green)