### PR TITLE
Auth abuse hardening P2: refresh/logout rate limits

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -202,6 +202,30 @@ async def _enforce_login_identifier_rate_limit(identifier: str) -> None:
     )
 
 
+async def _enforce_refresh_rate_limit(ident: str) -> None:
+    if not ident:
+        return
+    await enforce_rate_limit(
+        tag="refresh",
+        ident=ident,
+        max_requests=_env_int("REFRESH_RATE_LIMIT", 20),
+        window_seconds=_env_int("REFRESH_RATE_WINDOW", 60),
+        detail="auth_refresh_rate_limited",
+    )
+
+
+async def _enforce_logout_rate_limit(ident: str) -> None:
+    if not ident:
+        return
+    await enforce_rate_limit(
+        tag="logout",
+        ident=ident,
+        max_requests=_env_int("LOGOUT_RATE_LIMIT", 30),
+        window_seconds=_env_int("LOGOUT_RATE_WINDOW", 60),
+        detail="auth_logout_rate_limited",
+    )
+
+
 def _gen_otp_code(length: int = OTP_CODE_LEN) -> str:
     return "".join(str(secrets.randbelow(10)) for _ in range(max(4, min(10, length))))
 
@@ -554,12 +578,23 @@ async def login(login_data: UserLogin, request: Request, db: AsyncSession = Depe
 
 
 @router.post("/refresh", response_model=TokenResponse)
-async def refresh_token(refresh_data: RefreshTokenRequest, db: AsyncSession = Depends(get_async_db)):
+async def refresh_token(
+    refresh_data: RefreshTokenRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_async_db),
+):
     """
     Обновляет access-токен по действующему refresh-токену.
     Refresh при этом ротируется (one-time use).
     """
-    token_hash = _hash_refresh_token(refresh_data.refresh_token)
+    client_info = get_client_info(request)
+    raw_refresh = (refresh_data.refresh_token or "").strip()
+    if not raw_refresh:
+        await _enforce_refresh_rate_limit(client_info["ip_address"])
+        raise AuthenticationError("refresh_invalid", "INVALID_REFRESH_TOKEN")
+
+    token_hash = _hash_refresh_token(raw_refresh)
+    await _enforce_refresh_rate_limit(f"refresh:token:{token_hash}")
     now = _utcnow_naive()
 
     res = await db.execute(
@@ -571,7 +606,12 @@ async def refresh_token(refresh_data: RefreshTokenRequest, db: AsyncSession = De
     session = res.scalars().first()
 
     if not session:
+        await _enforce_refresh_rate_limit(client_info["ip_address"])
         raise AuthenticationError("refresh_invalid", "INVALID_REFRESH_TOKEN")
+
+    session_id = getattr(session, "id", None)
+    ident = f"refresh:session:{session_id}" if session_id is not None else f"refresh:user:{session.user_id}"
+    await _enforce_refresh_rate_limit(ident)
 
     if not session.is_active:
         await db.execute(
@@ -616,9 +656,13 @@ async def refresh_token(refresh_data: RefreshTokenRequest, db: AsyncSession = De
 
 
 @router.post("/token/refresh", response_model=TokenResponse)
-async def refresh_token_alias(refresh_data: RefreshTokenRequest, db: AsyncSession = Depends(get_async_db)):
+async def refresh_token_alias(
+    refresh_data: RefreshTokenRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_async_db),
+):
     """Legacy alias for /auth/refresh used by tests/older clients."""
-    return await refresh_token(refresh_data, db)
+    return await refresh_token(refresh_data, request, db)
 
 
 @router.post("/logout", response_model=SuccessResponse)
@@ -638,10 +682,18 @@ async def logout(
             token = header_val.split(" ", 1)[1].strip()
     if not token:
         token = request.cookies.get("access_token")
+    client_info = get_client_info(request)
     payload = None
     user_id = 0
     if token:
         payload = decode_and_validate(token, expected_type="access")
+        try:
+            user_id = int(payload.get("sub", 0))
+        except Exception:
+            user_id = 0
+
+        await _enforce_logout_rate_limit(f"user:{user_id}" if user_id > 0 else client_info["ip_address"])
+
         key = denylist_key_for_token(token, payload)
         exp = payload.get("exp")
         if key:
@@ -653,13 +705,9 @@ async def logout(
                     ttl_seconds = None
             revoke_token(key, ttl_seconds=ttl_seconds)
 
-        try:
-            user_id = int(payload.get("sub", 0))
-        except Exception:
-            user_id = 0
-
     if refresh_data and refresh_data.refresh_token:
-        token_hash = _hash_refresh_token(refresh_data.refresh_token)
+        raw_refresh = (refresh_data.refresh_token or "").strip()
+        token_hash = _hash_refresh_token(raw_refresh) if raw_refresh else ""
         res = await db.execute(
             select(UserSession).where(
                 UserSession.refresh_token == token_hash,
@@ -669,6 +717,13 @@ async def logout(
         session = res.scalars().first()
 
         if session:
+            await _enforce_logout_rate_limit(f"user:{session.user_id}")
+        else:
+            await _enforce_logout_rate_limit(
+                f"logout:refresh:{token_hash}" if token_hash else client_info["ip_address"]
+            )
+
+        if session:
             session.is_active = False
             session.terminated_at = _utcnow_naive()
             await db.commit()
@@ -676,6 +731,7 @@ async def logout(
         return SuccessResponse(message="Logged out successfully")
 
     if not token:
+        await _enforce_logout_rate_limit(client_info["ip_address"])
         raise AuthenticationError("Authentication required", "AUTH_REQUIRED")
 
     if user_id > 0:

--- a/tests/test_auth_refresh_logout_limits.py
+++ b/tests/test_auth_refresh_logout_limits.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core import dependencies as deps
+from app.core.rate_limiter import RateLimiter
+from app.core.security import get_password_hash
+from app.models import Company, User
+
+
+async def _login_and_tokens(async_client: AsyncClient, async_db_session: AsyncSession) -> dict:
+    company = Company(name="Rate Limit Co")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    user = User(
+        company_id=company.id,
+        phone="+77001239999",
+        hashed_password=get_password_hash("password123"),
+        role="admin",
+    )
+    async_db_session.add(user)
+    await async_db_session.commit()
+
+    login_data = {"identifier": "+77001239999", "password": "password123"}
+    resp = await async_client.post("/api/auth/login", json=login_data)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+@pytest.mark.asyncio
+async def test_refresh_rate_limited(async_client: AsyncClient, async_db_session: AsyncSession, monkeypatch):
+    monkeypatch.setenv("REFRESH_RATE_LIMIT", "1")
+    monkeypatch.setenv("REFRESH_RATE_WINDOW", "60")
+    monkeypatch.setattr(deps, "_RATE_ENABLED", True)
+    monkeypatch.setattr(deps, "_rate_limiter", RateLimiter(redis=None, env="test", prefix="rl"))
+
+    tokens = await _login_and_tokens(async_client, async_db_session)
+
+    r1 = await async_client.post("/api/auth/token/refresh", json={"refresh_token": tokens["refresh_token"]})
+    assert r1.status_code == 200, r1.text
+
+    r2 = await async_client.post("/api/auth/token/refresh", json={"refresh_token": tokens["refresh_token"]})
+    assert r2.status_code == 429
+    assert r2.json().get("detail") == "auth_refresh_rate_limited"
+    assert r2.headers.get("Retry-After")
+
+
+@pytest.mark.asyncio
+async def test_logout_rate_limited(async_client: AsyncClient, async_db_session: AsyncSession, monkeypatch):
+    monkeypatch.setenv("LOGOUT_RATE_LIMIT", "1")
+    monkeypatch.setenv("LOGOUT_RATE_WINDOW", "60")
+    monkeypatch.setattr(deps, "_RATE_ENABLED", True)
+    monkeypatch.setattr(deps, "_rate_limiter", RateLimiter(redis=None, env="test", prefix="rl"))
+
+    tokens = await _login_and_tokens(async_client, async_db_session)
+    access_token = tokens["access_token"]
+
+    r1 = await async_client.post("/api/auth/logout", headers={"Authorization": f"Bearer {access_token}"})
+    assert r1.status_code == 200, r1.text
+
+    r2 = await async_client.post("/api/auth/logout", headers={"Authorization": f"Bearer {access_token}"})
+    assert r2.status_code == 429
+    assert r2.json().get("detail") == "auth_logout_rate_limited"
+    assert r2.headers.get("Retry-After")


### PR DESCRIPTION
What
- Add rate limits for /auth/refresh and /auth/logout using enforce_rate_limit helper.
- Default limits via env, stable detail codes, Retry-After headers on 429.
- Update tests to assert detail codes + headers.

Tests
- pytest -q (green)