### PR TITLE
Security: require CSRF_SECRET in production

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -762,7 +762,23 @@ def clear_refresh_cookie(response) -> None:
 # =============================================================================
 # CSRF helpers (для cookie-based схем)
 # =============================================================================
-_CSRF_SECRET = os.getenv("CSRF_SECRET") or settings.SECRET_KEY
+
+
+def _resolve_csrf_secret() -> str:
+    csrf_secret = (os.getenv("CSRF_SECRET") or getattr(settings, "CSRF_SECRET", "") or "").strip()
+    secret_key = (settings.SECRET_KEY or "").strip()
+
+    if settings.is_production:
+        if not csrf_secret:
+            raise RuntimeError("csrf_secret_required_in_prod")
+        if csrf_secret == secret_key:
+            raise RuntimeError("csrf_secret_must_differ_from_secret_key")
+        return csrf_secret
+
+    return csrf_secret or secret_key
+
+
+_CSRF_SECRET = _resolve_csrf_secret()
 
 
 def generate_csrf_token(session_id: str) -> str:

--- a/tests/test_csrf_secret_required_in_prod.py
+++ b/tests/test_csrf_secret_required_in_prod.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+
+from app.core import config as config_mod
+
+
+def _reload_security():
+    import app.core.security as security
+
+    return importlib.reload(security)
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch, *, env: str, secret_key: str, csrf_secret: str | None) -> None:
+    monkeypatch.setattr(config_mod.settings, "ENVIRONMENT", env)
+    monkeypatch.setattr(config_mod.settings, "SECRET_KEY", secret_key)
+    if csrf_secret is None:
+        monkeypatch.delenv("CSRF_SECRET", raising=False)
+    else:
+        monkeypatch.setenv("CSRF_SECRET", csrf_secret)
+
+
+def test_csrf_secret_required_in_prod_missing(monkeypatch: pytest.MonkeyPatch):
+    _set_env(monkeypatch, env="production", secret_key="secret-key-123", csrf_secret=None)
+
+    with pytest.raises(RuntimeError, match="csrf_secret_required_in_prod"):
+        _reload_security()
+
+    _set_env(monkeypatch, env="development", secret_key="secret-key-123", csrf_secret=None)
+    _reload_security()
+
+
+def test_csrf_secret_required_in_prod_equal(monkeypatch: pytest.MonkeyPatch):
+    _set_env(monkeypatch, env="production", secret_key="secret-key-123", csrf_secret="secret-key-123")
+
+    with pytest.raises(RuntimeError, match="csrf_secret_must_differ_from_secret_key"):
+        _reload_security()
+
+    _set_env(monkeypatch, env="development", secret_key="secret-key-123", csrf_secret=None)
+    _reload_security()
+
+
+def test_csrf_secret_not_required_non_prod(monkeypatch: pytest.MonkeyPatch):
+    _set_env(monkeypatch, env="development", secret_key="secret-key-123", csrf_secret=None)
+    _reload_security()


### PR DESCRIPTION
What
- Require dedicated CSRF_SECRET in production (must not be empty and must differ from SECRET_KEY).
- Keep dev fallback: CSRF_SECRET optional, defaults to SECRET_KEY.

Tests
- pytest -q