### PR TITLE
Security: require dedicated invite/reset token secrets in production

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -472,6 +472,12 @@ class Settings(BaseSettings):
 
     # ---- security/JWT
     SECRET_KEY: str = Field(default="changeme", description="JWT secret key", validation_alias="SECRET_KEY")
+    INVITE_TOKEN_SECRET: str | None = Field(
+        default=None, description="Invitation token secret", validation_alias="INVITE_TOKEN_SECRET"
+    )
+    RESET_TOKEN_SECRET: str | None = Field(
+        default=None, description="Reset token secret", validation_alias="RESET_TOKEN_SECRET"
+    )
     ACCESS_TOKEN_EXPIRE_MINUTES: int = Field(
         default=30,
         description="Access token expiry",
@@ -1005,6 +1011,26 @@ class Settings(BaseSettings):
             raise ValueError("Set a secure SECRET_KEY in production!")
         if len(value) < 32:
             raise ValueError("SECRET_KEY must be at least 32 characters in production!")
+
+    def check_token_secrets(self) -> None:
+        if not self.is_production:
+            return
+        invite_secret = (self.INVITE_TOKEN_SECRET or "").strip()
+        reset_secret = (self.RESET_TOKEN_SECRET or "").strip()
+
+        if not invite_secret:
+            raise ValueError("invite_token_secret_required_in_prod")
+        if invite_secret.lower() in {"changeme", "secret", "password"}:
+            raise ValueError("invite_token_secret_required_in_prod")
+        if len(invite_secret) < 32:
+            raise ValueError("invite_token_secret_required_in_prod")
+
+        if not reset_secret:
+            raise ValueError("reset_token_secret_required_in_prod")
+        if reset_secret.lower() in {"changeme", "secret", "password"}:
+            raise ValueError("reset_token_secret_required_in_prod")
+        if len(reset_secret) < 32:
+            raise ValueError("reset_token_secret_required_in_prod")
     def _is_postgres_url(self, url: str) -> bool:
         try:
             parsed = urlparse(url)
@@ -2006,6 +2032,7 @@ def validate_prod_secrets(s: Settings | None = None) -> None:
     s = s or get_settings()
     if s.is_production:
         s.check_secret_key()
+        s.check_token_secrets()
 
 
 settings = get_settings()

--- a/app/utils/tokens.py
+++ b/app/utils/tokens.py
@@ -21,7 +21,11 @@ except Exception:  # pragma: no cover
 
 
 def _default_secret(preferred: Optional[str] = None) -> str:
-    return preferred or getattr(settings, "SECRET_KEY", "dev-secret")
+    if preferred:
+        return preferred
+    if getattr(settings, "is_production", False):
+        raise RuntimeError("token_secret_required_in_prod")
+    return getattr(settings, "SECRET_KEY", "dev-secret")
 
 
 def generate_token(length: int = 32) -> str:

--- a/tests/test_invite_reset_tokens_require_dedicated_secrets_in_prod.py
+++ b/tests/test_invite_reset_tokens_require_dedicated_secrets_in_prod.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from app.core import config as config_mod
+
+
+def _reload_tokens():
+    import app.utils.tokens as tokens
+
+    return importlib.reload(tokens)
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch, *, env: str, invite_secret: str | None, reset_secret: str | None):
+    monkeypatch.setattr(config_mod.settings, "ENVIRONMENT", env)
+    monkeypatch.setattr(config_mod.settings, "INVITE_TOKEN_SECRET", invite_secret)
+    monkeypatch.setattr(config_mod.settings, "RESET_TOKEN_SECRET", reset_secret)
+
+
+def test_invite_token_secret_required_in_prod(monkeypatch: pytest.MonkeyPatch):
+    _set_env(monkeypatch, env="production", invite_secret=None, reset_secret="x" * 32)
+
+    with pytest.raises(ValueError, match="invite_token_secret_required_in_prod"):
+        config_mod.validate_prod_secrets(config_mod.settings)
+
+
+def test_reset_token_secret_required_in_prod(monkeypatch: pytest.MonkeyPatch):
+    _set_env(monkeypatch, env="production", invite_secret="x" * 32, reset_secret=None)
+
+    with pytest.raises(ValueError, match="reset_token_secret_required_in_prod"):
+        config_mod.validate_prod_secrets(config_mod.settings)
+
+
+def test_non_prod_missing_token_secrets_allowed(monkeypatch: pytest.MonkeyPatch):
+    _set_env(monkeypatch, env="development", invite_secret=None, reset_secret=None)
+    config_mod.validate_prod_secrets(config_mod.settings)
+    _reload_tokens()

--- a/tests/test_startup_fails_on_insecure_secret_in_prod.py
+++ b/tests/test_startup_fails_on_insecure_secret_in_prod.py
@@ -32,6 +32,8 @@ async def test_startup_allows_secure_secret_in_prod(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("DEBUG", "0")
     monkeypatch.setenv("SECRET_KEY", "x" * 48)
+    monkeypatch.setenv("INVITE_TOKEN_SECRET", "x" * 48)
+    monkeypatch.setenv("RESET_TOKEN_SECRET", "x" * 48)
     monkeypatch.setenv("DISABLE_APP_STARTUP_HOOKS", "1")
 
     config.get_settings.cache_clear()
@@ -41,6 +43,8 @@ async def test_startup_allows_secure_secret_in_prod(monkeypatch):
     monkeypatch.setattr(config.settings, "ENVIRONMENT", "production", raising=False)
     monkeypatch.setattr(config.settings, "DEBUG", False, raising=False)
     monkeypatch.setattr(config.settings, "SECRET_KEY", "x" * 48, raising=False)
+    monkeypatch.setattr(config.settings, "INVITE_TOKEN_SECRET", "x" * 48, raising=False)
+    monkeypatch.setattr(config.settings, "RESET_TOKEN_SECRET", "x" * 48, raising=False)
 
     app = create_app()
 


### PR DESCRIPTION
What
- Add INVITE_TOKEN_SECRET and RESET_TOKEN_SECRET settings.
- Enforce dedicated secrets in production (non-empty, >=32, not weak values).
- Ensure startup prod-secret validation covers these secrets.
- Make token generation refuse implicit SECRET_KEY fallback in production.

Tests
- pytest -q