### PR TITLE
fix(idempotency): fail in prod when redis unavailable

### DIFF
--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -655,6 +655,15 @@ async def _apply_idempotency(
     if not raw_key:
         return True
 
+    redis_client = get_redis()
+    if settings.is_production:
+        if redis_client is None:
+            raise HTTPException(status_code=503, detail="idempotency_unavailable")
+        try:
+            await redis_client.ping()  # type: ignore[attr-defined]
+        except Exception:
+            raise HTTPException(status_code=503, detail="idempotency_unavailable")
+
     ttl_header = request.headers.get("Idempotency-TTL")
     try:
         ttl_seconds = int(ttl_header) if ttl_header else _idem_default_ttl

--- a/app/core/idempotency.py
+++ b/app/core/idempotency.py
@@ -10,6 +10,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.models.idempotency_key import IdempotencyKey
 
 log = logging.getLogger(__name__)
@@ -30,6 +31,15 @@ class IdempotencyEnforcer:
         self.default_ttl = max(1, int(default_ttl or 1))
         self.env = env or "dev"
         self._mem: dict[str, tuple[int, float]] = {}
+
+    def _is_production(self) -> bool:
+        try:
+            return bool(settings.is_production) or self.env.lower() == "production"
+        except Exception:
+            return self.env.lower() == "production"
+
+    def _key(self, key: str) -> str:
+        return f"{self.env}:{self.prefix}:{key}"
 
     async def reserve(
         self,
@@ -106,6 +116,14 @@ class IdempotencyEnforcer:
         ttl_seconds = kwargs.get("ttl_seconds")
         if key is None or status_code is None:
             return
+        if self.redis is not None:
+            try:
+                await self._set_result_redis(str(key), int(status_code), ttl_seconds=ttl_seconds)
+                return
+            except Exception as exc:
+                log.error("Idempotency redis error", extra={"error": str(exc)})
+                if self._is_production():
+                    return
         await self._set_result_mem(str(key), int(status_code), ttl_seconds=ttl_seconds)
 
     async def _insert_processing(
@@ -150,6 +168,33 @@ class IdempotencyEnforcer:
         ttl = max(1, int(ttl_seconds or self.default_ttl))
         self._mem[key] = (int(status_code), time.time() + ttl)
 
+    async def _reserve_redis(self, key: str, ttl_seconds: int) -> tuple[bool, Optional[int]]:
+        ttl = max(1, int(ttl_seconds))
+        rkey = self._key(key)
+        existing = await self.redis.get(rkey)  # type: ignore[attr-defined]
+        if existing is not None:
+            try:
+                return False, int(existing)
+            except Exception:
+                return False, None
+
+        inserted = await self.redis.set(rkey, "102", nx=True, ex=ttl)  # type: ignore[attr-defined]
+        if inserted:
+            return True, None
+
+        existing = await self.redis.get(rkey)  # type: ignore[attr-defined]
+        if existing is not None:
+            try:
+                return False, int(existing)
+            except Exception:
+                return False, None
+        return True, None
+
+    async def _set_result_redis(self, key: str, status_code: int, ttl_seconds: Optional[int] = None) -> None:
+        ttl = max(1, int(ttl_seconds or self.default_ttl))
+        rkey = self._key(key)
+        await self.redis.set(rkey, str(int(status_code)), ex=ttl)  # type: ignore[attr-defined]
+
     def dependency(self, allow_replay: bool = False):
         async def dep(request: Request, response: Response):
             method = request.method.upper()
@@ -166,7 +211,20 @@ class IdempotencyEnforcer:
             except Exception:
                 ttl_seconds = self.default_ttl
 
-            allowed, processed_status = await self._reserve_mem(key, ttl_seconds)
+            try:
+                if self.redis is not None:
+                    allowed, processed_status = await self._reserve_redis(key, ttl_seconds)
+                else:
+                    if self._is_production():
+                        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "idempotency_unavailable")
+                    allowed, processed_status = await self._reserve_mem(key, ttl_seconds)
+            except HTTPException:
+                raise
+            except Exception as exc:
+                log.error("Idempotency redis error", extra={"error": str(exc)})
+                if self._is_production():
+                    raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "idempotency_unavailable")
+                allowed, processed_status = await self._reserve_mem(key, ttl_seconds)
             if not allowed:
                 if processed_status is not None and allow_replay:
                     request.state.idempotency_key = key

--- a/tests/app/test_idempotency_redis_down.py
+++ b/tests/app/test_idempotency_redis_down.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import AsyncClient
+
+from app.core.config import settings
+from app.core.idempotency import IdempotencyEnforcer
+
+
+class FailingRedis:
+    async def get(self, *args, **kwargs):
+        raise ConnectionError("redis down")
+
+    async def set(self, *args, **kwargs):
+        raise ConnectionError("redis down")
+
+
+@pytest.mark.asyncio
+async def test_idempotency_redis_down_in_prod_returns_503(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production", raising=False)
+    enforcer = IdempotencyEnforcer(redis=FailingRedis(), env="production")
+
+    app = FastAPI()
+
+    @app.post("/probe", dependencies=[Depends(enforcer.dependency())])
+    async def probe():
+        return {"ok": True}
+
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        resp = await client.post("/probe", headers={"Idempotency-Key": "k1"})
+
+    assert resp.status_code == 503
+    assert resp.json().get("detail") == "idempotency_unavailable"
+
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development", raising=False)
+    enforcer_dev = IdempotencyEnforcer(redis=FailingRedis(), env="development")
+
+    app_dev = FastAPI()
+
+    @app_dev.post("/probe", dependencies=[Depends(enforcer_dev.dependency())])
+    async def probe_dev():
+        return {"ok": True}
+
+    async with AsyncClient(app=app_dev, base_url="http://test") as client:
+        resp_dev = await client.post("/probe", headers={"Idempotency-Key": "k1"})
+
+    assert resp_dev.status_code == 200


### PR DESCRIPTION
P1: no in-memory fallback in production; return 503 when Redis down; add test.