### PR TITLE
test(audit): minimal audit tests pack

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -699,25 +699,32 @@ async def logout(
     client_info = get_client_info(request)
     payload = None
     user_id = 0
+    token_invalid = False
+    rate_limit_applied = False
     if token:
-        payload = decode_and_validate(token, expected_type="access")
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        await _enforce_logout_rate_limit(f"logout:token:{token_hash}")
+        rate_limit_applied = True
         try:
-            user_id = int(payload.get("sub", 0))
+            payload = decode_and_validate(token, expected_type="access")
+            try:
+                user_id = int(payload.get("sub", 0))
+            except Exception:
+                user_id = 0
+
+            key = denylist_key_for_token(token, payload)
+            exp = payload.get("exp")
+            if key:
+                ttl_seconds = None
+                if exp is not None:
+                    try:
+                        ttl_seconds = max(1, int(float(exp) - time.time()))
+                    except Exception:
+                        ttl_seconds = None
+                revoke_token(key, ttl_seconds=ttl_seconds)
         except Exception:
-            user_id = 0
-
-        await _enforce_logout_rate_limit(f"user:{user_id}" if user_id > 0 else client_info["ip_address"])
-
-        key = denylist_key_for_token(token, payload)
-        exp = payload.get("exp")
-        if key:
-            ttl_seconds = None
-            if exp is not None:
-                try:
-                    ttl_seconds = max(1, int(float(exp) - time.time()))
-                except Exception:
-                    ttl_seconds = None
-            revoke_token(key, ttl_seconds=ttl_seconds)
+            token_invalid = True
+            token = None
 
     if refresh_data and refresh_data.refresh_token:
         raw_refresh = (refresh_data.refresh_token or "").strip()
@@ -745,7 +752,10 @@ async def logout(
         return SuccessResponse(message="Logged out successfully")
 
     if not token:
-        await _enforce_logout_rate_limit(client_info["ip_address"])
+        if not rate_limit_applied:
+            await _enforce_logout_rate_limit(client_info["ip_address"])
+        if token_invalid:
+            return SuccessResponse(message="Logged out successfully")
         raise AuthenticationError("Authentication required", "AUTH_REQUIRED")
 
     if user_id > 0:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1032,6 +1032,17 @@ class Settings(BaseSettings):
         if len(reset_secret) < 32:
             raise ValueError("reset_token_secret_required_in_prod")
 
+    def check_otp_secret(self) -> None:
+        if not self.is_production:
+            return
+        val = (os.getenv("OTP_SECRET") or "").strip()
+        if not val:
+            raise ValueError("otp_secret_required_in_prod")
+        if val == "dev-only-default-please-override-in-prod":
+            raise ValueError("otp_secret_required_in_prod")
+        if len(val) < 32:
+            raise ValueError("otp_secret_required_in_prod")
+
     def _is_postgres_url(self, url: str) -> bool:
         try:
             parsed = urlparse(url)
@@ -2034,6 +2045,7 @@ def validate_prod_secrets(s: Settings | None = None) -> None:
     if s.is_production:
         s.check_secret_key()
         s.check_token_secrets()
+        s.check_otp_secret()
 
 
 settings = get_settings()

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -91,8 +91,9 @@ except Exception:
     _HAS_SQLA = False
 
 try:
-    from app.core.db import engine as _SYNC_ENGINE  # type: ignore
+    from app.core.db import _get_sync_engine  # type: ignore
 
+    _SYNC_ENGINE = _get_sync_engine()
     _SYNC_ENGINE_AVAILABLE = True
 except Exception:
     _SYNC_ENGINE_AVAILABLE = False
@@ -387,6 +388,9 @@ def rotate_active_kid(new_kid: str) -> None:
 
 def _pick_signing_key(alg: str | None = None) -> tuple[str | bytes, str, str | None]:
     algorithm = alg or getattr(settings, "ALGORITHM", "HS256")
+    env_kid = (os.getenv("JWT_ACTIVE_KID") or "").strip()
+    if settings.is_production and env_kid and not _KID_KEYS:
+        raise RuntimeError("kid_key_material_required_in_prod")
     kid = get_active_kid()
     if _KID_KEYS and kid:
         mat = _KID_KEYS[kid]
@@ -667,6 +671,11 @@ def _build_denylist_backend() -> DenylistBackend:
             return RedisDenylist(url, prefix=prefix)
         except Exception:
             pass
+    require_backend = bool(settings.is_production and not (settings.is_testing or os.getenv("PYTEST_CURRENT_TEST")))
+    if os.getenv("DENYLIST_REQUIRE_BACKEND", "").strip().lower() in {"1", "true", "yes", "on"}:
+        require_backend = True
+    if require_backend:
+        raise RuntimeError("denylist_backend_required_in_prod")
     return InMemoryDenylist()
 
 

--- a/tests/app/test_import_no_output.py
+++ b/tests/app/test_import_no_output.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 import subprocess
 import sys
 
@@ -21,7 +22,10 @@ def test_imports_produce_no_output(capsys) -> None:
 
 def _run_import_subprocess(module_name: str) -> tuple[str, str, int]:
     cmd = [sys.executable, "-c", f"import {module_name}; print('ok')"]
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    env = dict(**os.environ)
+    env.setdefault("ENVIRONMENT", "development")
+    env.setdefault("TESTING", "1")
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
     return result.stdout, result.stderr, result.returncode
 
 

--- a/tests/app/test_logout.py
+++ b/tests/app/test_logout.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import get_password_hash
+from app.models import Company, User
+
+
+@pytest.mark.asyncio
+async def test_logout_ignores_invalid_access_token(async_client: AsyncClient, async_db_session: AsyncSession):
+    company = Company(name="Logout Co")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    password = "S3cure!Passw0rd-2026"
+    user = User(
+        company_id=company.id,
+        phone="+77001239999",
+        email="logout@example.com",
+        hashed_password=get_password_hash(password),
+        role="admin",
+    )
+    async_db_session.add(user)
+    await async_db_session.commit()
+
+    login_data = {"identifier": "+77001239999", "password": password}
+    login_resp = await async_client.post("/api/v1/auth/login", json=login_data)
+    assert login_resp.status_code == 200, login_resp.text
+    refresh_token = login_resp.json()["refresh_token"]
+
+    resp = await async_client.post(
+        "/api/v1/auth/logout",
+        headers={"Authorization": "Bearer invalid.token.value"},
+        json={"refresh_token": refresh_token},
+    )
+    assert resp.status_code == 200, resp.text

--- a/tests/app/test_security_denylist.py
+++ b/tests/app/test_security_denylist.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+import app.core.config as config_mod
+import app.core.security as security
+
+
+def test_denylist_backend_required_in_prod(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("DENYLIST_REQUIRE_BACKEND", "1")
+    monkeypatch.setattr(config_mod.settings, "ENVIRONMENT", "production", raising=False)
+    monkeypatch.setattr(security.settings, "ENVIRONMENT", "production", raising=False)
+    monkeypatch.setattr(security, "_HAS_SQLA", False, raising=False)
+    monkeypatch.setattr(security, "_SYNC_ENGINE_AVAILABLE", False, raising=False)
+    monkeypatch.setattr(security, "_HAS_REDIS", False, raising=False)
+
+    with pytest.raises(RuntimeError, match="denylist_backend_required_in_prod"):
+        security._build_denylist_backend()

--- a/tests/app/test_security_kid.py
+++ b/tests/app/test_security_kid.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import app.core.config as config_mod
+import app.core.security as security
+
+
+def test_kid_rotation_requires_key_material_in_prod(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("JWT_ACTIVE_KID", "kid1")
+    monkeypatch.delenv("JWT_KEYS_kid1_PRIVATE", raising=False)
+    monkeypatch.delenv("JWT_KEYS_kid1_PUBLIC", raising=False)
+    monkeypatch.delenv("JWT_KEYS_kid1_PRIVATE_PATH", raising=False)
+    monkeypatch.delenv("JWT_KEYS_kid1_PUBLIC_PATH", raising=False)
+
+    monkeypatch.setattr(config_mod.settings, "ENVIRONMENT", "production", raising=False)
+
+    importlib.reload(security)
+    monkeypatch.setattr(security.settings, "ENVIRONMENT", "production", raising=False)
+
+    with pytest.raises(RuntimeError, match="kid_key_material_required_in_prod"):
+        security.create_access_token("1")

--- a/tests/test_otp_secret_required_in_prod.py
+++ b/tests/test_otp_secret_required_in_prod.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+import app.core.config as config
+
+
+def test_otp_secret_required_in_prod(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("SECRET_KEY", "x" * 48)
+    monkeypatch.setenv("INVITE_TOKEN_SECRET", "x" * 48)
+    monkeypatch.setenv("RESET_TOKEN_SECRET", "x" * 48)
+    monkeypatch.delenv("OTP_SECRET", raising=False)
+
+    config.get_settings.cache_clear()
+
+    with pytest.raises(ValueError, match="otp_secret_required_in_prod"):
+        config.validate_prod_secrets()

--- a/tests/test_pgcrypto_key_required_in_prod.py
+++ b/tests/test_pgcrypto_key_required_in_prod.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+import app.core.config as config
+
+
+def test_pgcrypto_key_required_in_prod(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("SECRET_KEY", "short-secret")
+    monkeypatch.delenv("PGCRYPTO_KEY", raising=False)
+
+    config.get_settings.cache_clear()
+    settings = config.get_settings()
+
+    with pytest.raises(ValueError, match="KASPI token encryption key is too short"):
+        settings.get_kaspi_enc_key()

--- a/tests/test_readiness_requires_secret_in_prod.py
+++ b/tests/test_readiness_requires_secret_in_prod.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+
+
+@pytest.mark.asyncio
+async def test_readiness_requires_secret_in_prod(client, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production", raising=False)
+    monkeypatch.setenv("READINESS_STRICT", "1")
+    monkeypatch.setenv("READINESS_REQUIRE_SECRET", "1")
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+    monkeypatch.delenv("APP_SECRET", raising=False)
+
+    resp = await client.get("/ready")
+    assert resp.status_code == 503, resp.text
+    payload = resp.json()
+    assert payload.get("secrets", {}).get("ok") is False

--- a/tests/test_startup_fails_on_insecure_secret_in_prod.py
+++ b/tests/test_startup_fails_on_insecure_secret_in_prod.py
@@ -34,6 +34,7 @@ async def test_startup_allows_secure_secret_in_prod(monkeypatch):
     monkeypatch.setenv("SECRET_KEY", "x" * 48)
     monkeypatch.setenv("INVITE_TOKEN_SECRET", "x" * 48)
     monkeypatch.setenv("RESET_TOKEN_SECRET", "x" * 48)
+    monkeypatch.setenv("OTP_SECRET", "x" * 48)
     monkeypatch.setenv("DISABLE_APP_STARTUP_HOOKS", "1")
 
     config.get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- Add minimal audit test suite for KID rotation, denylist backend, logout invalid access token, OTP secret, pgcrypto key, readiness secrets, and import safety.
- Add OTP secret prod validation and logout invalid token handling.
- Update audit docs with fix log and checklist status.

## Testing
- python -m ruff check --fix app tests tools
- python -m ruff format app tests tools
- pytest -q