### PR TITLE
feat(email): SMTP provider with prod guards

### DIFF
--- a/app/integrations/providers/smtp/__init__.py
+++ b/app/integrations/providers/smtp/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from app.integrations.providers.smtp.messaging import SmtpMessagingProvider
+
+__all__ = ["SmtpMessagingProvider"]

--- a/app/integrations/providers/smtp/messaging.py
+++ b/app/integrations/providers/smtp/messaging.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import os
+import smtplib
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Any
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.integrations.errors import ProviderNotConfiguredError
+from app.integrations.ports.messaging import MessagingProvider
+from app.utils.pii import mask_email
+
+log = get_logger(__name__)
+
+
+class SmtpMessagingProvider(MessagingProvider):
+    def __init__(
+        self,
+        *,
+        config: dict[str, Any] | None = None,
+        name: str | None = None,
+        version: int | None = None,
+    ) -> None:
+        cfg = config or {}
+        self.name = (name or "smtp").strip() or "smtp"
+        self.version = int(version or 0)
+
+        self.host = (cfg.get("host") or settings.SMTP_HOST or "").strip()
+        self.port = int(cfg.get("port") or settings.SMTP_PORT or 587)
+        self.user = (cfg.get("user") or settings.SMTP_USER or "").strip()
+        self.password = (cfg.get("password") or settings.SMTP_PASSWORD or "").strip()
+        self.from_email = (cfg.get("from_email") or settings.SMTP_FROM_EMAIL or "").strip()
+        self.use_tls = bool(cfg.get("tls") if "tls" in cfg else settings.SMTP_TLS)
+        self.use_ssl = bool(cfg.get("ssl") if "ssl" in cfg else settings.SMTP_SSL)
+
+        if self.use_tls and self.use_ssl:
+            log.warning("SMTP TLS and SSL are both enabled; prefer one", extra={"provider": self.name})
+
+        if settings.is_production and not self._is_configured():
+            raise ProviderNotConfiguredError("email_provider_not_configured")
+
+    def _is_configured(self) -> bool:
+        return bool(self.host and self.port and self.user and self.password and self.from_email)
+
+    def _payload(self, status: str, extra: dict[str, Any] | None = None) -> dict[str, Any]:
+        data: dict[str, Any] = {"status": status, "provider": self.name, "version": self.version}
+        if extra:
+            data.update(extra)
+        return data
+
+    def _build_message(
+        self,
+        *,
+        to: str,
+        subject: str,
+        text: str,
+        html_body: str | None,
+        attachments: list[str] | None,
+        cc: list[str] | None,
+    ) -> MIMEMultipart:
+        msg = MIMEMultipart("alternative")
+        msg["From"] = self.from_email
+        msg["To"] = to
+        msg["Subject"] = subject
+        if cc:
+            msg["Cc"] = ", ".join(cc)
+
+        msg.attach(MIMEText(text, "plain", "utf-8"))
+        if html_body:
+            msg.attach(MIMEText(html_body, "html", "utf-8"))
+
+        if attachments:
+            for file_path in attachments:
+                if not os.path.exists(file_path):
+                    continue
+                with open(file_path, "rb") as f:
+                    attachment = MIMEApplication(f.read())
+                    attachment.add_header(
+                        "Content-Disposition",
+                        "attachment",
+                        filename=os.path.basename(file_path),
+                    )
+                    msg.attach(attachment)
+        return msg
+
+    async def send_message(
+        self,
+        to: str,
+        text: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if settings.is_production and not self._is_configured():
+            raise ProviderNotConfiguredError("email_provider_not_configured")
+
+        meta = metadata or {}
+        subject = str(meta.get("subject") or "Notification")
+        html_body = meta.get("html_body")
+        attachments = meta.get("attachments")
+        cc = meta.get("cc")
+        bcc = meta.get("bcc")
+        from_email = str(meta.get("from_email") or self.from_email)
+
+        if from_email and from_email != self.from_email:
+            self.from_email = from_email
+
+        msg = self._build_message(
+            to=to,
+            subject=subject,
+            text=text,
+            html_body=html_body,
+            attachments=attachments if isinstance(attachments, list) else None,
+            cc=cc if isinstance(cc, list) else None,
+        )
+
+        recipients = [to]
+        if isinstance(cc, list):
+            recipients.extend(cc)
+        if isinstance(bcc, list):
+            recipients.extend(bcc)
+
+        try:
+            if self.use_ssl:
+                with smtplib.SMTP_SSL(self.host, self.port) as server:
+                    server.login(self.user, self.password)
+                    server.send_message(msg, to_addrs=recipients)
+            else:
+                with smtplib.SMTP(self.host, self.port) as server:
+                    if self.use_tls:
+                        server.starttls()
+                    server.login(self.user, self.password)
+                    server.send_message(msg, to_addrs=recipients)
+            log.info(
+                "smtp_email_sent",
+                extra={"to": mask_email(to), "provider": self.name, "version": self.version},
+            )
+            return self._payload("ok", {"provider_status": "sent"})
+        except Exception as exc:  # pragma: no cover - network guard
+            log.warning(
+                "smtp_email_send_failed",
+                extra={"to": mask_email(to), "provider": self.name, "error": str(exc)},
+            )
+            return self._payload("error", {"provider_error": str(exc)})
+
+
+__all__ = ["SmtpMessagingProvider"]

--- a/app/main.py
+++ b/app/main.py
@@ -674,6 +674,19 @@ async def _check_provider_registry() -> dict[str, dict[str, Any]]:
                 if not provider_name or provider_name.startswith("noop"):
                     results[domain] = {"ok": False, "detail": "provider_noop"}
                     continue
+                if domain == "messaging" and provider_name in {"smtp", "email-smtp", "smtp-email"}:
+                    missing: list[str] = []
+                    if not settings.SMTP_HOST:
+                        missing.append("SMTP_HOST")
+                    if not settings.SMTP_USER:
+                        missing.append("SMTP_USER")
+                    if not settings.SMTP_PASSWORD:
+                        missing.append("SMTP_PASSWORD")
+                    if not settings.SMTP_FROM_EMAIL:
+                        missing.append("SMTP_FROM_EMAIL")
+                    if missing:
+                        results[domain] = {"ok": False, "detail": "smtp_missing_config", "missing": missing}
+                        continue
                 results[domain] = {
                     "ok": True,
                     "detail": "ok",
@@ -937,6 +950,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # type: ignore[overrid
     disable_hooks = should_disable_startup_hooks()
     if disable_hooks:
         logger.info("Startup hooks disabled (tests/CI flag)")
+    try:
+        require_providers = _env_truthy(os.getenv("STARTUP_REQUIRE_PROVIDERS", "1" if settings.is_production else "0"))
+        if settings.is_production and require_providers and not disable_hooks:
+            providers = await _check_provider_registry()
+            messaging = providers.get("messaging") if isinstance(providers, dict) else None
+            if messaging and not messaging.get("ok", False):
+                raise RuntimeError("email_provider_not_configured")
+    except Exception as e:
+        logger.error("startup provider validation failed: %s", e)
+        raise
     try:
         run_startup_side_effects(settings)
     except Exception as e:

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -4,16 +4,13 @@ Email service for sending notifications and documents.
 
 import html
 import os
-import smtplib
-from email.mime.application import MIMEApplication
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
 
 from jinja2 import Environment, FileSystemLoader
 
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.models import Company, Order
+from app.services.messaging import send_email as send_provider_email
 from app.utils.pii import mask_email
 
 logger = get_logger(__name__)
@@ -44,54 +41,22 @@ class EmailService:
         bcc: list[str] | None = None,
     ) -> bool:
         """Send email via SMTP"""
-
         try:
-            # Create message
-            msg = MIMEMultipart("alternative")
-            msg["From"] = self.from_email
-            msg["To"] = to_email
-            msg["Subject"] = subject
-
-            if cc:
-                msg["Cc"] = ", ".join(cc)
-
-            # Add text body
-            text_part = MIMEText(body, "plain", "utf-8")
-            msg.attach(text_part)
-
-            # Add HTML body if provided
-            if html_body:
-                html_part = MIMEText(html_body, "html", "utf-8")
-                msg.attach(html_part)
-
-            # Add attachments
-            if attachments:
-                for file_path in attachments:
-                    if os.path.exists(file_path):
-                        with open(file_path, "rb") as f:
-                            attachment = MIMEApplication(f.read())
-                            attachment.add_header(
-                                "Content-Disposition",
-                                "attachment",
-                                filename=os.path.basename(file_path),
-                            )
-                            msg.attach(attachment)
-
-            # Send email
-            recipients = [to_email]
-            if cc:
-                recipients.extend(cc)
-            if bcc:
-                recipients.extend(bcc)
-
-            with smtplib.SMTP(self.smtp_host, self.smtp_port) as server:
-                server.starttls()
-                server.login(self.smtp_user, self.smtp_password)
-                server.send_message(msg, to_addrs=recipients)
-
-            logger.info("Email sent successfully to %s", mask_email(to_email))
-            return True
-
+            result = await send_provider_email(
+                to=to_email,
+                subject=subject,
+                body=body,
+                html_body=html_body,
+                attachments=attachments,
+                cc=cc,
+                bcc=bcc,
+                from_email=self.from_email,
+            )
+            if result.get("success"):
+                logger.info("Email sent successfully to %s", mask_email(to_email))
+                return True
+            logger.error("Failed to send email to %s", mask_email(to_email))
+            return False
         except Exception as e:
             logger.error("Failed to send email to %s: %s", mask_email(to_email), e)
             return False

--- a/app/services/messaging.py
+++ b/app/services/messaging.py
@@ -40,20 +40,65 @@ class MessagingConfigError(RuntimeError):
     pass
 
 
-def _env() -> str:
-    return str(os.getenv("ENVIRONMENT") or getattr(settings, "ENVIRONMENT", "production") or "production").lower()
+async def _resolve_provider(db=None):
+    from app.services.messaging_providers import MessagingProviderResolver
+
+    if db is not None:
+        return await MessagingProviderResolver.resolve(db, domain="messaging")
+
+    from app.core.db import async_session_maker
+
+    async with async_session_maker() as session:
+        return await MessagingProviderResolver.resolve(session, domain="messaging")
 
 
-def _provider_name() -> str:
-    return str(getattr(settings, "EMAIL_PROVIDER", "") or os.getenv("EMAIL_PROVIDER", "")).strip()
+async def send_email(
+    *,
+    to: str,
+    subject: str,
+    body: str,
+    html_body: str | None = None,
+    attachments: list[str] | None = None,
+    cc: list[str] | None = None,
+    bcc: list[str] | None = None,
+    from_email: str | None = None,
+    meta: dict[str, Any] | None = None,
+    db=None,
+) -> dict[str, Any]:
+    """Send email via configured provider. In dev/test, noop is allowed."""
 
+    try:
+        provider = await _resolve_provider(db)
+    except Exception as exc:
+        raise MessagingConfigError("email_provider_not_configured") from exc
 
-async def send_email(*, to: str, subject: str, body: str, meta: dict[str, Any] | None = None) -> dict[str, Any]:
-    """Send email via configured provider. In dev, logs; in prod without provider, raises."""
+    metadata: dict[str, Any] = {
+        "subject": subject,
+        "html_body": html_body,
+        "attachments": attachments or [],
+        "cc": cc or [],
+        "bcc": bcc or [],
+    }
+    if from_email:
+        metadata["from_email"] = from_email
+    if meta:
+        metadata["meta"] = meta
 
-    provider = _provider_name()
-    if _env() == "production" and not provider:
-        raise MessagingConfigError("Email provider is not configured")
+    result = await provider.send_message(to=to, text=body, metadata=metadata)
+    provider_name = result.get("provider") or getattr(provider, "name", "unknown")
+    status = result.get("status")
+    success = bool(result.get("success")) or status in {"ok", "sent", "noop"}
 
-    log.info("email.send", to=mask_email(to), subject=subject, provider=provider or "noop", meta=meta or {})
-    return {"success": True, "provider": provider or "noop"}
+    log.info(
+        "email.send",
+        to=mask_email(to),
+        subject=subject,
+        provider=provider_name,
+        status=status,
+        meta=meta or {},
+    )
+    return {
+        "success": success,
+        "provider": provider_name,
+        "status": status,
+    }

--- a/app/services/messaging_providers.py
+++ b/app/services/messaging_providers.py
@@ -9,6 +9,7 @@ from app.core.provider_registry import ProviderRegistry
 from app.integrations.errors import ProviderNotConfiguredError
 from app.integrations.ports.messaging import MessagingProvider
 from app.integrations.providers.noop.messaging import NoOpMessagingProvider
+from app.integrations.providers.smtp.messaging import SmtpMessagingProvider
 from app.integrations.providers.webhook.messaging import WebhookMessagingProvider
 from app.services.provider_configs import ProviderConfigService
 
@@ -39,6 +40,9 @@ class MessagingProviderResolver:
 
         if normalized.startswith("noop"):
             return NoOpMessagingProvider(name=name, config=config, version=version)
+
+        if normalized in {"smtp", "email-smtp", "smtp-email"}:
+            return SmtpMessagingProvider(name=name, config=config, version=version)
 
         if normalized.startswith("webhook"):
             return WebhookMessagingProvider(name=name, config=config, version=version)

--- a/tests/test_prod_safety_integrations.py
+++ b/tests/test_prod_safety_integrations.py
@@ -7,7 +7,7 @@ import pytest
 
 from app import main as main_mod
 from app.core.config import settings
-from app.core.provider_registry import ProviderRegistry
+from app.core.provider_registry import CachedProvider, ProviderRegistry
 from app.services import background_tasks
 from app.services.otp_providers import OtpProviderResolver
 from app.services.payment_providers import PaymentProviderResolver
@@ -151,3 +151,24 @@ async def test_ready_fails_when_noop_providers_in_prod(async_client, monkeypatch
     assert resp.status_code == 503, resp.text
     payload = resp.json()
     assert payload.get("providers", {}).get("ok") is False
+
+
+@pytest.mark.asyncio
+async def test_ready_fails_when_smtp_missing_in_prod(async_client, monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    monkeypatch.setenv("READINESS_STRICT", "1")
+    monkeypatch.setenv("READINESS_REQUIRE_PROVIDERS", "1")
+    monkeypatch.setattr(settings, "SMTP_HOST", "", raising=False)
+    monkeypatch.setattr(settings, "SMTP_USER", "", raising=False)
+    monkeypatch.setattr(settings, "SMTP_PASSWORD", "", raising=False)
+    monkeypatch.setattr(settings, "SMTP_FROM_EMAIL", "", raising=False)
+
+    async def _smtp_provider(*_args, **_kwargs):
+        return CachedProvider(provider="smtp", config={}, version=1, cached_at=time.monotonic())
+
+    monkeypatch.setattr(ProviderRegistry, "get_active_provider", _smtp_provider)
+
+    resp = await async_client.get("/ready")
+    assert resp.status_code == 503, resp.text
+    payload = resp.json()
+    assert payload.get("providers", {}).get("details", {}).get("messaging", {}).get("detail") == "smtp_missing_config"

--- a/tests/test_provider_resolvers.py
+++ b/tests/test_provider_resolvers.py
@@ -4,10 +4,13 @@ import time
 
 import pytest
 
+from app.core.config import settings
 from app.core.provider_registry import CachedProvider, ProviderRegistry
 from app.integrations.providers.noop import NoOpMessagingProvider, NoOpPaymentGateway
+from app.integrations.providers.smtp.messaging import SmtpMessagingProvider
 from app.services.messaging_providers import MessagingProviderResolver
 from app.services.payment_providers import PaymentProviderResolver
+from app.services.provider_configs import ProviderConfigService
 
 
 @pytest.fixture(autouse=True)
@@ -60,6 +63,51 @@ async def test_messaging_provider_fallback(monkeypatch):
     provider = await MessagingProviderResolver.resolve(None, domain="messaging")
     assert isinstance(provider, NoOpMessagingProvider)
     assert provider.name == "noop"
+
+
+@pytest.mark.asyncio
+async def test_messaging_provider_noop_allowed_in_dev(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development", raising=False)
+
+    async def no_provider(db, domain):
+        return None
+
+    monkeypatch.setattr(ProviderRegistry, "get_active_provider", staticmethod(no_provider))
+
+    provider = await MessagingProviderResolver.resolve(None, domain="messaging")
+    assert isinstance(provider, NoOpMessagingProvider)
+
+
+@pytest.mark.asyncio
+async def test_messaging_provider_smtp_resolution(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development", raising=False)
+    smtp_config = {
+        "host": "smtp.example.com",
+        "port": 587,
+        "user": "user",
+        "password": "pass",
+        "from_email": "noreply@example.com",
+        "tls": True,
+    }
+
+    async def fake_get_active(db, domain):
+        return CachedProvider(
+            provider="smtp",
+            config=smtp_config,
+            version=1,
+            cached_at=time.monotonic(),
+        )
+
+    monkeypatch.setattr(ProviderRegistry, "get_active_provider", staticmethod(fake_get_active))
+
+    async def fake_get_config(*_args, **_kwargs):
+        return smtp_config
+
+    monkeypatch.setattr(ProviderConfigService, "get_provider_config", staticmethod(fake_get_config))
+
+    provider = await MessagingProviderResolver.resolve(None, domain="messaging")
+    assert isinstance(provider, SmtpMessagingProvider)
+    assert provider.host == "smtp.example.com"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add SMTP messaging provider and wire resolver to support smtp.
- Route email sending through provider registry; noop allowed only in dev/test.
- Add readiness/startup guards and tests for SMTP config.

## Testing
- python -m ruff check --fix app tests tools
- python -m ruff format app tests tools
- pytest -q