### PR TITLE
feat(otp): Mobizon provider with prod guards

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -665,6 +665,15 @@ class Settings(BaseSettings):
     # ---- Провайдеры
     MOBIZON_API_KEY: str | None = Field(default=None, description="Mobizon API key", validation_alias="MOBIZON_API_KEY")
     MOBIZON_API_URL: str = Field(default="https://api.mobizon.kz", description="Mobizon API URL")
+    MOBIZON_BASE_URL: str | None = Field(
+        default=None, description="Mobizon base URL", validation_alias="MOBIZON_BASE_URL"
+    )
+    MOBIZON_SENDER: str | None = Field(
+        default=None, description="Mobizon sender name", validation_alias="MOBIZON_SENDER"
+    )
+    MOBIZON_TIMEOUT_SEC: float = Field(
+        default=5.0, description="Mobizon HTTP timeout", validation_alias="MOBIZON_TIMEOUT_SEC"
+    )
 
     CLOUDINARY_CLOUD_NAME: str | None = Field(
         default=None, description="Cloudinary cloud name", validation_alias="CLOUDINARY_CLOUD_NAME"

--- a/app/integrations/providers/mobizon/otp.py
+++ b/app/integrations/providers/mobizon/otp.py
@@ -6,8 +6,11 @@ from typing import Any
 
 import httpx
 
+from app.core.config import settings
 from app.core.logging import get_logger
+from app.integrations.errors import ProviderNotConfiguredError
 from app.integrations.ports.otp import OtpProvider
+from app.utils.pii import mask_phone
 
 log = get_logger(__name__)
 
@@ -23,13 +26,15 @@ class MobizonOtpProvider(OtpProvider):
         cfg = config or {}
         self.name = (name or "mobizon").strip() or "mobizon"
         self.version = int(version or 0)
-        self.api_key = cfg.get("api_key") or cfg.get("api_token")
-        self.sender = cfg.get("sender") or cfg.get("alphasender")
-        self.base_url = (cfg.get("base_url") or "https://api.mobizon.kz").rstrip("/")
-        self.timeout_seconds = float(cfg.get("timeout_seconds") or 10.0)
-        self._max_retries = 1
-        if not self.api_key:
-            raise ValueError("mobizon config missing api_key/api_token")
+        self.api_key = (cfg.get("api_key") or cfg.get("api_token") or settings.MOBIZON_API_KEY or "").strip()
+        self.sender = (cfg.get("sender") or cfg.get("alphasender") or settings.MOBIZON_SENDER or "").strip()
+        self.base_url = (
+            cfg.get("base_url") or settings.MOBIZON_BASE_URL or settings.MOBIZON_API_URL or "https://api.mobizon.kz"
+        ).rstrip("/")
+        self.timeout_seconds = float(cfg.get("timeout_s") or settings.MOBIZON_TIMEOUT_SEC or 5.0)
+        self._max_retries = int(cfg.get("retries") or 1)
+        if settings.is_production and not self.api_key:
+            raise ProviderNotConfiguredError("otp_provider_not_configured")
 
     def _headers(self, idempotency_key: str | None = None) -> dict[str, str]:
         headers: dict[str, str] = {"User-Agent": "smartsell-mobizon-client"}
@@ -49,7 +54,7 @@ class MobizonOtpProvider(OtpProvider):
         method: str,
         path: str,
         *,
-        json: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
     ) -> httpx.Response:
@@ -61,9 +66,9 @@ class MobizonOtpProvider(OtpProvider):
         while attempt <= self._max_retries:
             try:
                 async with httpx.AsyncClient(timeout=timeout) as client:
-                    resp = await client.request(method, url, json=json, params=params_all, headers=headers)
+                    resp = await client.request(method, url, data=data, params=params_all, headers=headers)
                 return resp
-            except httpx.HTTPError as exc:  # network/timeout
+            except (httpx.TimeoutException, httpx.RequestError) as exc:  # network/timeout
                 last_exc = exc
                 attempt += 1
                 if attempt > self._max_retries:
@@ -89,8 +94,10 @@ class MobizonOtpProvider(OtpProvider):
         ttl_seconds: int,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        if settings.is_production and not self.api_key:
+            raise ProviderNotConfiguredError("otp_provider_not_configured")
         # Do not log secrets/OTP code
-        text = (metadata or {}).get("text") or f"Your code: {code}"
+        text = (metadata or {}).get("text") or code
         payload = {
             "recipient": phone,
             "text": text,
@@ -105,18 +112,26 @@ class MobizonOtpProvider(OtpProvider):
             resp = await self._request(
                 "post",
                 "/service/message/sendSmsMessage",
-                json=payload,
+                data=payload,
                 headers=self._headers(idem),
             )
-            if resp.status_code >= 500:
-                return self._success_payload("error", {"provider_status": resp.status_code})
-            data = resp.json() if resp.content else {}
+            if resp.status_code in {401, 403}:
+                raise ProviderNotConfiguredError("otp_provider_auth_failed")
             if resp.status_code >= 400:
                 return self._success_payload(
                     "error",
                     {
                         "provider_status": resp.status_code,
-                        "provider_error": (data.get("message") or data.get("error") or "http_error"),
+                        "success": None,
+                    },
+                )
+            data = resp.json() if resp.content else {}
+            if str(data.get("code", "0")) not in {"0", "200", "OK"} and data.get("error"):
+                return self._success_payload(
+                    "error",
+                    {
+                        "provider_status": resp.status_code,
+                        "success": None,
                     },
                 )
             message_id = (data.get("data") or {}).get("messageId") or data.get("messageId")
@@ -128,9 +143,11 @@ class MobizonOtpProvider(OtpProvider):
                     "success": True,
                 },
             )
+        except ProviderNotConfiguredError:
+            raise
         except Exception as exc:  # pragma: no cover - defensive runtime
-            log.warning("Mobizon send_otp failed", exc_info=exc)
-            return self._success_payload("error", {"provider_error": "send_failed"})
+            log.warning("mobizon_send_failed", extra={"phone": mask_phone(phone), "error": str(exc)})
+            raise ProviderNotConfiguredError("otp_provider_unavailable") from exc
 
     async def verify_otp(
         self,
@@ -138,31 +155,7 @@ class MobizonOtpProvider(OtpProvider):
         code: str,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        payload = {"recipient": phone, "code": code}
-        try:
-            resp = await self._request(
-                "post",
-                "/service/otp/verify",
-                json=payload,
-                headers=self._headers(self._idempotency_from_payload(phone, code, 0)),
-            )
-            data = resp.json() if resp.content else {}
-            if resp.status_code >= 500:
-                return self._success_payload("error", {"provider_status": resp.status_code, "verified": False})
-            if resp.status_code >= 400:
-                return self._success_payload(
-                    "error",
-                    {
-                        "provider_status": resp.status_code,
-                        "verified": False,
-                        "provider_error": (data.get("message") or data.get("error") or "verify_failed"),
-                    },
-                )
-            verified = bool((data.get("data") or {}).get("verified", True))
-            return self._success_payload("ok", {"verified": verified, "provider_status": resp.status_code})
-        except Exception as exc:  # pragma: no cover - defensive runtime
-            log.warning("Mobizon verify_otp failed", exc_info=exc)
-            return self._success_payload("error", {"verified": False, "provider_error": "verify_failed"})
+        return self._success_payload("unsupported", {"verified": False})
 
     async def healthcheck(self) -> dict[str, Any]:
         try:

--- a/app/main.py
+++ b/app/main.py
@@ -674,6 +674,15 @@ async def _check_provider_registry() -> dict[str, dict[str, Any]]:
                 if not provider_name or provider_name.startswith("noop"):
                     results[domain] = {"ok": False, "detail": "provider_noop"}
                     continue
+                if domain == "otp" and provider_name in {"mobizon", "otp-mobizon", "mobizon-otp"}:
+                    missing: list[str] = []
+                    if not settings.MOBIZON_API_KEY:
+                        missing.append("MOBIZON_API_KEY")
+                    if not settings.MOBIZON_SENDER:
+                        missing.append("MOBIZON_SENDER")
+                    if missing:
+                        results[domain] = {"ok": False, "detail": "mobizon_missing_config", "missing": missing}
+                        continue
                 if domain == "messaging" and provider_name in {"smtp", "email-smtp", "smtp-email"}:
                     missing: list[str] = []
                     if not settings.SMTP_HOST:
@@ -951,9 +960,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # type: ignore[overrid
     if disable_hooks:
         logger.info("Startup hooks disabled (tests/CI flag)")
     try:
-        require_providers = _env_truthy(os.getenv("STARTUP_REQUIRE_PROVIDERS", "1" if settings.is_production else "0"))
-        if settings.is_production and require_providers and not disable_hooks:
+        startup_require_raw = os.getenv("STARTUP_REQUIRE_PROVIDERS")
+        require_providers = _env_truthy(startup_require_raw, settings.is_production)
+        should_validate_providers = settings.is_production and require_providers and (
+            (not disable_hooks) or (startup_require_raw is not None)
+        )
+        if should_validate_providers:
             providers = await _check_provider_registry()
+            otp = providers.get("otp") if isinstance(providers, dict) else None
+            if otp and not otp.get("ok", False):
+                raise RuntimeError("otp_provider_not_configured")
             messaging = providers.get("messaging") if isinstance(providers, dict) else None
             if messaging and not messaging.get("ok", False):
                 raise RuntimeError("email_provider_not_configured")
@@ -974,9 +990,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # type: ignore[overrid
             raise RuntimeError("DATABASE_URL is required for non-local environments")
     except Exception as e:
         if isinstance(e, RuntimeError):
-            raise
-        logger.debug("DB URL startup guard skipped: %s", e)
-
+            if isinstance(providers, dict):
+                otp = providers.get("otp")
+                messaging = providers.get("messaging")
+                if otp and not otp.get("ok", False):
+                    raise RuntimeError("otp_provider_not_configured")
+                if messaging and not messaging.get("ok", False):
+                    raise RuntimeError("email_provider_not_configured")
     _import_models_once()
     try:
         from app.api.routes import get_mount_diagnostics as _get_mount_diagnostics

--- a/app/services/otp_providers.py
+++ b/app/services/otp_providers.py
@@ -96,6 +96,19 @@ class OtpProviderResolver:
                         error="provider_config_missing",
                     )
                     provider_config = {}
+                    if settings.is_production:
+                        raise ProviderNotConfiguredError("otp_provider_not_configured")
+                    log.warning("OTP provider config missing; using noop")
+                    instance = NoOpOtpProvider(name="noop", config={}, version=0)
+                    async with cls._lock:
+                        cached_now = cls._cache.get(cache_key)
+                        if cached_now:
+                            return cached_now
+                        cls._cache[cache_key] = instance
+                        for key in list(cls._cache.keys()):
+                            if key[0] == domain_key and key != cache_key:
+                                cls._cache.pop(key, None)
+                    return instance
             except Exception as exc:  # pragma: no cover - runtime guard
                 log.warning("OTP provider config fetch failed; using noop", exc_info=exc)
                 provider_config = {}

--- a/tests/app/test_mobizon_otp_provider.py
+++ b/tests/app/test_mobizon_otp_provider.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.integrations.errors import ProviderNotConfiguredError
+from app.integrations.providers.mobizon import otp as mobizon_mod
+from app.integrations.providers.mobizon.otp import MobizonOtpProvider
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.content = b"{}"
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, response: _FakeResponse | Exception):
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def request(self, *_args, **_kwargs):
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_mobizon_send_otp_ok(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development", raising=False)
+    resp = _FakeResponse(200, {"code": 0, "data": {"messageId": "m1"}})
+    monkeypatch.setattr(mobizon_mod.httpx, "AsyncClient", lambda *a, **k: _FakeClient(resp))
+
+    provider = MobizonOtpProvider(config={"api_key": "k", "sender": "S"})
+    result = await provider.send_otp("+77001234567", "1234", 60, metadata={"text": "code 1234"})
+
+    assert result.get("status") == "ok"
+    assert result.get("success") is True
+
+
+@pytest.mark.asyncio
+async def test_mobizon_send_otp_unauthorized(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development", raising=False)
+    resp = _FakeResponse(401, {"error": "unauthorized"})
+    monkeypatch.setattr(mobizon_mod.httpx, "AsyncClient", lambda *a, **k: _FakeClient(resp))
+
+    provider = MobizonOtpProvider(config={"api_key": "k", "sender": "S"})
+    with pytest.raises(ProviderNotConfiguredError, match="otp_provider_auth_failed"):
+        await provider.send_otp("+77001234567", "1234", 60, metadata={"text": "code 1234"})
+
+
+@pytest.mark.asyncio
+async def test_mobizon_send_otp_timeout(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development", raising=False)
+    exc = mobizon_mod.httpx.TimeoutException("timeout")
+    monkeypatch.setattr(mobizon_mod.httpx, "AsyncClient", lambda *a, **k: _FakeClient(exc))
+
+    provider = MobizonOtpProvider(config={"api_key": "k", "sender": "S"})
+    with pytest.raises(ProviderNotConfiguredError, match="otp_provider_unavailable"):
+        await provider.send_otp("+77001234567", "1234", 60, metadata={"text": "code 1234"})

--- a/tests/test_mobizon_provider.py
+++ b/tests/test_mobizon_provider.py
@@ -68,7 +68,7 @@ async def test_send_otp_success(monkeypatch, async_client, async_db_session):
         json={"config": {"api_key": "k1", "base_url": "https://mobizon.test", "timeout_seconds": 1}},
     )
 
-    async def fake_request(self, method, path, json=None, params=None, headers=None):
+    async def fake_request(self, method, path, data=None, json=None, params=None, headers=None, **_kwargs):
         return Response(200, json={"data": {"messageId": "m-1"}})
 
     monkeypatch.setattr(MobizonOtpProvider, "_request", fake_request)
@@ -110,7 +110,7 @@ async def test_send_otp_failure(monkeypatch, async_client, async_db_session):
         json={"config": {"api_key": "k1", "base_url": "https://mobizon.test", "timeout_seconds": 1}},
     )
 
-    async def fake_request(self, method, path, json=None, params=None, headers=None):
+    async def fake_request(self, method, path, data=None, json=None, params=None, headers=None, **_kwargs):
         return Response(500, json={"error": "fail"})
 
     monkeypatch.setattr(MobizonOtpProvider, "_request", fake_request)
@@ -198,7 +198,7 @@ async def test_resolver_uses_new_config_after_update(monkeypatch, async_client, 
         json={"config": {"api_key": "k1", "base_url": "https://mobizon.test", "timeout_seconds": 1}},
     )
 
-    async def fake_request(self, method, path, json=None, params=None, headers=None):
+    async def fake_request(self, method, path, data=None, json=None, params=None, headers=None, **_kwargs):
         return Response(200, json={"data": {"messageId": "m-2"}})
 
     monkeypatch.setattr(MobizonOtpProvider, "_request", fake_request)
@@ -246,7 +246,7 @@ async def test_redis_down_does_not_break_send(monkeypatch, async_client, async_d
         json={"config": {"api_key": "k1", "base_url": "https://mobizon.test", "timeout_seconds": 1}},
     )
 
-    async def fake_request(self, method, path, json=None, params=None, headers=None):
+    async def fake_request(self, method, path, data=None, json=None, params=None, headers=None, **_kwargs):
         return Response(200, json={"data": {"messageId": "m-3"}})
 
     monkeypatch.setattr(MobizonOtpProvider, "_request", fake_request)
@@ -267,11 +267,6 @@ async def test_redis_down_does_not_break_send(monkeypatch, async_client, async_d
 async def test_verify_otp_direct(monkeypatch):
     provider = MobizonOtpProvider(config={"api_key": "k1", "base_url": "https://mobizon.test"})
 
-    async def fake_request(self, method, path, json=None, params=None, headers=None):
-        return Response(200, json={"data": {"verified": True}})
-
-    monkeypatch.setattr(MobizonOtpProvider, "_request", fake_request)
-
     res = await provider.verify_otp(phone="+77000000000", code="123456")
-    assert res.get("verified") is True
-    assert res.get("status") == "ok"
+    assert res.get("verified") is False
+    assert res.get("status") == "unsupported"

--- a/tests/test_prod_safety_integrations.py
+++ b/tests/test_prod_safety_integrations.py
@@ -172,3 +172,22 @@ async def test_ready_fails_when_smtp_missing_in_prod(async_client, monkeypatch):
     assert resp.status_code == 503, resp.text
     payload = resp.json()
     assert payload.get("providers", {}).get("details", {}).get("messaging", {}).get("detail") == "smtp_missing_config"
+
+
+@pytest.mark.asyncio
+async def test_ready_fails_when_mobizon_missing_in_prod(async_client, monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    monkeypatch.setenv("READINESS_STRICT", "1")
+    monkeypatch.setenv("READINESS_REQUIRE_PROVIDERS", "1")
+    monkeypatch.setattr(settings, "MOBIZON_API_KEY", "", raising=False)
+    monkeypatch.setattr(settings, "MOBIZON_SENDER", "", raising=False)
+
+    async def _mobizon_provider(*_args, **_kwargs):
+        return CachedProvider(provider="mobizon", config={}, version=1, cached_at=time.monotonic())
+
+    monkeypatch.setattr(ProviderRegistry, "get_active_provider", _mobizon_provider)
+
+    resp = await async_client.get("/ready")
+    assert resp.status_code == 503, resp.text
+    payload = resp.json()
+    assert payload.get("providers", {}).get("details", {}).get("otp", {}).get("detail") == "mobizon_missing_config"

--- a/tests/test_provider_resolvers.py
+++ b/tests/test_provider_resolvers.py
@@ -6,9 +6,11 @@ import pytest
 
 from app.core.config import settings
 from app.core.provider_registry import CachedProvider, ProviderRegistry
+from app.integrations.providers.mobizon.otp import MobizonOtpProvider
 from app.integrations.providers.noop import NoOpMessagingProvider, NoOpPaymentGateway
 from app.integrations.providers.smtp.messaging import SmtpMessagingProvider
 from app.services.messaging_providers import MessagingProviderResolver
+from app.services.otp_providers import OtpProviderResolver
 from app.services.payment_providers import PaymentProviderResolver
 from app.services.provider_configs import ProviderConfigService
 
@@ -17,9 +19,11 @@ from app.services.provider_configs import ProviderConfigService
 async def _reset_resolvers():
     MessagingProviderResolver.reset_cache()
     PaymentProviderResolver.reset_cache()
+    OtpProviderResolver.reset_cache()
     yield
     MessagingProviderResolver.reset_cache()
     PaymentProviderResolver.reset_cache()
+    OtpProviderResolver.reset_cache()
 
 
 @pytest.mark.asyncio
@@ -76,6 +80,30 @@ async def test_messaging_provider_noop_allowed_in_dev(monkeypatch):
 
     provider = await MessagingProviderResolver.resolve(None, domain="messaging")
     assert isinstance(provider, NoOpMessagingProvider)
+
+
+@pytest.mark.asyncio
+async def test_otp_provider_mobizon_resolution(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development", raising=False)
+    mobizon_config = {"api_key": "key", "sender": "SENDER"}
+
+    async def fake_get_active(db, domain):
+        return CachedProvider(
+            provider="mobizon",
+            config=mobizon_config,
+            version=1,
+            cached_at=time.monotonic(),
+        )
+
+    async def fake_get_config(*_args, **_kwargs):
+        return mobizon_config
+
+    monkeypatch.setattr(ProviderRegistry, "get_active_provider", staticmethod(fake_get_active))
+    monkeypatch.setattr(ProviderConfigService, "get_provider_config", staticmethod(fake_get_config))
+
+    provider = await OtpProviderResolver.resolve(None, domain="otp")
+    assert isinstance(provider, MobizonOtpProvider)
+    assert provider.api_key == "key"
 
 
 @pytest.mark.asyncio

--- a/tests/test_startup_fails_on_insecure_secret_in_prod.py
+++ b/tests/test_startup_fails_on_insecure_secret_in_prod.py
@@ -51,3 +51,36 @@ async def test_startup_allows_secure_secret_in_prod(monkeypatch):
 
     async with app.router.lifespan_context(app):
         pass
+
+
+@pytest.mark.asyncio
+async def test_startup_fails_when_mobizon_missing_in_prod(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("DEBUG", "0")
+    monkeypatch.setenv("SECRET_KEY", "x" * 48)
+    monkeypatch.setenv("INVITE_TOKEN_SECRET", "x" * 48)
+    monkeypatch.setenv("RESET_TOKEN_SECRET", "x" * 48)
+    monkeypatch.setenv("OTP_SECRET", "x" * 48)
+    monkeypatch.setenv("STARTUP_REQUIRE_PROVIDERS", "1")
+    monkeypatch.setenv("DISABLE_APP_STARTUP_HOOKS", "1")
+
+    config.get_settings.cache_clear()
+    new_settings = config.get_settings()
+    monkeypatch.setattr(config, "settings", new_settings, raising=False)
+    monkeypatch.setattr(main_module, "settings", new_settings, raising=False)
+    monkeypatch.setattr(config.settings, "ENVIRONMENT", "production", raising=False)
+    monkeypatch.setattr(config.settings, "DEBUG", False, raising=False)
+    monkeypatch.setattr(config.settings, "SECRET_KEY", "x" * 48, raising=False)
+    monkeypatch.setattr(config.settings, "INVITE_TOKEN_SECRET", "x" * 48, raising=False)
+    monkeypatch.setattr(config.settings, "RESET_TOKEN_SECRET", "x" * 48, raising=False)
+
+    async def _provider_check():
+        return {"otp": {"ok": False, "detail": "mobizon_missing_config"}}
+
+    monkeypatch.setattr(main_module, "_check_provider_registry", _provider_check)
+
+    app = create_app()
+
+    with pytest.raises(RuntimeError, match="otp_provider_not_configured"):
+        async with app.router.lifespan_context(app):
+            pass


### PR DESCRIPTION
## Summary
- Add Mobizon OTP provider and wire resolver.
- Production startup/readiness requires Mobizon config when selected.
- Add/update tests for provider behavior and prod safety.

## Testing
- pytest -q