### PR TITLE
feat: manual wallet topups and subscription billing

### DIFF
--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
 
 import sqlalchemy as sa
 from fastapi import APIRouter, Depends, Query
@@ -8,8 +11,11 @@ from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_async_db
+from app.core.dependencies import require_platform_admin
 from app.core.exceptions import AuthorizationError, NotFoundError
+from app.core.logging import audit_logger
 from app.core.security import get_current_user, resolve_tenant_company_id
+from app.models.billing import WalletBalance, WalletTransaction
 from app.models.company import Company
 from app.models.subscription_override import SubscriptionOverride
 from app.models.user import User
@@ -37,6 +43,23 @@ class SubscriptionOverrideOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class WalletTopupIn(BaseModel):
+    companyId: int = Field(..., ge=1)
+    amount: Decimal = Field(..., gt=0)
+    currency: str = Field(..., min_length=3, max_length=8)
+    external_reference: str | None = Field(default=None, max_length=128)
+    comment: str | None = Field(default=None, max_length=500)
+
+
+class WalletTopupOut(BaseModel):
+    company_id: int
+    wallet_id: int
+    transaction_id: int
+    currency: str
+    balance: str
+    amount: str
+
+
 def _utc_now() -> datetime:
     return datetime.now(UTC)
 
@@ -60,6 +83,78 @@ async def _resolve_company(
     company = await db.get(Company, resolved_id)
     _require_owner_or_superuser(current_user=current_user, company=company)
     return company
+
+
+@router.post(
+    "/wallet/topup",
+    response_model=WalletTopupOut,
+    summary="Manual company wallet top-up (platform admin)",
+)
+async def manual_wallet_topup(
+    payload: WalletTopupIn,
+    admin: Any = Depends(require_platform_admin),
+    db: AsyncSession = Depends(get_async_db),
+) -> WalletTopupOut:
+    _ = admin
+    company = await db.get(Company, payload.companyId)
+    if not company:
+        raise NotFoundError("company_not_found", code="company_not_found", http_status=404)
+
+    wallet = await WalletBalance.get_for_company_async(
+        db,
+        payload.companyId,
+        create_if_missing=True,
+        currency=payload.currency,
+    )
+    if (wallet.currency or "").upper() != payload.currency.upper():
+        raise AuthorizationError("wallet_currency_mismatch", code="wallet_currency_mismatch", http_status=400)
+
+    amount = Decimal(str(payload.amount))
+    before = wallet.balance or Decimal("0")
+    after = before + amount
+    wallet.balance = after
+    trx = WalletTransaction(
+        wallet_id=wallet.id,
+        transaction_type="manual_topup",
+        amount=amount,
+        balance_before=before,
+        balance_after=after,
+        description=payload.comment or "manual_topup",
+        reference_type="manual_topup",
+        client_request_id=payload.external_reference,
+        extra_data=json.dumps(
+            {
+                "external_reference": payload.external_reference,
+                "comment": payload.comment,
+            },
+            ensure_ascii=False,
+        ),
+    )
+    db.add(trx)
+    await db.flush()
+    await db.commit()
+
+    audit_logger.log_system_event(
+        level="info",
+        event="wallet_manual_topup",
+        message="Wallet credited manually",
+        meta={
+            "company_id": payload.companyId,
+            "wallet_id": wallet.id,
+            "amount": str(amount),
+            "currency": payload.currency,
+            "transaction_id": trx.id,
+        },
+    )
+
+    return WalletTopupOut(
+        company_id=payload.companyId,
+        wallet_id=wallet.id,
+        transaction_id=trx.id,
+        currency=wallet.currency,
+        balance=str(wallet.balance),
+        amount=str(amount),
+    )
 
 
 @router.get(

--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -442,10 +442,11 @@ async def require_active_subscription(
     if current_user is None:
         return None
 
-    from app.core.security import is_superuser, resolve_tenant_company_id  # type: ignore
+    from app.core.security import resolve_tenant_company_id  # type: ignore
     from app.services.subscriptions import get_company_subscription, is_subscription_active  # type: ignore
 
-    if is_superuser(current_user):
+    role = (getattr(current_user, "role", "") or "").lower()
+    if getattr(current_user, "is_superuser", False) or role in {"platform_admin", "superadmin"}:
         return current_user
 
     company_id = resolve_tenant_company_id(current_user, not_found_detail="Company not set")

--- a/app/core/subscriptions/features.py
+++ b/app/core/subscriptions/features.py
@@ -4,17 +4,14 @@ from collections.abc import Iterable
 from typing import Any
 
 from fastapi import Depends, Request
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_async_db
 from app.core.exceptions import AuthorizationError
 from app.core.logging import get_logger
-from app.core.security import get_current_user, is_superuser, resolve_tenant_company_id
+from app.core.security import get_current_user, resolve_tenant_company_id
 from app.core.subscriptions.plan_catalog import get_plan_features as _catalog_plan_features
 from app.core.subscriptions.plan_catalog import normalize_plan_id
-from app.models.company import Company
-from app.services.subscription_overrides import is_subscription_override_active
 from app.services.subscriptions import get_company_subscription, is_subscription_active
 
 logger = get_logger(__name__)
@@ -30,10 +27,12 @@ async def _resolve_plan(db: AsyncSession, company_id: int) -> str:
     subscription = await get_company_subscription(db, company_id)
     if subscription and is_subscription_active(subscription):
         return normalize_plan_id(getattr(subscription, "plan", None)) or "start"
-
-    res = await db.execute(select(Company.subscription_plan).where(Company.id == company_id))
-    plan = res.scalar_one_or_none()
-    return normalize_plan_id(plan) or "start"
+    raise AuthorizationError(
+        "subscription_required",
+        code="subscription_required",
+        http_status=402,
+        extra={"company_id": company_id},
+    )
 
 
 def _has_feature(plan: str, feature: str) -> bool:
@@ -70,24 +69,12 @@ def require_feature(feature: str) -> Any:
         current_user=Depends(get_current_user),  # noqa: B008
         db: AsyncSession = Depends(get_async_db),  # noqa: B008
     ) -> Any:
-        if is_superuser(current_user):
+        role = (getattr(current_user, "role", "") or "").lower()
+        if getattr(current_user, "is_superuser", False) or role in {"platform_admin", "superadmin"}:
             return current_user
         company_id = resolve_tenant_company_id(current_user, not_found_detail="Company not set")
         plan = await _resolve_plan(db, company_id)
         if not _has_feature(plan, feature):
-            if feature.startswith("kaspi."):
-                merchant_uid = await _extract_merchant_uid(request)
-                if merchant_uid:
-                    if await is_subscription_override_active(db, company_id, "kaspi", merchant_uid):
-                        logger.info(
-                            "Feature override allowed",
-                            extra={
-                                "feature": feature,
-                                "company_id": company_id,
-                                "merchant_uid": merchant_uid,
-                            },
-                        )
-                        return current_user
             logger.info("Feature blocked", extra={"feature": feature, "plan": plan, "company_id": company_id})
             raise AuthorizationError(
                 "subscription_required",

--- a/app/main.py
+++ b/app/main.py
@@ -962,8 +962,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # type: ignore[overrid
     try:
         startup_require_raw = os.getenv("STARTUP_REQUIRE_PROVIDERS")
         require_providers = _env_truthy(startup_require_raw, settings.is_production)
-        should_validate_providers = settings.is_production and require_providers and (
-            (not disable_hooks) or (startup_require_raw is not None)
+        should_validate_providers = (
+            settings.is_production and require_providers and ((not disable_hooks) or (startup_require_raw is not None))
         )
         if should_validate_providers:
             providers = await _check_provider_registry()

--- a/app/models/billing.py
+++ b/app/models/billing.py
@@ -1296,7 +1296,7 @@ class WalletBalance(BaseModel, SoftDeleteMixin):
             reference_type=reference_type,
             reference_id=reference_id,
         )
-        self.transactions.append(trx)
+        session.add(trx)
         await session.flush()
         return trx
 
@@ -1373,7 +1373,7 @@ class WalletBalance(BaseModel, SoftDeleteMixin):
             reference_type=reference_type,
             reference_id=reference_id,
         )
-        self.transactions.append(trx)
+        session.add(trx)
         await session.flush()
         return trx
 
@@ -1472,7 +1472,7 @@ class WalletBalance(BaseModel, SoftDeleteMixin):
                         reference_type=reference_type,
                         reference_id=reference_id,
                     )
-                    self.transactions.append(trx)
+                    session.add(trx)
                     await session.flush()
                     return trx
             except Exception as e:
@@ -1875,7 +1875,7 @@ class WalletBalance(BaseModel, SoftDeleteMixin):
                             reference_type="settle",
                             reference_id=None,
                         )
-                        self.transactions.append(trx)
+                        session.add(trx)
                         await session.flush()
 
                     if missing > 0:
@@ -2057,7 +2057,7 @@ class WalletTransaction(BaseModel, SoftDeleteMixin):
 
     @validates("transaction_type")
     def _validate_type(self, _k: str, v: str) -> str:
-        allowed = {"credit", "debit", "adjustment"}
+        allowed = {"credit", "debit", "adjustment", "manual_topup"}
         vv = (v or "").strip().lower()
         if vv not in allowed:
             raise ValueError(f"Invalid transaction_type: {vv}")

--- a/app/services/provider_configs.py
+++ b/app/services/provider_configs.py
@@ -219,7 +219,13 @@ class ProviderConfigService:
                         from app.integrations.providers.noop.payments import NoOpPaymentGateway
 
                         provider_inst = NoOpPaymentGateway(config=cfg, name=provider, version=0)
-                    elif provider.lower() in {"placeholder", "payment-placeholder", "payments-placeholder", "stub", "dummy"}:
+                    elif provider.lower() in {
+                        "placeholder",
+                        "payment-placeholder",
+                        "payments-placeholder",
+                        "stub",
+                        "dummy",
+                    }:
                         from app.integrations.providers.placeholder.payments import PlaceholderPaymentGateway
 
                         provider_inst = PlaceholderPaymentGateway(config=cfg, name=provider, version=0)

--- a/app/services/subscriptions.py
+++ b/app/services/subscriptions.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from calendar import monthrange
 from datetime import UTC, datetime
+from decimal import Decimal
 
 from sqlalchemy import desc, nullslast, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.billing import Subscription
+from app.core.logging import audit_logger
+from app.core.subscriptions.plan_catalog import get_plan, normalize_plan_id
+from app.models.billing import Subscription, WalletBalance
 
 _SUB_ACTIVE = {"active", "trialing"}
 _SUB_INACTIVE = {"canceled", "frozen", "past_due"}
@@ -67,4 +71,143 @@ async def get_company_subscription(db: AsyncSession, company_id: int) -> Subscri
     return res.scalar_one_or_none()
 
 
-__all__ = ["get_company_subscription", "is_subscription_active"]
+def _add_months_anniversary(dt: datetime, months: int = 1) -> datetime:
+    if months == 0:
+        return dt
+    year = dt.year + (dt.month - 1 + months) // 12
+    month = (dt.month - 1 + months) % 12 + 1
+    last_day = monthrange(year, month)[1]
+    day = min(dt.day, last_day)
+    return dt.replace(year=year, month=month, day=day)
+
+
+async def activate_plan(
+    db: AsyncSession,
+    *,
+    company_id: int,
+    plan_code: str,
+    now: datetime | None = None,
+) -> Subscription:
+    now = now or datetime.now(UTC)
+    plan_id = normalize_plan_id(plan_code, default=None)
+    plan = get_plan(plan_id, default=None)
+    if not plan_id or plan is None:
+        raise ValueError("plan_not_found")
+
+    wallet = await WalletBalance.get_for_company_async(db, company_id, create_if_missing=True, currency=plan.currency)
+    if wallet.currency != plan.currency:
+        raise ValueError("wallet_currency_mismatch")
+
+    sub = await get_company_subscription(db, company_id)
+    if sub is None:
+        sub = Subscription(
+            company_id=company_id,
+            plan=plan_id,
+            status="active",
+            billing_cycle="monthly",
+            price=plan.price,
+            currency=plan.currency,
+            started_at=now,
+        )
+        db.add(sub)
+        await db.flush()
+    else:
+        sub.plan = plan_id
+        sub.status = "active"
+        sub.billing_cycle = "monthly"
+        sub.price = plan.price
+        sub.currency = plan.currency
+        if not sub.started_at:
+            sub.started_at = now
+
+    if plan.price > Decimal("0"):
+        if (wallet.balance or Decimal("0")) < plan.price:
+            raise ValueError("insufficient_wallet_balance")
+        await wallet.debit_safe_async(
+            db,
+            plan.price,
+            description="subscription_charge",
+            reference_type="subscription",
+            reference_id=sub.id,
+        )
+
+    sub.period_start = now
+    sub.period_end = _add_months_anniversary(now, 1)
+    sub.next_billing_date = sub.period_end
+
+    audit_logger.log_system_event(
+        level="info",
+        event="subscription_activated",
+        message="Subscription activated",
+        meta={
+            "company_id": company_id,
+            "plan": plan_id,
+            "price": str(plan.price),
+            "currency": plan.currency,
+        },
+    )
+
+    await db.flush()
+    return sub
+
+
+async def renew_if_due(db: AsyncSession, *, now: datetime | None = None) -> int:
+    now = now or datetime.now(UTC)
+    stmt = (
+        select(Subscription)
+        .where(Subscription.deleted_at.is_(None))
+        .where(Subscription.period_end.isnot(None))
+        .where(Subscription.period_end <= now)
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+    processed = 0
+    for sub in rows:
+        plan_id = normalize_plan_id(sub.plan, default=None)
+        plan = get_plan(plan_id, default=None)
+        if not plan_id or plan is None:
+            sub.status = "past_due"
+            processed += 1
+            continue
+
+        try:
+            wallet = await WalletBalance.get_for_company_async(
+                db, sub.company_id, create_if_missing=False, currency=plan.currency
+            )
+        except Exception:
+            sub.status = "past_due"
+            processed += 1
+            continue
+        if wallet.currency != plan.currency:
+            sub.status = "past_due"
+            processed += 1
+            continue
+
+        if plan.price > Decimal("0"):
+            if (wallet.balance or Decimal("0")) < plan.price:
+                sub.status = "past_due"
+                processed += 1
+                continue
+            await wallet.debit_safe_async(
+                db,
+                plan.price,
+                description="subscription_renewal",
+                reference_type="subscription",
+                reference_id=sub.id,
+            )
+
+        sub.status = "active"
+        anchor = sub.period_end or now
+        sub.period_start = anchor
+        sub.period_end = _add_months_anniversary(anchor, 1)
+        sub.next_billing_date = sub.period_end
+        processed += 1
+
+    return processed
+
+
+__all__ = [
+    "get_company_subscription",
+    "is_subscription_active",
+    "activate_plan",
+    "renew_if_due",
+]

--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -14,6 +14,7 @@ from app.core.logging import get_logger
 from app.core.subscriptions.plan_catalog import get_plan_display_name, normalize_plan_id
 from app.models import AuditLog, Company, OtpAttempt, Product, ProductStock, User
 from app.services import EmailService, KaspiService
+from app.services.subscriptions import renew_if_due
 from app.utils.idempotency import cleanup_idempotency_records
 
 logger = get_logger(__name__)
@@ -41,6 +42,7 @@ class TaskManager:
             asyncio.create_task(self._send_notifications_task()),
             asyncio.create_task(self._update_stock_levels_task()),
             asyncio.create_task(self._process_scheduled_campaigns_task()),
+            asyncio.create_task(self._renew_subscriptions_task()),
         ]
 
         logger.info("Background tasks started")
@@ -196,6 +198,23 @@ class TaskManager:
 
             except Exception as e:
                 logger.error(f"Campaigns task error: {e}")
+
+    async def _renew_subscriptions_task(self):
+        """Periodic task to renew subscriptions from wallet balance."""
+
+        while self.running:
+            try:
+                await asyncio.sleep(86400)  # Run daily
+
+                async with async_session_maker() as db:
+                    processed = await renew_if_due(db)
+                    if processed:
+                        await db.commit()
+                        logger.info("Subscription renewals processed", extra={"count": processed})
+                    else:
+                        await db.rollback()
+            except Exception as e:
+                logger.error(f"Subscription renewal task error: {e}")
 
     async def _send_low_stock_alerts(self, db: AsyncSession):
         """Send low stock alerts to company admins"""

--- a/tests/app/test_subscription_overrides_kaspi.py
+++ b/tests/app/test_subscription_overrides_kaspi.py
@@ -116,7 +116,7 @@ async def test_kaspi_subscription_override_bypasses_gate(
         headers=_auth_headers(owner),
         json={"merchant_uid": merchant_uid},
     )
-    assert ok.status_code == 200
+    assert ok.status_code == 402
 
     expired_at = (datetime.now(UTC) - timedelta(days=1)).isoformat()
     expired = await async_client.put(

--- a/tests/app/test_superuser_allowlist.py
+++ b/tests/app/test_superuser_allowlist.py
@@ -57,10 +57,10 @@ async def test_superuser_allowlist_bypasses_feature_and_admin(
     _refresh_settings(monkeypatch)
 
     resp_orders = await async_client.get("/api/v1/kaspi/orders", headers=company_a_manager_headers)
-    assert resp_orders.status_code == 200
+    assert resp_orders.status_code in {402, 403}
 
     resp_autosync = await async_client.get("/api/v1/kaspi/autosync/status", headers=company_a_manager_headers)
-    assert resp_autosync.status_code == 200
+    assert resp_autosync.status_code == 402
 
     monkeypatch.delenv("SUPERUSER_ALLOWLIST", raising=False)
     _refresh_settings(monkeypatch)

--- a/tests/test_billing_wallet_topup.py
+++ b/tests/test_billing_wallet_topup.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+import sqlalchemy as sa
+
+from app.core.subscriptions import plan_catalog
+from app.models.billing import Subscription, WalletBalance, WalletTransaction
+from app.models.company import Company
+from app.services.subscriptions import activate_plan, renew_if_due
+
+
+@pytest.mark.asyncio
+async def test_manual_topup_increases_balance_and_records_ledger(
+    async_client,
+    async_db_session,
+    auth_headers,
+):
+    company = Company(id=9001, name="Topup Co")
+    async_db_session.add(company)
+    await async_db_session.commit()
+    await async_db_session.refresh(company)
+
+    resp = await async_client.post(
+        "/api/v1/admin/wallet/topup",
+        headers=auth_headers,
+        json={
+            "companyId": company.id,
+            "amount": "100.00",
+            "currency": "KZT",
+            "external_reference": "topup-001",
+            "comment": "manual credit",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    wallet = await WalletBalance.get_for_company_async(async_db_session, company.id)
+    await async_db_session.refresh(wallet)
+    assert wallet.balance == Decimal("100.00")
+
+    row = (
+        (await async_db_session.execute(sa.select(WalletTransaction).where(WalletTransaction.wallet_id == wallet.id)))
+        .scalars()
+        .first()
+    )
+    assert row is not None
+    assert row.transaction_type == "manual_topup"
+    assert row.client_request_id == "topup-001"
+
+
+@pytest.mark.asyncio
+async def test_activate_plan_charges_wallet_and_sets_period(async_db_session, monkeypatch):
+    monkeypatch.setitem(
+        plan_catalog.PLAN_CATALOG,
+        "business",
+        plan_catalog.PlanCatalogEntry(
+            plan_id="business",
+            display_name="Business",
+            price=Decimal("50.00"),
+            currency="KZT",
+        ),
+    )
+
+    company = Company(id=9002, name="Billing Co")
+    async_db_session.add(company)
+    await async_db_session.commit()
+    await async_db_session.refresh(company)
+
+    wallet = WalletBalance(company_id=company.id, balance=Decimal("100.00"), currency="KZT")
+    async_db_session.add(wallet)
+    await async_db_session.commit()
+    await async_db_session.refresh(wallet)
+
+    now = datetime(2026, 2, 5, 12, 0, tzinfo=UTC)
+    sub = await activate_plan(async_db_session, company_id=company.id, plan_code="business", now=now)
+    await async_db_session.commit()
+    await async_db_session.refresh(sub)
+    await async_db_session.refresh(wallet)
+
+    assert sub.status == "active"
+    assert sub.period_start == now
+    assert sub.period_end == datetime(2026, 3, 5, 12, 0, tzinfo=UTC)
+    assert wallet.balance == Decimal("50.00")
+
+
+@pytest.mark.asyncio
+async def test_renewal_extends_period_when_balance_sufficient(async_db_session, monkeypatch):
+    monkeypatch.setitem(
+        plan_catalog.PLAN_CATALOG,
+        "business",
+        plan_catalog.PlanCatalogEntry(
+            plan_id="business",
+            display_name="Business",
+            price=Decimal("30.00"),
+            currency="KZT",
+        ),
+    )
+
+    company = Company(id=9003, name="Renew Co")
+    async_db_session.add(company)
+    await async_db_session.commit()
+    await async_db_session.refresh(company)
+
+    wallet = WalletBalance(company_id=company.id, balance=Decimal("100.00"), currency="KZT")
+    async_db_session.add(wallet)
+    await async_db_session.flush()
+
+    period_end = datetime(2026, 2, 1, 0, 0, tzinfo=UTC)
+    sub = Subscription(
+        company_id=company.id,
+        plan="business",
+        status="active",
+        billing_cycle="monthly",
+        price=Decimal("30.00"),
+        currency="KZT",
+        started_at=period_end - timedelta(days=30),
+        period_start=period_end - timedelta(days=30),
+        period_end=period_end,
+        next_billing_date=period_end,
+    )
+    async_db_session.add(sub)
+    await async_db_session.commit()
+
+    processed = await renew_if_due(async_db_session, now=datetime(2026, 2, 5, 0, 0, tzinfo=UTC))
+    await async_db_session.commit()
+    await async_db_session.refresh(sub)
+    await async_db_session.refresh(wallet)
+
+    assert processed == 1
+    assert sub.status == "active"
+    assert sub.period_end == datetime(2026, 3, 1, 0, 0, tzinfo=UTC)
+    assert wallet.balance == Decimal("70.00")
+
+
+@pytest.mark.asyncio
+async def test_renewal_marks_past_due_when_insufficient_balance(async_db_session, monkeypatch):
+    monkeypatch.setitem(
+        plan_catalog.PLAN_CATALOG,
+        "business",
+        plan_catalog.PlanCatalogEntry(
+            plan_id="business",
+            display_name="Business",
+            price=Decimal("30.00"),
+            currency="KZT",
+        ),
+    )
+
+    company = Company(id=9004, name="Past Due Co")
+    async_db_session.add(company)
+    await async_db_session.commit()
+    await async_db_session.refresh(company)
+
+    wallet = WalletBalance(company_id=company.id, balance=Decimal("10.00"), currency="KZT")
+    async_db_session.add(wallet)
+    await async_db_session.flush()
+
+    period_end = datetime(2026, 2, 1, 0, 0, tzinfo=UTC)
+    sub = Subscription(
+        company_id=company.id,
+        plan="business",
+        status="active",
+        billing_cycle="monthly",
+        price=Decimal("30.00"),
+        currency="KZT",
+        started_at=period_end - timedelta(days=30),
+        period_start=period_end - timedelta(days=30),
+        period_end=period_end,
+        next_billing_date=period_end,
+    )
+    async_db_session.add(sub)
+    await async_db_session.commit()
+
+    processed = await renew_if_due(async_db_session, now=datetime(2026, 2, 5, 0, 0, tzinfo=UTC))
+    await async_db_session.commit()
+    await async_db_session.refresh(sub)
+    await async_db_session.refresh(wallet)
+
+    assert processed == 1
+    assert sub.status == "past_due"
+    assert sub.period_end == period_end
+    assert wallet.balance == Decimal("10.00")


### PR DESCRIPTION
## Summary
- add platform-admin manual wallet top-up endpoint
- charge subscriptions from wallet with activation/renewal helpers and daily renewal task
- remove allowlist/override bypasses from subscription gating
- add billing wallet top-up and renewal tests

## Testing
- pytest -q