### PR TITLE
fix(billing): anchor-day + grace + topup idempotency

### DIFF
--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
+from decimal import Decimal
 
 import sqlalchemy as sa
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_async_db
+from app.core.dependencies import require_platform_admin
 from app.core.exceptions import AuthorizationError, NotFoundError
 from app.core.security import get_current_user, resolve_tenant_company_id
+from app.models.billing import WalletBalance, WalletTransaction
 from app.models.company import Company
 from app.models.subscription_override import SubscriptionOverride
 from app.models.user import User
@@ -37,6 +43,23 @@ class SubscriptionOverrideOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class WalletTopupIn(BaseModel):
+    companyId: int
+    amount: Decimal = Field(..., gt=0)
+    currency: str = Field(default="KZT", min_length=3, max_length=8)
+    external_reference: str | None = Field(default=None, max_length=128)
+    comment: str | None = Field(default=None, max_length=255)
+
+
+class WalletTopupOut(BaseModel):
+    company_id: int
+    wallet_id: int
+    transaction_id: int
+    currency: str
+    balance: str
+    amount: str
+
+
 def _utc_now() -> datetime:
     return datetime.now(UTC)
 
@@ -60,6 +83,101 @@ async def _resolve_company(
     company = await db.get(Company, resolved_id)
     _require_owner_or_superuser(current_user=current_user, company=company)
     return company
+
+
+@router.post(
+    "/wallet/topup",
+    response_model=WalletTopupOut,
+    summary="Manual company wallet top-up (platform admin)",
+)
+async def manual_wallet_topup(
+    payload: WalletTopupIn,
+    admin: User = Depends(require_platform_admin),
+    db: AsyncSession = Depends(get_async_db),
+) -> WalletTopupOut:
+    _ = admin
+    company = await db.get(Company, payload.companyId)
+    if not company:
+        raise NotFoundError("company_not_found", code="company_not_found", http_status=404)
+
+    wallet = await WalletBalance.get_for_company_async(
+        db,
+        payload.companyId,
+        create_if_missing=True,
+        currency=payload.currency,
+    )
+    if (wallet.currency or "").upper() != payload.currency.upper():
+        raise AuthorizationError("wallet_currency_mismatch", code="wallet_currency_mismatch", http_status=400)
+
+    amount = Decimal(str(payload.amount))
+
+    if payload.external_reference:
+        existing_stmt = select(WalletTransaction).where(
+            WalletTransaction.wallet_id == wallet.id,
+            WalletTransaction.client_request_id == payload.external_reference,
+        )
+        existing = (await db.execute(existing_stmt)).scalar_one_or_none()
+        if existing:
+            return WalletTopupOut(
+                company_id=payload.companyId,
+                wallet_id=wallet.id,
+                transaction_id=existing.id,
+                currency=wallet.currency,
+                balance=str(existing.balance_after),
+                amount=str(existing.amount),
+            )
+
+    before = wallet.balance or Decimal("0")
+    after = before + amount
+    wallet.balance = after
+    trx = WalletTransaction(
+        wallet_id=wallet.id,
+        transaction_type="manual_topup",
+        amount=amount,
+        balance_before=before,
+        balance_after=after,
+        description=payload.comment or "manual_topup",
+        reference_type="manual_topup",
+        client_request_id=payload.external_reference,
+        extra_data=json.dumps(
+            {
+                "external_reference": payload.external_reference,
+                "comment": payload.comment,
+            },
+            ensure_ascii=False,
+        ),
+    )
+    db.add(trx)
+    try:
+        await db.flush()
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        if payload.external_reference:
+            existing_stmt = select(WalletTransaction).where(
+                WalletTransaction.wallet_id == wallet.id,
+                WalletTransaction.client_request_id == payload.external_reference,
+            )
+            existing = (await db.execute(existing_stmt)).scalar_one_or_none()
+            if existing:
+                return WalletTopupOut(
+                    company_id=payload.companyId,
+                    wallet_id=wallet.id,
+                    transaction_id=existing.id,
+                    currency=wallet.currency,
+                    balance=str(existing.balance_after),
+                    amount=str(existing.amount),
+                )
+        raise
+
+    return WalletTopupOut(
+        company_id=payload.companyId,
+        wallet_id=wallet.id,
+        transaction_id=trx.id,
+        currency=wallet.currency,
+        balance=str(wallet.balance),
+        amount=str(amount),
+    )
 
 
 @router.get(

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.db import get_async_db
 from app.core.dependencies import require_platform_admin
 from app.core.exceptions import AuthorizationError, NotFoundError
+from app.core.logging import audit_logger
 from app.core.security import get_current_user, resolve_tenant_company_id
 from app.models.billing import WalletBalance, WalletTransaction
 from app.models.company import Company
@@ -169,6 +170,19 @@ async def manual_wallet_topup(
                     amount=str(existing.amount),
                 )
         raise
+
+    audit_logger.log_system_event(
+        level="info",
+        event="wallet_manual_topup",
+        message="Wallet credited manually",
+        meta={
+            "company_id": payload.companyId,
+            "wallet_id": wallet.id,
+            "amount": str(amount),
+            "currency": payload.currency,
+            "transaction_id": trx.id,
+        },
+    )
 
     return WalletTopupOut(
         company_id=payload.companyId,

--- a/app/models/billing.py
+++ b/app/models/billing.py
@@ -477,6 +477,8 @@ class Subscription(BaseModel, SoftDeleteMixin):
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     period_start: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     period_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), index=True)
+    billing_anchor_day: Mapped[int | None] = mapped_column(Integer)
+    grace_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), index=True)
     expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), index=True)
     cancel_at_period_end: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     canceled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
@@ -510,6 +512,10 @@ class Subscription(BaseModel, SoftDeleteMixin):
         ),
         CheckConstraint("price >= 0", name="ck_subscription_price_nonneg"),
         CheckConstraint("grace_period_days >= 0", name="ck_subscription_grace_nonneg"),
+        CheckConstraint(
+            "billing_anchor_day IS NULL OR (billing_anchor_day >= 1 AND billing_anchor_day <= 31)",
+            name="ck_subscription_anchor_day",
+        ),
         {"extend_existing": True},
     )
 
@@ -1296,7 +1302,7 @@ class WalletBalance(BaseModel, SoftDeleteMixin):
             reference_type=reference_type,
             reference_id=reference_id,
         )
-        self.transactions.append(trx)
+        session.add(trx)
         await session.flush()
         return trx
 
@@ -1373,7 +1379,7 @@ class WalletBalance(BaseModel, SoftDeleteMixin):
             reference_type=reference_type,
             reference_id=reference_id,
         )
-        self.transactions.append(trx)
+        session.add(trx)
         await session.flush()
         return trx
 
@@ -1472,7 +1478,7 @@ class WalletBalance(BaseModel, SoftDeleteMixin):
                         reference_type=reference_type,
                         reference_id=reference_id,
                     )
-                    self.transactions.append(trx)
+                    session.add(trx)
                     await session.flush()
                     return trx
             except Exception as e:
@@ -2048,7 +2054,13 @@ class WalletTransaction(BaseModel, SoftDeleteMixin):
 
     __table_args__ = (
         Index("ix_wallet_transaction_wallet_type", "wallet_id", "transaction_type"),
-        Index("ix_wallet_transaction_wallet_client_request", "wallet_id", "client_request_id"),
+        Index(
+            "uq_wallet_transaction_wallet_client_request",
+            "wallet_id",
+            "client_request_id",
+            unique=True,
+            postgresql_where=text("client_request_id IS NOT NULL"),
+        ),
         CheckConstraint("amount >= 0", name="ck_wallet_trx_amount_nonneg"),
         CheckConstraint("balance_before >= 0", name="ck_wallet_trx_before_nonneg"),
         CheckConstraint("balance_after >= 0", name="ck_wallet_trx_after_nonneg"),
@@ -2057,7 +2069,7 @@ class WalletTransaction(BaseModel, SoftDeleteMixin):
 
     @validates("transaction_type")
     def _validate_type(self, _k: str, v: str) -> str:
-        allowed = {"credit", "debit", "adjustment"}
+        allowed = {"credit", "debit", "adjustment", "manual_topup"}
         vv = (v or "").strip().lower()
         if vv not in allowed:
             raise ValueError(f"Invalid transaction_type: {vv}")

--- a/app/services/subscriptions.py
+++ b/app/services/subscriptions.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from calendar import monthrange
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 from sqlalchemy import desc, nullslast, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.billing import Subscription
+from app.core.subscriptions.plan_catalog import get_plan, normalize_plan_id
+from app.models.billing import Subscription, WalletBalance, WalletTransaction
 
 _SUB_ACTIVE = {"active", "trialing"}
-_SUB_INACTIVE = {"canceled", "frozen", "past_due"}
 _STATUS_ALIASES = {
     "trial": "trialing",
     "overdue": "past_due",
@@ -21,6 +23,37 @@ def _normalize_status(status: str | None) -> str:
     return _STATUS_ALIASES.get(val, val)
 
 
+def _anchor_day_from_subscription(subscription: Subscription, *, fallback: datetime) -> int:
+    anchor = getattr(subscription, "billing_anchor_day", None)
+    if anchor:
+        return int(anchor)
+    started_at = getattr(subscription, "started_at", None)
+    if started_at:
+        return int(started_at.day)
+    period_end = getattr(subscription, "period_end", None)
+    if period_end:
+        return int(period_end.day)
+    return int(fallback.day)
+
+
+def _add_months_anchor(dt: datetime, anchor_day: int, months: int) -> datetime:
+    month_index = (dt.month - 1) + months
+    year = dt.year + (month_index // 12)
+    month = (month_index % 12) + 1
+    last_day = monthrange(year, month)[1]
+    day = min(max(anchor_day, 1), last_day)
+    return dt.replace(year=year, month=month, day=day)
+
+
+def _ceil_to_midnight_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    midnight = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    if dt > midnight:
+        midnight = midnight + timedelta(days=1)
+    return midnight
+
+
 def is_subscription_active(subscription: Subscription | None, now: datetime | None = None) -> bool:
     if not subscription:
         return False
@@ -30,8 +63,6 @@ def is_subscription_active(subscription: Subscription | None, now: datetime | No
     now = now or datetime.now(UTC)
     status = _normalize_status(getattr(subscription, "status", None))
 
-    if status in _SUB_INACTIVE:
-        return False
     if getattr(subscription, "canceled_at", None):
         return False
 
@@ -41,14 +72,13 @@ def is_subscription_active(subscription: Subscription | None, now: datetime | No
         return False
 
     period_end = getattr(subscription, "period_end", None)
-    if period_end and now > period_end:
-        return False
+    grace_until = getattr(subscription, "grace_until", None)
 
     if status in _SUB_ACTIVE:
-        return True
+        return period_end is None or now <= period_end
 
-    if status == "active":
-        return True
+    if status == "past_due":
+        return grace_until is not None and now < grace_until
 
     return False
 
@@ -67,4 +97,132 @@ async def get_company_subscription(db: AsyncSession, company_id: int) -> Subscri
     return res.scalar_one_or_none()
 
 
-__all__ = ["get_company_subscription", "is_subscription_active"]
+async def activate_plan(
+    db: AsyncSession,
+    *,
+    company_id: int,
+    plan_code: str,
+    now: datetime | None = None,
+) -> Subscription:
+    now = now or datetime.now(UTC)
+    plan = get_plan(normalize_plan_id(plan_code))
+    if plan is None:
+        raise ValueError("Unknown plan")
+
+    wallet = await WalletBalance.get_for_company_async(
+        db,
+        company_id,
+        create_if_missing=True,
+        currency=plan.currency,
+    )
+
+    if (wallet.currency or "").upper() != (plan.currency or "").upper():
+        raise ValueError("Wallet currency mismatch")
+
+    amount = Decimal(plan.price)
+    if amount > 0:
+        await wallet.debit_safe_async(
+            db,
+            amount,
+            description="subscription_activation",
+            reference_type="subscription",
+            reference_id=None,
+        )
+
+    anchor_day = now.day
+    period_end = _add_months_anchor(now, anchor_day, 1)
+
+    sub = Subscription(
+        company_id=company_id,
+        plan=plan.plan_id,
+        status="active",
+        billing_cycle="monthly",
+        price=amount,
+        currency=plan.currency,
+        started_at=now,
+        period_start=now,
+        period_end=period_end,
+        next_billing_date=period_end,
+        billing_anchor_day=anchor_day,
+        grace_until=None,
+    )
+    db.add(sub)
+    await db.flush()
+    return sub
+
+
+async def renew_if_due(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    grace_days: int = 3,
+) -> int:
+    now = now or datetime.now(UTC)
+    due_stmt = (
+        select(Subscription)
+        .where(Subscription.deleted_at.is_(None))
+        .where(Subscription.period_end.is_not(None))
+        .where(Subscription.period_end <= now)
+        .where(Subscription.status.in_(["active", "past_due", "trialing"]))
+    )
+    rows = (await db.execute(due_stmt)).scalars().all()
+    processed = 0
+    for sub in rows:
+        processed += 1
+        anchor_day = _anchor_day_from_subscription(sub, fallback=now)
+        if not sub.billing_anchor_day:
+            sub.billing_anchor_day = anchor_day
+
+        base_period_end = sub.period_end or now
+        plan = get_plan(normalize_plan_id(sub.plan))
+        price = Decimal(plan.price) if plan else Decimal(sub.price or 0)
+        currency = plan.currency if plan else (sub.currency or "KZT")
+
+        wallet = (
+            await db.execute(select(WalletBalance).where(WalletBalance.company_id == sub.company_id).limit(1))
+        ).scalar_one_or_none()
+
+        if wallet is None or (wallet.currency or "").upper() != (currency or "").upper():
+            sub.status = "past_due"
+            sub.grace_until = _ceil_to_midnight_utc(base_period_end + timedelta(days=grace_days))
+            continue
+
+        try:
+            if price > 0:
+                before = wallet.balance or Decimal("0")
+                if before < price:
+                    raise ValueError("Insufficient wallet balance")
+                after = before - price
+                wallet.balance = after
+                trx = WalletTransaction(
+                    wallet_id=wallet.id,
+                    transaction_type="debit",
+                    amount=price,
+                    balance_before=before,
+                    balance_after=after,
+                    description="subscription_renewal",
+                    reference_type="subscription",
+                    reference_id=sub.id,
+                )
+                db.add(trx)
+                await db.flush()
+        except ValueError:
+            sub.status = "past_due"
+            sub.grace_until = _ceil_to_midnight_utc(base_period_end + timedelta(days=grace_days))
+            continue
+
+        sub.status = "active"
+        sub.grace_until = None
+        sub.period_start = base_period_end
+        sub.period_end = _add_months_anchor(base_period_end, anchor_day, 1)
+        sub.next_billing_date = sub.period_end
+
+    return processed
+
+
+__all__ = [
+    "activate_plan",
+    "get_company_subscription",
+    "is_subscription_active",
+    "renew_if_due",
+]

--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -3,7 +3,7 @@ Background tasks for SmartSell3 using asyncio.
 """
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from sqlalchemy import and_, select
@@ -14,6 +14,7 @@ from app.core.logging import get_logger
 from app.core.subscriptions.plan_catalog import get_plan_display_name, normalize_plan_id
 from app.models import AuditLog, Company, OtpAttempt, Product, ProductStock, User
 from app.services import EmailService, KaspiService
+from app.services.subscriptions import renew_if_due
 from app.utils.idempotency import cleanup_idempotency_records
 
 logger = get_logger(__name__)
@@ -41,6 +42,7 @@ class TaskManager:
             asyncio.create_task(self._send_notifications_task()),
             asyncio.create_task(self._update_stock_levels_task()),
             asyncio.create_task(self._process_scheduled_campaigns_task()),
+            asyncio.create_task(self._renew_subscriptions_task()),
         ]
 
         logger.info("Background tasks started")
@@ -196,6 +198,23 @@ class TaskManager:
 
             except Exception as e:
                 logger.error(f"Campaigns task error: {e}")
+
+    async def _renew_subscriptions_task(self):
+        """Renew subscriptions daily (runs immediately on start)."""
+
+        while self.running:
+            try:
+                async with async_session_maker() as db:
+                    try:
+                        await renew_if_due(db, now=datetime.now(UTC))
+                        await db.commit()
+                    except Exception as e:
+                        await db.rollback()
+                        logger.error(f"Subscription renewal error: {e}")
+            except Exception as e:
+                logger.error(f"Subscription renewal task error: {e}")
+
+            await asyncio.sleep(86400)
 
     async def _send_low_stock_alerts(self, db: AsyncSession):
         """Send low stock alerts to company admins"""

--- a/migrations/versions/20260206_subscription_billing_anchor_grace_wallet_tx_idempotent.py
+++ b/migrations/versions/20260206_subscription_billing_anchor_grace_wallet_tx_idempotent.py
@@ -1,0 +1,104 @@
+"""Subscription anchor/grace + wallet topup idempotency
+
+Revision ID: 20260206_subscription_billing_anchor_grace_wallet_tx_idempotent
+Revises: 20260205_idempotency_keys
+Create Date: 2026-02-06
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+try:
+    from migrations.utils.pghelpers import safe_inspect
+except Exception:  # pragma: no cover - fallback if utils import fails
+    safe_inspect = None  # type: ignore
+
+revision = "20260206_subscription_billing_anchor_grace_wallet_tx_idempotent"
+down_revision = "20260205_idempotency_keys"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(insp, table: str, column: str) -> bool:
+    try:
+        return any(col.get("name") == column for col in insp.get_columns(table))
+    except Exception:
+        return False
+
+
+def _has_index(insp, table: str, index: str) -> bool:
+    try:
+        return any(idx.get("name") == index for idx in insp.get_indexes(table))
+    except Exception:
+        return False
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = safe_inspect(bind) if safe_inspect else None
+
+    if not insp or insp.has_table("subscriptions"):
+        if not insp or not _has_column(insp, "subscriptions", "billing_anchor_day"):
+            op.add_column("subscriptions", sa.Column("billing_anchor_day", sa.Integer(), nullable=True))
+        if not insp or not _has_column(insp, "subscriptions", "grace_until"):
+            op.add_column("subscriptions", sa.Column("grace_until", sa.DateTime(timezone=True), nullable=True))
+            if not insp or not _has_index(insp, "subscriptions", "ix_subscriptions_grace_until"):
+                op.create_index("ix_subscriptions_grace_until", "subscriptions", ["grace_until"], unique=False)
+        try:
+            op.create_check_constraint(
+                "ck_subscription_anchor_day",
+                "subscriptions",
+                "billing_anchor_day IS NULL OR (billing_anchor_day >= 1 AND billing_anchor_day <= 31)",
+            )
+        except Exception:
+            pass
+
+    if not insp or insp.has_table("wallet_transactions"):
+        if not insp or _has_index(insp, "wallet_transactions", "ix_wallet_transaction_wallet_client_request"):
+            try:
+                op.drop_index("ix_wallet_transaction_wallet_client_request", table_name="wallet_transactions")
+            except Exception:
+                pass
+        if not insp or not _has_index(insp, "wallet_transactions", "uq_wallet_transaction_wallet_client_request"):
+            op.create_index(
+                "uq_wallet_transaction_wallet_client_request",
+                "wallet_transactions",
+                ["wallet_id", "client_request_id"],
+                unique=True,
+                postgresql_where=sa.text("client_request_id IS NOT NULL"),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = safe_inspect(bind) if safe_inspect else None
+
+    if not insp or insp.has_table("wallet_transactions"):
+        try:
+            op.drop_index("uq_wallet_transaction_wallet_client_request", table_name="wallet_transactions")
+        except Exception:
+            pass
+        try:
+            op.create_index(
+                "ix_wallet_transaction_wallet_client_request",
+                "wallet_transactions",
+                ["wallet_id", "client_request_id"],
+                unique=False,
+            )
+        except Exception:
+            pass
+
+    if not insp or insp.has_table("subscriptions"):
+        try:
+            op.drop_constraint("ck_subscription_anchor_day", "subscriptions", type_="check")
+        except Exception:
+            pass
+        try:
+            op.drop_index("ix_subscriptions_grace_until", table_name="subscriptions")
+        except Exception:
+            pass
+        for col in ("grace_until", "billing_anchor_day"):
+            try:
+                op.drop_column("subscriptions", col)
+            except Exception:
+                pass

--- a/tests/test_billing_wallet_topup.py
+++ b/tests/test_billing_wallet_topup.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+import sqlalchemy as sa
+
+from app.core.subscriptions import plan_catalog
+from app.models.billing import Subscription, WalletBalance, WalletTransaction
+from app.models.company import Company
+from app.services.subscriptions import renew_if_due
+
+pytestmark = pytest.mark.asyncio
+
+
+def _ceil_midnight(dt: datetime) -> datetime:
+    midnight = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    if dt > midnight:
+        midnight = midnight + timedelta(days=1)
+    return midnight
+
+
+async def _ensure_company(async_db_session, company_id: int, *, plan: str = "start") -> Company:
+    company = await async_db_session.get(Company, company_id)
+    if company is None:
+        company = Company(id=company_id, name=f"Company {company_id}")
+        async_db_session.add(company)
+        await async_db_session.flush()
+    company.subscription_plan = plan
+    await async_db_session.commit()
+    return company
+
+
+async def test_manual_topup_idempotent(async_client, async_db_session, auth_headers):
+    company = Company(id=9001, name="Topup Co")
+    async_db_session.add(company)
+    await async_db_session.commit()
+
+    payload = {
+        "companyId": company.id,
+        "amount": "100.00",
+        "currency": "KZT",
+        "external_reference": "topup-001",
+        "comment": "manual credit",
+    }
+
+    resp1 = await async_client.post("/api/v1/admin/wallet/topup", headers=auth_headers, json=payload)
+    assert resp1.status_code == 200, resp1.text
+    data1 = resp1.json()
+
+    resp2 = await async_client.post("/api/v1/admin/wallet/topup", headers=auth_headers, json=payload)
+    assert resp2.status_code == 200, resp2.text
+    data2 = resp2.json()
+
+    assert data2["transaction_id"] == data1["transaction_id"]
+    assert data2["balance"] == data1["balance"]
+
+    wallet = (
+        await async_db_session.execute(sa.select(WalletBalance).where(WalletBalance.company_id == company.id))
+    ).scalar_one()
+    assert str(wallet.balance) == "100.00"
+
+
+async def test_past_due_within_grace_allows_access(
+    async_client,
+    async_db_session,
+    company_a_admin_headers,
+):
+    company_id = 1001
+    await _ensure_company(async_db_session, company_id, plan="start")
+    await async_db_session.execute(sa.delete(Subscription).where(Subscription.company_id == company_id))
+
+    now = datetime.now(UTC)
+    period_end = now - timedelta(days=1)
+    grace_until = _ceil_midnight(period_end + timedelta(days=3))
+
+    sub = Subscription(
+        company_id=company_id,
+        plan="business",
+        status="past_due",
+        billing_cycle="monthly",
+        price=Decimal("30.00"),
+        currency="KZT",
+        started_at=period_end - timedelta(days=30),
+        period_start=period_end - timedelta(days=30),
+        period_end=period_end,
+        next_billing_date=period_end,
+        billing_anchor_day=period_end.day,
+        grace_until=grace_until,
+    )
+    async_db_session.add(sub)
+    await async_db_session.commit()
+
+    resp = await async_client.get("/api/v1/kaspi/autosync/status", headers=company_a_admin_headers)
+    assert resp.status_code == 200, resp.text
+
+
+async def test_after_grace_access_denied(
+    async_client,
+    async_db_session,
+    company_a_admin_headers,
+):
+    company_id = 1001
+    await _ensure_company(async_db_session, company_id, plan="start")
+    await async_db_session.execute(sa.delete(Subscription).where(Subscription.company_id == company_id))
+
+    now = datetime.now(UTC)
+    period_end = now - timedelta(days=5)
+    grace_until = _ceil_midnight(period_end + timedelta(days=3))
+
+    sub = Subscription(
+        company_id=company_id,
+        plan="business",
+        status="past_due",
+        billing_cycle="monthly",
+        price=Decimal("30.00"),
+        currency="KZT",
+        started_at=period_end - timedelta(days=30),
+        period_start=period_end - timedelta(days=30),
+        period_end=period_end,
+        next_billing_date=period_end,
+        billing_anchor_day=period_end.day,
+        grace_until=grace_until,
+    )
+    async_db_session.add(sub)
+    await async_db_session.commit()
+
+    resp = await async_client.get("/api/v1/kaspi/autosync/status", headers=company_a_admin_headers)
+    assert resp.status_code == 402, resp.text
+    payload = resp.json()
+    assert payload.get("detail") == "subscription_required"
+
+
+async def test_renewal_within_grace_reactivates_and_extends(async_db_session, monkeypatch):
+    monkeypatch.setitem(
+        plan_catalog.PLAN_CATALOG,
+        "business",
+        plan_catalog.PlanCatalogEntry(
+            plan_id="business",
+            display_name="Business",
+            price=Decimal("30.00"),
+            currency="KZT",
+        ),
+    )
+
+    company = Company(id=9002, name="Grace Renew Co")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    wallet = WalletBalance(company_id=company.id, balance=Decimal("100.00"), currency="KZT")
+    async_db_session.add(wallet)
+    await async_db_session.flush()
+
+    period_end = datetime(2026, 1, 31, 0, 0, tzinfo=UTC)
+    grace_until = datetime(2026, 2, 4, 0, 0, tzinfo=UTC)
+
+    sub = Subscription(
+        company_id=company.id,
+        plan="business",
+        status="past_due",
+        billing_cycle="monthly",
+        price=Decimal("30.00"),
+        currency="KZT",
+        started_at=period_end - timedelta(days=30),
+        period_start=period_end - timedelta(days=30),
+        period_end=period_end,
+        next_billing_date=period_end,
+        billing_anchor_day=31,
+        grace_until=grace_until,
+    )
+    async_db_session.add(sub)
+    await async_db_session.commit()
+
+    processed = await renew_if_due(async_db_session, now=datetime(2026, 2, 2, 12, 0, tzinfo=UTC))
+    assert processed == 1
+
+    await async_db_session.commit()
+
+    await async_db_session.refresh(sub)
+    await async_db_session.refresh(wallet)
+
+    assert sub.status == "active"
+    assert sub.grace_until is None
+    assert sub.period_end == datetime(2026, 2, 28, 0, 0, tzinfo=UTC)
+    assert str(wallet.balance) == "70.00"
+
+    tx = (
+        (await async_db_session.execute(sa.select(WalletTransaction).where(WalletTransaction.wallet_id == wallet.id)))
+        .scalars()
+        .all()
+    )
+    assert tx


### PR DESCRIPTION
Patch for wallet subscription billing: anchor-day to avoid drift, 3-day grace, idempotent manual topup; includes migration + tests.