### PR TITLE
fix(api): enriched 402 subscription required payload

### DIFF
--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -443,6 +443,7 @@ async def require_active_subscription(
         return None
 
     from app.core.security import resolve_tenant_company_id  # type: ignore
+    from app.core.subscriptions.errors import build_subscription_required_payload  # type: ignore
     from app.services.subscriptions import get_company_subscription, is_subscription_active  # type: ignore
 
     role = (getattr(current_user, "role", "") or "").lower()
@@ -452,7 +453,8 @@ async def require_active_subscription(
     company_id = resolve_tenant_company_id(current_user, not_found_detail="Company not set")
     subscription = await get_company_subscription(db, company_id)
     if not is_subscription_active(subscription):
-        raise HTTPException(status_code=402, detail="subscription_required")
+        payload = await build_subscription_required_payload(db, current_user)
+        raise HTTPException(status_code=402, detail=payload)
     return current_user
 
 

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -223,8 +223,12 @@ def _json_error_response(
     headers: dict[str, str] | None = None,
 ) -> JSONResponse:
     rid = _ensure_request_id(request)
+    if isinstance(detail, (dict, list)):
+        detail_value: Any = detail
+    else:
+        detail_value = _stringify_detail(detail)
     payload = {
-        "detail": _stringify_detail(detail),
+        "detail": detail_value,
         "code": code,
         "request_id": rid,
     }

--- a/app/core/subscriptions/errors.py
+++ b/app/core/subscriptions/errors.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import desc, nullslast, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import resolve_tenant_company_id
+from app.models.billing import Subscription, WalletBalance
+
+_SUB_STATUS_RELEVANT = {"active", "trial", "trialing", "past_due", "frozen", "overdue", "paused"}
+
+
+def _iso_or_none(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+def _decimal_or_none(value: Decimal | None) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+async def _build_payload(db: AsyncSession, company_id: int | None) -> dict:
+    subscription_data = {
+        "status": None,
+        "plan": None,
+        "period_end": None,
+        "grace_until": None,
+        "next_billing_date": None,
+    }
+    wallet_data = {"balance": None, "currency": None}
+
+    if company_id is not None:
+        stmt = (
+            select(Subscription)
+            .where(Subscription.company_id == company_id)
+            .where(Subscription.deleted_at.is_(None))
+            .where(Subscription.status.in_(list(_SUB_STATUS_RELEVANT)))
+            .order_by(nullslast(desc(Subscription.period_end)))
+            .order_by(desc(Subscription.started_at))
+            .order_by(desc(Subscription.created_at))
+            .limit(1)
+        )
+        sub = (await db.execute(stmt)).scalar_one_or_none()
+        if sub is not None:
+            subscription_data = {
+                "status": sub.status,
+                "plan": sub.plan,
+                "period_end": _iso_or_none(sub.period_end),
+                "grace_until": _iso_or_none(getattr(sub, "grace_until", None)),
+                "next_billing_date": _iso_or_none(sub.next_billing_date),
+            }
+
+        wallet = (
+            await db.execute(select(WalletBalance).where(WalletBalance.company_id == company_id).limit(1))
+        ).scalar_one_or_none()
+        if wallet is not None:
+            wallet_data = {
+                "balance": _decimal_or_none(wallet.balance),
+                "currency": wallet.currency,
+            }
+
+    return {
+        "code": "SUBSCRIPTION_REQUIRED",
+        "detail": "Subscription required",
+        "company_id": company_id,
+        "subscription": subscription_data,
+        "wallet": wallet_data,
+        "actions": [
+            {"type": "TOPUP_WALLET", "hint": "Пополните кошелек"},
+            {"type": "ACTIVATE_PLAN", "hint": "Активируйте тариф после пополнения"},
+        ],
+    }
+
+
+async def build_subscription_required_payload(db: AsyncSession, user: object | None) -> dict:
+    company_id: int | None = None
+    try:
+        if user is not None:
+            company_id = resolve_tenant_company_id(user, not_found_detail="Company not set")
+    except Exception:
+        company_id = None
+    return await _build_payload(db, company_id)
+
+
+async def build_subscription_required_payload_for_company(db: AsyncSession, company_id: int | None) -> dict:
+    return await _build_payload(db, company_id)
+
+
+__all__ = ["build_subscription_required_payload", "build_subscription_required_payload_for_company"]

--- a/app/core/subscriptions/features.py
+++ b/app/core/subscriptions/features.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
-from fastapi import Depends, Request
+from fastapi import Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_async_db
-from app.core.exceptions import AuthorizationError
 from app.core.logging import get_logger
 from app.core.security import get_current_user, resolve_tenant_company_id
+from app.core.subscriptions.errors import (
+    build_subscription_required_payload,
+    build_subscription_required_payload_for_company,
+)
 from app.core.subscriptions.plan_catalog import get_plan_features as _catalog_plan_features
 from app.core.subscriptions.plan_catalog import normalize_plan_id
 from app.services.subscriptions import get_company_subscription, is_subscription_active
@@ -27,12 +30,8 @@ async def _resolve_plan(db: AsyncSession, company_id: int) -> str:
     subscription = await get_company_subscription(db, company_id)
     if subscription and is_subscription_active(subscription):
         return normalize_plan_id(getattr(subscription, "plan", None)) or "start"
-    raise AuthorizationError(
-        "subscription_required",
-        code="subscription_required",
-        http_status=402,
-        extra={"company_id": company_id},
-    )
+    payload = await build_subscription_required_payload_for_company(db, company_id)
+    raise HTTPException(status_code=402, detail=payload)
 
 
 def _has_feature(plan: str, feature: str) -> bool:
@@ -76,12 +75,8 @@ def require_feature(feature: str) -> Any:
         plan = await _resolve_plan(db, company_id)
         if not _has_feature(plan, feature):
             logger.info("Feature blocked", extra={"feature": feature, "plan": plan, "company_id": company_id})
-            raise AuthorizationError(
-                "subscription_required",
-                code="subscription_required",
-                http_status=402,
-                extra={"feature": feature, "plan": plan, "company_id": company_id},
-            )
+            payload = await build_subscription_required_payload(db, current_user)
+            raise HTTPException(status_code=402, detail=payload)
         return current_user
 
     return _dep

--- a/tests/app/test_analytics_hardening.py
+++ b/tests/app/test_analytics_hardening.py
@@ -81,7 +81,9 @@ async def test_analytics_subscription_inactive_blocked(
 
     resp = await async_client.get("/api/v1/analytics/dashboard", headers=company_a_admin_headers)
     assert resp.status_code == 402
-    assert resp.json().get("detail") == "subscription_required"
+    detail = resp.json().get("detail")
+    assert isinstance(detail, dict)
+    assert detail.get("code") == "SUBSCRIPTION_REQUIRED"
 
 
 @pytest.mark.asyncio

--- a/tests/app/test_campaigns_hardening.py
+++ b/tests/app/test_campaigns_hardening.py
@@ -150,4 +150,6 @@ async def test_campaign_subscription_inactive_blocks_access(
         json={"title": "Subscription Inactive"},
     )
     assert resp.status_code == 402
-    assert resp.json().get("detail") == "subscription_required"
+    detail = resp.json().get("detail")
+    assert isinstance(detail, dict)
+    assert detail.get("code") == "SUBSCRIPTION_REQUIRED"

--- a/tests/app/test_invoices_mvp_core.py
+++ b/tests/app/test_invoices_mvp_core.py
@@ -178,4 +178,6 @@ async def test_invoices_subscription_inactive_blocked(
 
     resp = await async_client.get("/api/v1/invoices", headers=company_a_admin_headers)
     assert resp.status_code == 402
-    assert resp.json().get("detail") == "subscription_required"
+    detail = resp.json().get("detail")
+    assert isinstance(detail, dict)
+    assert detail.get("code") == "SUBSCRIPTION_REQUIRED"

--- a/tests/app/test_kaspi_subscription_enforcement_e.py
+++ b/tests/app/test_kaspi_subscription_enforcement_e.py
@@ -97,9 +97,14 @@ async def test_kaspi_enforcement_admin_missing_feature(
     resp = await request(path, headers=company_a_admin_headers, json=payload)
     assert resp.status_code == 402
     data = resp.json()
-    assert data.get("detail") == "subscription_required"
-    assert data.get("code") == "subscription_required"
-    assert data.get("request_id")
+    detail = data.get("detail")
+    assert isinstance(detail, dict)
+    assert detail.get("code") == "SUBSCRIPTION_REQUIRED"
+    assert detail.get("company_id") == 1001
+    assert "subscription" in detail
+    assert "wallet" in detail
+    actions = detail.get("actions") or []
+    assert any(action.get("type") == "TOPUP_WALLET" for action in actions)
 
 
 async def test_kaspi_enforcement_admin_allowed_plan_goods_imports_list(

--- a/tests/app/test_kaspi_subscription_matrix.py
+++ b/tests/app/test_kaspi_subscription_matrix.py
@@ -47,8 +47,9 @@ async def _set_plan(async_db_session, company_id: int, plan: str) -> None:
 def _assert_subscription_required(resp) -> None:
     assert resp.status_code == 402
     payload = resp.json()
-    assert payload.get("detail") == "subscription_required"
-    assert payload.get("code") == "subscription_required"
+    detail = payload.get("detail")
+    assert isinstance(detail, dict)
+    assert detail.get("code") == "SUBSCRIPTION_REQUIRED"
     assert payload.get("request_id")
 
 

--- a/tests/app/test_kaspi_sync_now.py
+++ b/tests/app/test_kaspi_sync_now.py
@@ -111,8 +111,9 @@ async def test_kaspi_sync_now_trial_requires_subscription(
     )
     assert resp.status_code == 402
     payload = resp.json()
-    assert payload.get("detail") == "subscription_required"
-    assert payload.get("code") == "subscription_required"
+    detail = payload.get("detail")
+    assert isinstance(detail, dict)
+    assert detail.get("code") == "SUBSCRIPTION_REQUIRED"
     assert payload.get("request_id")
 
 

--- a/tests/app/test_subscription_enforcement.py
+++ b/tests/app/test_subscription_enforcement.py
@@ -12,7 +12,9 @@ async def test_subscription_required_blocks_protected_endpoint(
 ):
     resp = await async_client.get("/api/v1/products", headers=company_a_admin_headers)
     assert resp.status_code == 402
-    assert resp.json().get("detail") == "subscription_required"
+    detail = resp.json().get("detail")
+    assert isinstance(detail, dict)
+    assert detail.get("code") == "SUBSCRIPTION_REQUIRED"
 
 
 @pytest.mark.asyncio
@@ -60,4 +62,6 @@ async def test_cross_tenant_subscription_does_not_grant_access(
 
     foreign = await async_client.get("/api/v1/products", headers=company_b_admin_headers)
     assert foreign.status_code == 402
-    assert foreign.json().get("detail") == "subscription_required"
+    detail = foreign.json().get("detail")
+    assert isinstance(detail, dict)
+    assert detail.get("code") == "SUBSCRIPTION_REQUIRED"

--- a/tests/app/test_subscription_required_payload.py
+++ b/tests/app/test_subscription_required_payload.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.core.security import get_password_hash
+from app.core.subscriptions.errors import build_subscription_required_payload
+from app.models.billing import Subscription, WalletBalance
+from app.models.company import Company
+from app.models.user import User
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_build_subscription_required_payload_with_wallet_and_grace(async_db_session):
+    company = Company(id=9201, name="Payload Co")
+    async_db_session.add(company)
+    await async_db_session.flush()
+
+    user = User(
+        company_id=company.id,
+        phone="77000092001",
+        hashed_password=get_password_hash("Secret123!"),
+        role="admin",
+        is_active=True,
+        is_verified=True,
+    )
+    async_db_session.add(user)
+
+    now = datetime.now(UTC)
+    period_end = now + timedelta(days=1)
+    grace_until = period_end + timedelta(days=3)
+    sub = Subscription(
+        company_id=company.id,
+        plan="business",
+        status="past_due",
+        billing_cycle="monthly",
+        price=Decimal("30.00"),
+        currency="KZT",
+        started_at=now,
+        period_start=now,
+        period_end=period_end,
+        next_billing_date=period_end,
+        grace_until=grace_until,
+    )
+    async_db_session.add(sub)
+
+    wallet = WalletBalance(company_id=company.id, balance=Decimal("123.45"), currency="KZT")
+    async_db_session.add(wallet)
+
+    await async_db_session.commit()
+
+    payload = await build_subscription_required_payload(async_db_session, user)
+    assert payload["code"] == "SUBSCRIPTION_REQUIRED"
+    assert payload["company_id"] == company.id
+    assert payload["subscription"]["status"] == "past_due"
+    assert payload["subscription"]["plan"] == "business"
+    assert payload["subscription"]["period_end"] == period_end.isoformat()
+    assert payload["subscription"]["grace_until"] == grace_until.isoformat()
+    assert payload["wallet"]["balance"] == "123.45"
+    assert payload["wallet"]["currency"] == "KZT"

--- a/tests/app/test_superuser_allowlist.py
+++ b/tests/app/test_superuser_allowlist.py
@@ -51,7 +51,9 @@ async def test_superuser_allowlist_bypasses_feature_and_admin(
     resp_subscription = await async_client.get("/api/v1/kaspi/autosync/status", headers=company_a_manager_headers)
     assert resp_subscription.status_code == 402
     payload = resp_subscription.json()
-    assert payload.get("detail") == "subscription_required"
+    detail = payload.get("detail")
+    assert isinstance(detail, dict)
+    assert detail.get("code") == "SUBSCRIPTION_REQUIRED"
 
     monkeypatch.setenv("SUPERUSER_ALLOWLIST", str(user.id))
     _refresh_settings(monkeypatch)
@@ -84,5 +86,6 @@ async def test_kaspi_sync_now_subscription_required_for_normal_user(
     )
     assert resp.status_code == 402
     payload = resp.json()
-    assert payload.get("detail") == "subscription_required"
-    assert payload.get("code") == "subscription_required"
+    detail = payload.get("detail")
+    assert isinstance(detail, dict)
+    assert detail.get("code") == "SUBSCRIPTION_REQUIRED"

--- a/tests/test_billing_wallet_topup.py
+++ b/tests/test_billing_wallet_topup.py
@@ -210,7 +210,9 @@ async def test_after_grace_access_denied(
     resp = await async_client.get("/api/v1/kaspi/autosync/status", headers=company_a_admin_headers)
     assert resp.status_code == 402, resp.text
     payload = resp.json()
-    assert payload.get("detail") == "subscription_required"
+    detail = payload.get("detail")
+    assert isinstance(detail, dict)
+    assert detail.get("code") == "SUBSCRIPTION_REQUIRED"
 
 
 async def test_renewal_within_grace_reactivates_and_extends(async_db_session, monkeypatch):


### PR DESCRIPTION
Unifies 402 response with machine-readable code and actionable hints; includes tests.