### PR TITLE
fix(admin): renew-run endpoint + admin access in require_platform_admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,9 @@ scripts/**
 docs/audit/
 docs/SMARTSELL_TZ_v2_*.md
 docs/План работы.txt
+
+# local-only scripts
+scripts/*.local.ps1
+scripts/smoke-*.local.ps1
+
+

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import sqlalchemy as sa
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_async_db
 from app.core.dependencies import require_platform_admin
-from app.core.exceptions import AuthorizationError, NotFoundError
+from app.core.exceptions import AuthorizationError, NotFoundError, _ensure_request_id
 from app.core.logging import audit_logger
 from app.core.security import get_current_user, resolve_tenant_company_id
 from app.core.subscriptions.plan_catalog import get_plan, normalize_plan_id
@@ -24,7 +24,7 @@ from app.models.kaspi_offer import KaspiOffer
 from app.models.kaspi_trial_grant import KaspiTrialGrant
 from app.models.subscription_override import SubscriptionOverride
 from app.models.user import User
-from app.services.subscriptions import activate_plan
+from app.services.subscriptions import activate_plan, renew_if_due
 
 router = APIRouter(prefix="/api/v1/admin", tags=["admin"])
 
@@ -77,6 +77,25 @@ class SubscriptionKaspiTrialIn(BaseModel):
     merchant_uid: str = Field(..., min_length=1, max_length=128)
     plan: str = Field(default="pro", min_length=2, max_length=32)
     trial_days: int = Field(default=15, ge=1, le=15)
+
+
+@router.post(
+    "/tasks/subscriptions/renew/run",
+    summary="Run subscription renewal task (platform admin)",
+)
+async def run_subscription_renew_task(
+    request: Request,
+    admin: User = Depends(require_platform_admin),
+    db: AsyncSession = Depends(get_async_db),
+) -> dict:
+    _ = admin
+    processed = await renew_if_due(db, now=datetime.now(UTC))
+    if processed:
+        await db.commit()
+    else:
+        await db.rollback()
+    rid = _ensure_request_id(request)
+    return {"ok": True, "processed": processed, "request_id": rid}
 
 
 class SubscriptionActivateIn(BaseModel):

--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -465,8 +465,9 @@ async def get_current_superuser(current_user: Any = Depends(get_current_user)) -
 
 
 async def require_platform_admin(current_user: Any = Depends(get_current_user)) -> Any:
-    role = getattr(current_user, "role", "") or ""
-    if role not in {"platform_admin", "superadmin"}:
+    role = (getattr(current_user, "role", "") or "").lower()
+    is_admin = getattr(current_user, "is_admin", lambda: False)()
+    if not (is_admin or role in {"platform_admin", "superadmin"}):
         raise AuthorizationError("Admin role required", "ADMIN_REQUIRED")
     return current_user
 

--- a/tests/app/api/test_openapi_legacy_contract.py
+++ b/tests/app/api/test_openapi_legacy_contract.py
@@ -21,6 +21,9 @@ async def test_openapi_hides_legacy_api_and_exposes_v1(async_client):
     admin_topup = paths.get("/api/v1/admin/wallet/topup", {})
     assert "post" in admin_topup
 
+    renew_run = paths.get("/api/v1/admin/tasks/subscriptions/renew/run", {})
+    assert "post" in renew_run
+
 
 @pytest.mark.asyncio
 async def test_openapi_kaspi_catalog_template_has_binary_types(async_client):

--- a/tests/app/test_subscription_renew_run_endpoint.py
+++ b/tests/app/test_subscription_renew_run_endpoint.py
@@ -1,0 +1,69 @@
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+import tests.conftest as base_conftest
+from app.core.security import create_access_token, get_password_hash
+from app.models.user import User
+
+
+def _platform_admin_headers_without_company() -> dict[str, str]:
+    if base_conftest.sync_engine is None:
+        raise RuntimeError("sync_engine is not initialized; ensure test_db fixture runs first")
+
+    SessionLocal = sessionmaker(bind=base_conftest.sync_engine, expire_on_commit=False, autoflush=False)
+    with SessionLocal() as s:
+        user = s.query(User).filter(User.phone == "+79999990000").first()
+        if not user:
+            user = User(
+                phone="+79999990000",
+                company_id=None,
+                hashed_password=get_password_hash("Secret123!"),
+                role="platform_admin",
+                is_active=True,
+                is_verified=True,
+            )
+            s.add(user)
+        else:
+            user.company_id = None
+            user.role = "platform_admin"
+            user.is_active = True
+            user.is_verified = True
+        s.commit()
+        s.refresh(user)
+        token = create_access_token(subject=user.id, extra={"role": "platform_admin"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_subscription_renew_run_requires_admin(async_client, company_a_admin_headers):
+    resp = await async_client.post(
+        "/api/v1/admin/tasks/subscriptions/renew/run",
+        headers=company_a_admin_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload.get("ok") is True
+
+
+@pytest.mark.asyncio
+async def test_subscription_renew_run_ok(async_client, test_db):
+    _ = test_db
+    headers = _platform_admin_headers_without_company()
+    resp = await async_client.post(
+        "/api/v1/admin/tasks/subscriptions/renew/run",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload.get("ok") is True
+    assert "processed" in payload
+    assert payload.get("request_id")
+
+
+@pytest.mark.asyncio
+async def test_subscription_renew_run_allows_admin(async_client, company_a_admin_headers):
+    resp = await async_client.post(
+        "/api/v1/admin/tasks/subscriptions/renew/run",
+        headers=company_a_admin_headers,
+    )
+    assert resp.status_code != 403, resp.text


### PR DESCRIPTION
Adds /api/v1/admin/tasks/subscriptions/renew/run; relaxes platform admin guard to allow admin/superuser via is_admin(); asserts OpenAPI exposure; ignores *.local.ps1 smoke scripts.