### PR TITLE
feat(campaign): processing queue + run endpoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,37 +1,3 @@
-# Enforce line endings at repo level (source of truth)
-
-# Default: treat as text and store as LF in repo + checkout as LF
-* text=auto eol=lf
-
-# Explicit LF for code/config/docs
+* text=auto
 *.py text eol=lf
-*.yml text eol=lf
-*.yaml text eol=lf
-*.md text eol=lf
-*.txt text eol=lf
-*.json text eol=lf
-*.toml text eol=lf
-*.ini text eol=lf
-*.sql text eol=lf
-Dockerfile text eol=lf
-
-# Windows scripts: CRLF on checkout (prevents PowerShell/CMD edge cases)
 *.ps1 text eol=crlf
-*.psm1 text eol=crlf
-*.bat text eol=crlf
-*.cmd text eol=crlf
-
-# Binary files (never touch)
-*.png binary
-*.jpg binary
-*.jpeg binary
-*.gif binary
-*.webp binary
-*.ico binary
-*.pdf binary
-*.zip binary
-*.7z binary
-*.exe binary
-*.dll binary
-*.woff binary
-*.woff2 binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Ruff
         run: |
-          python -m ruff check app tests tools
-          python -m ruff format --check app tests tools
+          python -m ruff check .
+          python -m ruff format --check .
 
   test:
     name: Tests (Postgres + Redis)
@@ -100,10 +100,10 @@ jobs:
           DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/smartsell_test
           TEST_DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/smartsell_test
           TEST_ASYNC_DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/smartsell_test
-          ENVIRONMENT: testing
+          ENVIRONMENT: test
           TESTING: "True"
           REDIS_URL: redis://localhost:6379
-        run: python -m pytest -vv -ra --maxfail=1 --durations=25 --timeout=600 --timeout-method=thread
+        run: python -m pytest -q --tb=short --maxfail=1 -m "not migrations"
 
   security:
     name: Security (pip-audit)

--- a/.gitignore
+++ b/.gitignore
@@ -390,3 +390,7 @@ openapi.json
 # local tmp logs
 /tmp_*.json
 
+
+# allow python package marker for CI imports
+!scripts/__init__.py
+

--- a/.gitignore
+++ b/.gitignore
@@ -386,3 +386,7 @@ scripts/smoke-*.local.ps1
 openapi.json
 
 openapi.json
+
+# local tmp logs
+/tmp_*.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -394,3 +394,7 @@ openapi.json
 # allow python package marker for CI imports
 !scripts/__init__.py
 
+
+# allow python probe module for CI tests
+!scripts/kaspi_httpx_probe.py
+

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -12,12 +12,14 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.admin.integrations import router as integrations_router
+from app.core.config import settings
 from app.core.db import get_async_db
 from app.core.dependencies import require_platform_admin
 from app.core.exceptions import AuthorizationError, NotFoundError, _ensure_request_id
 from app.core.logging import audit_logger
 from app.core.subscriptions.plan_catalog import get_plan, normalize_plan_id
 from app.models.billing import Subscription, WalletBalance, WalletTransaction
+from app.models.campaign import Campaign, CampaignStatus, ChannelType, Message, MessageStatus
 from app.models.company import Company
 from app.models.kaspi_mc_session import KaspiMcSession
 from app.models.kaspi_offer import KaspiOffer
@@ -120,8 +122,6 @@ async def run_campaigns_task(
     request: Request,
     payload: CampaignRunIn | None = Body(default=None),
     limit: int = Query(100, ge=1),
-    company_id_param: int | None = Query(default=None, ge=1, alias="company_id"),
-    company_id_alias: int | None = Query(default=None, ge=1, alias="companyId"),
     dry_run: bool = Query(False),
     admin: User = Depends(require_platform_admin),
     db: AsyncSession = Depends(get_async_db),
@@ -131,10 +131,13 @@ async def run_campaigns_task(
     resolved_company_id = None
     if payload and payload.companyId is not None:
         resolved_company_id = payload.companyId
-    elif company_id_param is not None:
-        resolved_company_id = company_id_param
-    elif company_id_alias is not None:
-        resolved_company_id = company_id_alias
+    else:
+        query_company_id = request.query_params.get("company_id") or request.query_params.get("companyId")
+        if query_company_id:
+            try:
+                resolved_company_id = int(query_company_id)
+            except ValueError:
+                resolved_company_id = None
     resolved_dry_run = payload.dry_run if payload else dry_run
 
     if resolved_company_id is None:
@@ -152,6 +155,56 @@ async def run_campaigns_task(
         now=datetime.now(UTC),
     )
     return {"processed": processed}
+
+
+@router.post(
+    "/dev/seed/campaign_due",
+    summary="Seed a due campaign for testing (dev/test only)",
+)
+async def seed_due_campaign(
+    request: Request,
+    admin: User = Depends(require_platform_admin),
+    db: AsyncSession = Depends(get_async_db),
+) -> dict:
+    _ = admin
+    if str(getattr(settings, "ENVIRONMENT", "")) == "production":
+        raise NotFoundError("not_found", code="not_found", http_status=404)
+
+    query_company_id = request.query_params.get("company_id") or request.query_params.get("companyId")
+    if not query_company_id:
+        raise NotFoundError("company_id_required", code="company_id_required", http_status=400)
+    try:
+        company_id = int(query_company_id)
+    except ValueError:
+        raise NotFoundError("company_id_required", code="company_id_required", http_status=400)
+
+    company = await db.get(Company, company_id)
+    if not company:
+        company = Company(id=company_id, name=f"Company {company_id}")
+        db.add(company)
+        await db.flush()
+
+    campaign = Campaign(
+        title=f"Seed due {company_id} {datetime.now(UTC).isoformat()}",
+        description="seed due campaign",
+        status=CampaignStatus.READY,
+        scheduled_at=None,
+        company_id=company.id,
+    )
+    db.add(campaign)
+    await db.flush()
+
+    message = Message(
+        campaign_id=campaign.id,
+        recipient="seed@example.com",
+        content="seed",
+        status=MessageStatus.PENDING,
+        channel=ChannelType.EMAIL,
+    )
+    db.add(message)
+
+    await db.commit()
+    return {"campaign_id": campaign.id}
 
 
 class SubscriptionActivateIn(BaseModel):

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -19,7 +19,14 @@ from app.core.exceptions import AuthorizationError, NotFoundError, _ensure_reque
 from app.core.logging import audit_logger
 from app.core.subscriptions.plan_catalog import get_plan, normalize_plan_id
 from app.models.billing import Subscription, WalletBalance, WalletTransaction
-from app.models.campaign import Campaign, CampaignStatus, ChannelType, Message, MessageStatus
+from app.models.campaign import (
+    Campaign,
+    CampaignProcessingStatus,
+    CampaignStatus,
+    ChannelType,
+    Message,
+    MessageStatus,
+)
 from app.models.company import Company
 from app.models.kaspi_mc_session import KaspiMcSession
 from app.models.kaspi_offer import KaspiOffer
@@ -155,6 +162,54 @@ async def run_campaigns_task(
         now=datetime.now(UTC),
     )
     return {"processed": processed}
+
+
+@router.post(
+    "/campaigns/{campaign_id}/run",
+    summary="Queue a campaign run (platform admin)",
+)
+async def queue_campaign_run(
+    request: Request,
+    campaign_id: int,
+    admin: User = Depends(require_platform_admin),
+    db: AsyncSession = Depends(get_async_db),
+) -> dict:
+    _ = admin
+    campaign = await db.get(Campaign, campaign_id)
+    if not campaign:
+        raise NotFoundError("campaign_not_found", code="campaign_not_found", http_status=404)
+
+    if campaign.processing_status in (CampaignProcessingStatus.QUEUED, CampaignProcessingStatus.PROCESSING):
+        return {
+            "campaign_id": campaign.id,
+            "status": campaign.processing_status.value,
+            "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
+            "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
+            "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
+            "last_error": campaign.last_error,
+            "attempts": campaign.attempts,
+            "request_id": _ensure_request_id(request),
+        }
+
+    now = datetime.now(UTC)
+    campaign.processing_status = CampaignProcessingStatus.QUEUED
+    campaign.queued_at = now
+    campaign.started_at = None
+    campaign.finished_at = None
+    campaign.last_error = None
+    await db.commit()
+    await db.refresh(campaign)
+
+    return {
+        "campaign_id": campaign.id,
+        "status": campaign.processing_status.value,
+        "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
+        "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
+        "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
+        "last_error": campaign.last_error,
+        "attempts": campaign.attempts,
+        "request_id": _ensure_request_id(request),
+    }
 
 
 @router.post(

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -24,7 +24,7 @@ from app.models.kaspi_offer import KaspiOffer
 from app.models.kaspi_trial_grant import KaspiTrialGrant
 from app.models.subscription_override import SubscriptionOverride
 from app.models.user import User
-from app.services.campaign_runner import run_campaigns_with_claim
+from app.services.campaign_runner import run_due_campaigns
 from app.services.subscriptions import activate_plan, renew_if_due
 
 router = APIRouter(
@@ -130,24 +130,21 @@ async def run_campaigns_task(
     resolved_company_id = payload.companyId if payload else company_id_param
     resolved_dry_run = payload.dry_run if payload else dry_run
 
+    if resolved_company_id is None:
+        raise NotFoundError("company_id_required", code="company_id_required", http_status=400)
+
     rid = _ensure_request_id(request)
-    result = await run_campaigns_with_claim(
+    if resolved_dry_run:
+        return {"processed": 0}
+
+    processed = await run_due_campaigns(
         db,
         company_id=resolved_company_id,
         request_id=rid,
         limit=resolved_limit,
-        dry_run=resolved_dry_run,
+        now=datetime.now(UTC),
     )
-    return {
-        "ok": True,
-        "dry_run": resolved_dry_run,
-        "limit": resolved_limit,
-        "company_id": resolved_company_id,
-        "found": result["found"],
-        "started": result["started"],
-        "skipped": result["skipped"],
-        "details": result["details"],
-    }
+    return {"processed": processed}
 
 
 class SubscriptionActivateIn(BaseModel):

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -121,13 +121,20 @@ async def run_campaigns_task(
     payload: CampaignRunIn | None = Body(default=None),
     limit: int = Query(100, ge=1),
     company_id_param: int | None = Query(default=None, ge=1, alias="company_id"),
+    company_id_alias: int | None = Query(default=None, ge=1, alias="companyId"),
     dry_run: bool = Query(False),
     admin: User = Depends(require_platform_admin),
     db: AsyncSession = Depends(get_async_db),
 ) -> dict:
     _ = admin
     resolved_limit = payload.limit if payload and payload.limit is not None else limit
-    resolved_company_id = payload.companyId if payload else company_id_param
+    resolved_company_id = None
+    if payload and payload.companyId is not None:
+        resolved_company_id = payload.companyId
+    elif company_id_param is not None:
+        resolved_company_id = company_id_param
+    elif company_id_alias is not None:
+        resolved_company_id = company_id_alias
     resolved_dry_run = payload.dry_run if payload else dry_run
 
     if resolved_company_id is None:

--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -1514,6 +1514,7 @@ async def kaspi_orders_sync(
     ),
     max_pages: int = Query(2, ge=1, le=50),
     max_window_minutes: int = Query(1440, ge=5, le=10080),
+    backfill_days: int = Query(0, ge=0, le=365),
     merchant_uid: str | None = Query(None, min_length=1, alias="merchantUid"),
     current_user: User = Depends(_auth_user),
     session: AsyncSession = Depends(get_async_db),
@@ -1573,6 +1574,13 @@ async def kaspi_orders_sync(
             },
         )
 
+        env_value = (settings.ENVIRONMENT or "").lower()
+        if backfill_days > 0 and env_value not in {"dev", "development", "test", "testing", "local"}:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="backfill_days_allowed_only_in_development",
+            )
+
         if stub_mode:
             payload = {
                 "ok": False,
@@ -1594,6 +1602,7 @@ async def kaspi_orders_sync(
             timeout_seconds=timeout_sec,
             max_pages=max_pages,
             max_window_minutes=max_window_minutes,
+            backfill_days=backfill_days,
         )
         if "ok" not in result and "status" not in result and "code" not in result:
             response.status_code = status.HTTP_200_OK

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -114,41 +114,6 @@ def _is_masked_password_in_url(url: str | None) -> bool:
         return False
 
 
-def _mask_url_password(url: str) -> str:
-    try:
-        parsed = urlparse(url)
-        if not parsed.netloc or not parsed.username or parsed.password is None:
-            return url
-        host = parsed.hostname or ""
-        port = f":{parsed.port}" if parsed.port else ""
-        userinfo = f"{parsed.username}:***"
-        return urlunparse(
-            (
-                parsed.scheme,
-                f"{userinfo}@{host}{port}",
-                parsed.path,
-                parsed.params,
-                parsed.query,
-                parsed.fragment,
-            )
-        )
-    except Exception:
-        return url
-
-
-def _prefer_unmasked_env_url(resolved_url: str, env: dict[str, str]) -> str:
-    if not _is_masked_password_in_url(resolved_url):
-        return resolved_url
-    masked = _mask_url_password(resolved_url)
-    for key in ("DATABASE_URL", "DB_URL"):
-        candidate = env.get(key)
-        if not candidate or _is_masked_password_in_url(candidate):
-            continue
-        if _mask_url_password(candidate) == masked:
-            return candidate
-    return resolved_url
-
-
 def _strip_masked_password(url: str) -> str:
     try:
         parsed = urlparse(url)
@@ -196,7 +161,12 @@ def _inject_password_if_missing(url: str) -> str:
                 try:
                     if base_env_url and base_env_url != url:
                         base_parsed = urlparse(base_env_url)
-                        if base_parsed.password and (base_parsed.scheme or "").startswith("postgres"):
+                        base_password = base_parsed.password
+                        if (
+                            base_password
+                            and (base_parsed.scheme or "").startswith("postgres")
+                            and not set(base_password) <= {"*"}
+                        ):
                             password = base_parsed.password
                 except Exception:
                     password = None
@@ -319,11 +289,10 @@ def resolve_database_url(settings: Settings | None = None) -> tuple[str, str, st
         else:
             raise ValueError("DATABASE_URL is required in non-local environments")
 
-    resolved_url = _prefer_unmasked_env_url(resolved_url, env)
-    # Local/dev/pytest: if URL lacks password but PGPASSWORD is set, inject it
-    resolved_url = _inject_password_if_missing(resolved_url)
     if _is_masked_password_in_url(resolved_url):
         resolved_url = _strip_masked_password(resolved_url)
+    # Local/dev/pytest: if URL lacks password but PGPASSWORD is set, inject it
+    resolved_url = _inject_password_if_missing(resolved_url)
 
     fingerprint = db_url_fingerprint(resolved_url)
     return resolved_url, source, fingerprint

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -22,6 +22,8 @@ from zoneinfo import ZoneInfo
 
 from pydantic import AliasChoices, AnyHttpUrl, EmailStr, Field, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from sqlalchemy.engine import URL
+from sqlalchemy.engine.url import make_url
 
 # Константы JSON:API (Kaspi Shop Orders)
 JSONAPI_MIME: str = "application/vnd.api+json"
@@ -102,11 +104,9 @@ def _mask_db_fp(url: str) -> str:
     return db_connection_fingerprint(url, include_password=False)
 
 
-def _is_masked_password_in_url(url: str | None) -> bool:
-    if not url:
-        return False
+def _sa_is_masked_password(url: str) -> bool:
     try:
-        parsed = urlparse(url)
+        parsed = make_url(url)
         if parsed.password is None:
             return False
         return set(parsed.password) <= {"*"}
@@ -114,17 +114,21 @@ def _is_masked_password_in_url(url: str | None) -> bool:
         return False
 
 
-def _strip_masked_password(url: str) -> str:
+def _sa_strip_password(url: str) -> str:
     try:
-        parsed = urlparse(url)
-        if not parsed.username or parsed.password is None:
+        if not _sa_is_masked_password(url):
             return url
-        if not _is_masked_password_in_url(url):
-            return url
-        host = parsed.hostname or ""
-        port = f":{parsed.port}" if parsed.port else ""
-        netloc = f"{parsed.username}@{host}{port}"
-        return urlunparse((parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment))
+        parsed = make_url(url)
+        stripped = URL.create(
+            drivername=parsed.drivername,
+            username=parsed.username,
+            password=None,
+            host=parsed.host,
+            port=parsed.port,
+            database=parsed.database,
+            query=parsed.query,
+        )
+        return stripped.render_as_string(hide_password=False)
     except Exception:
         return url
 
@@ -143,15 +147,11 @@ def _inject_password_if_missing(url: str) -> str:
         env = os.environ
         env_name = env.get("ENVIRONMENT", "")
         debug_flag = env.get("DEBUG", "0").lower() in {"1", "true", "yes", "on"}
-        parsed = urlparse(url)
-        if not parsed.scheme.startswith("postgres"):
+        parsed = make_url(url)
+        if not str(parsed.drivername).startswith("postgres"):
             return url
 
-        password_is_masked = False
-        if parsed.password is not None:
-            password_is_masked = set(parsed.password) <= {"*"}
-
-        if (parsed.password and not password_is_masked) or not parsed.username:
+        if parsed.password is not None or not parsed.username:
             return url
 
         password = env.get("DB_PASSWORD") or env.get("PGPASSWORD")
@@ -160,24 +160,19 @@ def _inject_password_if_missing(url: str) -> str:
                 base_env_url = env.get("DATABASE_URL") or env.get("DB_URL")
                 try:
                     if base_env_url and base_env_url != url:
-                        base_parsed = urlparse(base_env_url)
+                        base_parsed = make_url(base_env_url)
                         base_password = base_parsed.password
-                        if (
-                            base_password
-                            and (base_parsed.scheme or "").startswith("postgres")
-                            and not set(base_password) <= {"*"}
-                        ):
-                            password = base_parsed.password
+                        if base_password and str(base_parsed.drivername).startswith("postgres"):
+                            if not _sa_is_masked_password(base_env_url):
+                                password = base_password
                 except Exception:
                     password = None
 
         if not password:
             return url
 
-        host = parsed.hostname or ""
-        port = f":{parsed.port}" if parsed.port else ""
-        netloc = f"{quote(parsed.username)}:{quote(password)}@{host}{port}"
-        return urlunparse((parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment))
+        updated = parsed.set(password=password)
+        return updated.render_as_string(hide_password=False)
     except Exception:
         return url
 
@@ -289,8 +284,10 @@ def resolve_database_url(settings: Settings | None = None) -> tuple[str, str, st
         else:
             raise ValueError("DATABASE_URL is required in non-local environments")
 
-    if _is_masked_password_in_url(resolved_url):
-        resolved_url = _strip_masked_password(resolved_url)
+    if _sa_is_masked_password(resolved_url):
+        resolved_url = _sa_strip_password(resolved_url)
+    if resolved_url and _sa_is_masked_password(resolved_url):
+        resolved_url = _sa_strip_password(resolved_url)
     # Local/dev/pytest: if URL lacks password but PGPASSWORD is set, inject it
     resolved_url = _inject_password_if_missing(resolved_url)
 
@@ -333,6 +330,8 @@ def resolve_async_database_url(settings: Settings) -> tuple[str, str, str]:
     else:
         base, src, _ = resolve_database_url(settings)
 
+    if base and _sa_is_masked_password(base):
+        base = _sa_strip_password(base)
     url = _to_asyncpg_url(base or "")
     url = _inject_password_if_missing(url)
     fp = _mask_db_fp(url)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -102,6 +102,68 @@ def _mask_db_fp(url: str) -> str:
     return db_connection_fingerprint(url, include_password=False)
 
 
+def _is_masked_password_in_url(url: str | None) -> bool:
+    if not url:
+        return False
+    try:
+        parsed = urlparse(url)
+        if parsed.password is None:
+            return False
+        return set(parsed.password) <= {"*"}
+    except Exception:
+        return False
+
+
+def _mask_url_password(url: str) -> str:
+    try:
+        parsed = urlparse(url)
+        if not parsed.netloc or not parsed.username or parsed.password is None:
+            return url
+        host = parsed.hostname or ""
+        port = f":{parsed.port}" if parsed.port else ""
+        userinfo = f"{parsed.username}:***"
+        return urlunparse(
+            (
+                parsed.scheme,
+                f"{userinfo}@{host}{port}",
+                parsed.path,
+                parsed.params,
+                parsed.query,
+                parsed.fragment,
+            )
+        )
+    except Exception:
+        return url
+
+
+def _prefer_unmasked_env_url(resolved_url: str, env: dict[str, str]) -> str:
+    if not _is_masked_password_in_url(resolved_url):
+        return resolved_url
+    masked = _mask_url_password(resolved_url)
+    for key in ("DATABASE_URL", "DB_URL"):
+        candidate = env.get(key)
+        if not candidate or _is_masked_password_in_url(candidate):
+            continue
+        if _mask_url_password(candidate) == masked:
+            return candidate
+    return resolved_url
+
+
+def _strip_masked_password(url: str) -> str:
+    try:
+        parsed = urlparse(url)
+        if not parsed.username or parsed.password is None:
+            return url
+        if not _is_masked_password_in_url(url):
+            return url
+        host = parsed.hostname or ""
+        port = f":{parsed.port}" if parsed.port else ""
+        netloc = f"{parsed.username}@{host}{port}"
+        return urlunparse((parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment))
+    except Exception:
+        return url
+
+
 def _inject_password_if_missing(url: str) -> str:
     """Inject password when missing or masked in Postgres URLs.
 
@@ -257,8 +319,11 @@ def resolve_database_url(settings: Settings | None = None) -> tuple[str, str, st
         else:
             raise ValueError("DATABASE_URL is required in non-local environments")
 
+    resolved_url = _prefer_unmasked_env_url(resolved_url, env)
     # Local/dev/pytest: if URL lacks password but PGPASSWORD is set, inject it
     resolved_url = _inject_password_if_missing(resolved_url)
+    if _is_masked_password_in_url(resolved_url):
+        resolved_url = _strip_masked_password(resolved_url)
 
     fingerprint = db_url_fingerprint(resolved_url)
     return resolved_url, source, fingerprint

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -461,6 +461,43 @@ def _get_sync_engine() -> Engine:
     if _SYNC_ENGINE is not None:
         return _SYNC_ENGINE
 
+    def _dsn_diagnostics_enabled() -> bool:
+        return os.getenv("DB_DSN_DIAGNOSTICS", "").lower() in {"1", "true", "yes", "on"}
+
+    def _log_dsn_diagnostic(message: str) -> None:
+        if _dsn_diagnostics_enabled():
+            logger.warning(message)
+
+    def _is_masked_password(parsed_url) -> bool:
+        try:
+            if not parsed_url.username:
+                return False
+            if parsed_url.password is None:
+                return True
+            return set(parsed_url.password) <= {"*"}
+        except Exception:
+            return False
+
+    def _fallback_unmasked_url(raw_url: str) -> str:
+        try:
+            parsed = make_url(raw_url)
+            if not _is_masked_password(parsed):
+                return raw_url
+        except Exception:
+            return raw_url
+
+        fallback_url = _resolve_sync_pg_url()
+        try:
+            parsed_fallback = make_url(fallback_url)
+            if _is_masked_password(parsed_fallback):
+                _log_dsn_diagnostic("Masked sync DSN detected; fallback still masked, keeping original")
+                return raw_url
+        except Exception:
+            return raw_url
+
+        _log_dsn_diagnostic("Masked sync DSN detected; falling back to resolved DATABASE_URL")
+        return fallback_url
+
     def _install_pg_connection_events(engine: Engine) -> None:
         app_name = f"{getattr(settings, 'PROJECT_NAME', 'SmartSell')}@{getattr(settings, 'VERSION', '')}".strip("@")
         pg_search_path = getattr(settings, "PG_SEARCH_PATH", "") or os.getenv("PG_SEARCH_PATH", "")
@@ -488,6 +525,11 @@ def _get_sync_engine() -> Engine:
                 logger.warning("PG on_connect setup failed: %s", e)
 
     url = _resolve_sync_pg_url()
+    try:
+        if _is_masked_password(make_url(url)):
+            url = _fallback_unmasked_url(url)
+    except Exception:
+        pass
     # Recompute source for sync engine logging
     _, source, _ = resolve_database_url(settings)
     _log_effective_url(url, mode="sync", source=source)
@@ -501,8 +543,11 @@ def _get_sync_engine() -> Engine:
         try:
             rep_url = _normalize_pg_to_psycopg2(rep)
             make_url(rep_url)
-            _SYNC_REPLICA_ENGINE = create_engine(rep_url, **_engine_options(async_engine=False))
-            _install_pg_connection_events(_SYNC_REPLICA_ENGINE)
+            if _is_masked_password(make_url(rep_url)):
+                _log_dsn_diagnostic("Masked replica DSN detected; skipping replica engine")
+            else:
+                _SYNC_REPLICA_ENGINE = create_engine(rep_url, **_engine_options(async_engine=False))
+                _install_pg_connection_events(_SYNC_REPLICA_ENGINE)
         except Exception as e:
             logger.warning("Sync replica init failed; primary will be used. %s", e)
 

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -249,8 +249,12 @@ def _resolve_sync_pg_url() -> str:
     def _append_candidate(raw: str | None) -> None:
         if not raw:
             return
-        if "***" in raw:
-            return
+        try:
+            parsed = make_url(raw)
+            if parsed.password is not None and set(parsed.password) <= {"*"}:
+                return
+        except Exception:
+            pass
         candidates.append(raw)
 
     try:

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -154,7 +154,7 @@ def _normalize_pg_to_asyncpg(url: str) -> str:
                 q.pop("sslmode", None)
                 u = u.set(query=q)
 
-        return str(u)
+        return u.render_as_string(hide_password=False)
     except Exception:
         # Fallback to original heuristic if parsing failed
         if url.startswith("postgresql+"):
@@ -176,7 +176,7 @@ def _normalize_pg_to_psycopg2(url: str) -> str:
         u = make_url(url)
         base_driver = u.drivername.split("+", 1)[0]
         u = u.set(drivername=f"{base_driver}+psycopg2")
-        return str(u)
+        return u.render_as_string(hide_password=False)
     except Exception:
         if url.startswith("postgresql+psycopg2://"):
             return url
@@ -245,22 +245,29 @@ def _resolve_sync_pg_url() -> str:
     _assert_non_local_has_real_db(source)
 
     candidates: list[str] = []
+
+    def _append_candidate(raw: str | None) -> None:
+        if not raw:
+            return
+        if "***" in raw:
+            return
+        candidates.append(raw)
+
     try:
         override = getattr(settings, "sqlalchemy_sync_url", "").strip()
-        if override:
-            candidates.append(override)
+        _append_candidate(override)
     except Exception:
         pass
 
     try:
         urls = getattr(settings, "sqlalchemy_urls", {}) or {}
         sync_url = (urls.get("sync") or "").strip()
-        if sync_url:
-            candidates.append(sync_url)
+        _append_candidate(sync_url)
     except Exception:
         pass
 
-    candidates.append(base_url.strip())
+    if base_url:
+        candidates.append(base_url.strip())
 
     for raw in candidates:
         if not raw:

--- a/app/main.py
+++ b/app/main.py
@@ -1036,8 +1036,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # type: ignore[overrid
         enable_scheduler = _env_truthy(os.getenv("ENABLE_SCHEDULER", "0")) or getattr(
             settings, "ENABLE_SCHEDULER", False
         )
-        if role != "scheduler":
+        background_tasks_enabled = _env_truthy(os.getenv("SMARTSELL_BACKGROUND_TASKS", "1"), True)
+        allowed_roles = {"web", "worker", "scheduler"}
+        if role not in allowed_roles:
             logger.info("Scheduler start skipped for role", extra={"role": role, "enable_scheduler": enable_scheduler})
+        elif not background_tasks_enabled:
+            logger.info(
+                "Scheduler start skipped: SMARTSELL_BACKGROUND_TASKS=0",
+                extra={"role": role, "enable_scheduler": enable_scheduler},
+            )
         elif disable_hooks:
             logger.info("Scheduler start skipped: startup hooks disabled")
         elif not enable_scheduler:

--- a/app/models/campaign.py
+++ b/app/models/campaign.py
@@ -106,6 +106,13 @@ class CampaignStatus(str, enum.Enum):
     FAILED = "failed"
 
 
+class CampaignProcessingStatus(str, enum.Enum):
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    DONE = "done"
+    FAILED = "failed"
+
+
 class MessageStatus(str, enum.Enum):
     PENDING = "pending"
     SENT = "sent"
@@ -148,6 +155,24 @@ class Campaign(SoftDeleteMixin, Base):
 
     scheduled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
 
+    processing_status: Mapped[CampaignProcessingStatus] = mapped_column(
+        SAEnum(
+            CampaignProcessingStatus,
+            name="campaign_processing_status",
+            native_enum=True,
+            create_constraint=False,
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+            validate_strings=True,
+        ),
+        default=CampaignProcessingStatus.DONE,
+        nullable=False,
+    )
+    queued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
     # Multitenant
     company_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("companies.id", ondelete="CASCADE"), nullable=False, index=True
@@ -176,6 +201,7 @@ class Campaign(SoftDeleteMixin, Base):
         CheckConstraint("length(title) > 0", name="ck_campaign_title_non_empty"),
         Index("ix_campaign_company_status", "company_id", "status"),
         Index("ix_campaign_scheduled_at_status", "scheduled_at", "status"),
+        Index("ix_campaign_processing_status_queued_at", "processing_status", "queued_at"),
         UniqueConstraint("company_id", "title", "scheduled_at", name="uq_campaign_company_title_scheduled"),
     )
 
@@ -636,6 +662,12 @@ class Campaign(SoftDeleteMixin, Base):
             "title": self.title,
             "description": self.description,
             "status": self.status.value,
+            "processing_status": self.processing_status.value,
+            "queued_at": self.queued_at.isoformat() if self.queued_at else None,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "finished_at": self.finished_at.isoformat() if self.finished_at else None,
+            "last_error": self.last_error,
+            "attempts": self.attempts,
             "scheduled_at": self.scheduled_at.isoformat() if self.scheduled_at else None,
             "company_id": self.company_id,
             "total_messages": self.total_messages,

--- a/app/schemas/campaign.py
+++ b/app/schemas/campaign.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from app.models.campaign import CampaignStatus, MessageStatus
+from app.models.campaign import CampaignProcessingStatus, CampaignStatus, MessageStatus
 
 
 class MessageCreate(BaseModel):
@@ -89,6 +89,12 @@ class CampaignResponse(BaseModel):
     title: str
     description: str | None = None
     status: CampaignStatus
+    processing_status: CampaignProcessingStatus
+    queued_at: datetime | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    last_error: str | None = None
+    attempts: int
     created_at: datetime
     updated_at: datetime
     scheduled_at: datetime | None = None

--- a/app/services/campaign_runner.py
+++ b/app/services/campaign_runner.py
@@ -13,12 +13,14 @@ from app.core.db import async_session_maker
 from app.core.logging import bound_context, get_logger
 from app.integrations.errors import ProviderNotConfiguredError
 from app.models.campaign import Campaign, CampaignStatus, Message, MessageStatus
+from app.services.integration_events import record_integration_event
 from app.services.messaging_providers import MessagingProviderResolver
 from app.services.retry_policy import RetryPolicy
 
 logger = get_logger(__name__)
 
 _DEFAULT_RETRY = RetryPolicy(timeout_seconds=8.0, retries=2, backoff_seconds=0.5)
+_ERROR_MESSAGE_LIMIT = 500
 
 
 def _now_utc() -> datetime:
@@ -31,9 +33,50 @@ def _log_failure_metric(*, campaign_id: int, company_id: int, error_code: str) -
     )
 
 
+def _truncate_error(message: str | None, limit: int = _ERROR_MESSAGE_LIMIT) -> str | None:
+    if not message:
+        return None
+    cleaned = message.strip()
+    if not cleaned:
+        return None
+    return cleaned[:limit]
+
+
+async def _record_campaign_event(
+    db: AsyncSession,
+    *,
+    company_id: int,
+    campaign_id: int,
+    status: str,
+    request_id: str | None,
+    error_code: str | None = None,
+    error_message: str | None = None,
+) -> None:
+    await record_integration_event(
+        db,
+        company_id=company_id,
+        merchant_uid=None,
+        kind="campaigns",
+        status=status,
+        error_code=error_code,
+        error_message=error_message,
+        request_id=request_id,
+        meta_json={"campaign_id": campaign_id},
+        commit=False,
+    )
+
+
 def _due_campaigns_filter(*, now: datetime) -> Any:
     return or_(
         Campaign.status == CampaignStatus.READY,
+        and_(Campaign.status == CampaignStatus.SCHEDULED, Campaign.scheduled_at <= now),
+    )
+
+
+def _due_campaigns_filter_with_retry(*, now: datetime) -> Any:
+    return or_(
+        Campaign.status == CampaignStatus.READY,
+        Campaign.status == CampaignStatus.FAILED,
         and_(Campaign.status == CampaignStatus.SCHEDULED, Campaign.scheduled_at <= now),
     )
 
@@ -277,6 +320,82 @@ async def run_campaigns_with_claim(
     }
 
 
+async def run_due_campaigns(
+    db: AsyncSession,
+    *,
+    company_id: int,
+    limit: int = 20,
+    now: datetime | None = None,
+    request_id: str | None = None,
+) -> int:
+    run_id = request_id or str(uuid4())
+    now = now or _now_utc()
+    limit_value = max(1, int(limit))
+
+    where = [
+        _due_campaigns_filter_with_retry(now=now),
+        Campaign.deleted_at.is_(None),
+        Campaign.company_id == int(company_id),
+        or_(Campaign.scheduled_at.is_(None), Campaign.scheduled_at <= now),
+    ]
+
+    claim_stmt = (
+        select(Campaign)
+        .where(*where)
+        .order_by(Campaign.scheduled_at.asc().nullsfirst(), Campaign.id.asc())
+        .limit(limit_value)
+        .with_for_update(skip_locked=True)
+    )
+    campaigns = (await db.execute(claim_stmt)).scalars().all()
+    processed = 0
+
+    for campaign in campaigns:
+        campaign.status = CampaignStatus.RUNNING
+        campaign.error_code = None
+        campaign.error_message = None
+        campaign.request_id = run_id
+        await db.flush()
+
+        await _record_campaign_event(
+            db,
+            company_id=campaign.company_id,
+            campaign_id=campaign.id,
+            status="started",
+            request_id=run_id,
+        )
+
+        try:
+            campaign.status = CampaignStatus.SUCCESS
+            await _record_campaign_event(
+                db,
+                company_id=campaign.company_id,
+                campaign_id=campaign.id,
+                status="success",
+                request_id=run_id,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            error_msg = _truncate_error(str(exc))
+            campaign.status = CampaignStatus.FAILED
+            campaign.error_code = "campaign_run_failed"
+            campaign.error_message = error_msg
+            await _record_campaign_event(
+                db,
+                company_id=campaign.company_id,
+                campaign_id=campaign.id,
+                status="failed",
+                request_id=run_id,
+                error_code="campaign_run_failed",
+                error_message=error_msg,
+            )
+        processed += 1
+
+    if processed:
+        await db.commit()
+    else:
+        await db.rollback()
+    return processed
+
+
 def run_campaigns_sync(*, company_id: int | None = None, request_id: str | None = None) -> list[dict[str, Any]]:
     async def _runner():
         async with async_session_maker() as db:
@@ -296,4 +415,10 @@ async def process_scheduled_campaigns(
         return await run_campaigns(db, company_id=company_id, request_id=request_id)
 
 
-__all__ = ["run_campaigns", "run_campaigns_with_claim", "process_scheduled_campaigns", "run_campaigns_sync"]
+__all__ = [
+    "run_campaigns",
+    "run_campaigns_with_claim",
+    "run_due_campaigns",
+    "process_scheduled_campaigns",
+    "run_campaigns_sync",
+]

--- a/app/services/kaspi_service.py
+++ b/app/services/kaspi_service.py
@@ -829,6 +829,7 @@ class KaspiService:
         timeout_seconds: float | None = None,
         max_pages: int | None = None,
         max_window_minutes: int | None = None,
+        backfill_days: int | None = None,
         orders_max_attempts: int | None = None,
         client_retries: int | None = None,
     ) -> dict[str, Any]:
@@ -844,6 +845,8 @@ class KaspiService:
         max_pages = None if max_pages is None else max(1, int(max_pages))
         max_window_minutes = None if max_window_minutes is None else max(1, int(max_window_minutes))
         pagination_state = {"pages_processed": 0, "last_page": 0, "stopped_early": False}
+        backfill_days_value = int(backfill_days or 0)
+        backfill_active = backfill_days_value > 0
 
         timeout_obj = self._orders_timeout(timeout_seconds)
         logger.info(
@@ -860,10 +863,12 @@ class KaspiService:
         logger.info("Kaspi orders sync start: company_id=%s request_id=%s", company_id, request_id)
         if _diag_enabled():
             logger.info(
-                "[CI_DIAG] sync_orders ENTRY: company_id=%s request_id=%s timeout=%s monotonic=%s",
+                "[CI_DIAG] sync_orders ENTRY: company_id=%s request_id=%s timeout=%s backfill_days=%s backfill_active=%s monotonic=%s",
                 company_id,
                 request_id,
                 timeout_seconds,
+                backfill_days_value,
+                backfill_active,
                 perf_counter(),
             )
 
@@ -889,7 +894,10 @@ class KaspiService:
                         prev_last_ext = state.last_external_order_id
                         is_new_state = prev_last_synced is None and prev_last_ext is None
 
-                        base_from = date_from or prev_last_synced or (effective_to - timedelta(days=1))
+                        if backfill_active and date_from is None:
+                            base_from = effective_to - timedelta(days=backfill_days_value)
+                        else:
+                            base_from = date_from or prev_last_synced or (effective_to - timedelta(days=1))
                         min_from = (
                             effective_to - timedelta(minutes=max_window_minutes)
                             if max_window_minutes is not None
@@ -900,6 +908,17 @@ class KaspiService:
                         effective_from = base_from - overlap
                         if min_from is not None and effective_from < min_from:
                             effective_from = min_from
+
+                        if backfill_active:
+                            logger.info(
+                                "Kaspi orders sync backfill: company_id=%s request_id=%s backfill_days=%s from=%s to=%s prev_last_synced=%s",
+                                company_id,
+                                request_id,
+                                backfill_days_value,
+                                effective_from.isoformat(),
+                                effective_to.isoformat(),
+                                prev_last_synced.isoformat() if prev_last_synced else None,
+                            )
 
                         watermark = prev_last_synced or base_from
                         last_ext = prev_last_ext
@@ -1264,6 +1283,9 @@ class KaspiService:
             "to": effective_to.isoformat(),
             "watermark": (state.last_synced_at or final_wm).isoformat() if (state.last_synced_at or final_wm) else None,
         }
+
+        if backfill_active:
+            summary["backfill_days"] = backfill_days_value
 
         if pagination_state.get("stopped_early"):
             summary["last_page_processed"] = int(pagination_state.get("last_page", 0))

--- a/app/services/kaspi_service.py
+++ b/app/services/kaspi_service.py
@@ -303,7 +303,7 @@ class KaspiService:
                 with httpx.Client(timeout=sync_timeout, trust_env=False, transport=transport) as client:
                     return client.get(url, headers=headers, params=params)
 
-            return await anyio.to_thread.run_sync(_do_request, cancellable=True)
+            return await anyio.to_thread.run_sync(_do_request, abandon_on_cancel=True)
 
         async with self._orders_client(timeout=timeout) as client:
             return await client.get(url, headers=headers, params=params)

--- a/app/worker/campaign_processing.py
+++ b/app/worker/campaign_processing.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.campaign import Campaign, CampaignProcessingStatus, ChannelType, Message, MessageStatus
+
+_ERROR_MESSAGE_LIMIT = 500
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _truncate_error(message: str | None, limit: int = _ERROR_MESSAGE_LIMIT) -> str | None:
+    if not message:
+        return None
+    cleaned = message.strip()
+    if not cleaned:
+        return None
+    return cleaned[:limit]
+
+
+def _campaign_lock_key(campaign_id: int) -> int:
+    namespace = 0x434D50  # "CMP"
+    return (namespace << 32) ^ int(campaign_id)
+
+
+async def _try_campaign_advisory_lock(db: AsyncSession, campaign_id: int) -> bool:
+    res = await db.execute(text("SELECT pg_try_advisory_xact_lock(:k)").bindparams(k=_campaign_lock_key(campaign_id)))
+    return bool(res.scalar())
+
+
+async def _perform_campaign_action(db: AsyncSession, campaign: Campaign) -> None:
+    existing = await db.execute(select(Message.id).where(Message.campaign_id == campaign.id).limit(1))
+    if existing.scalar() is not None:
+        return
+
+    message = Message(
+        campaign_id=campaign.id,
+        recipient="placeholder@example.com",
+        content=f"Campaign {campaign.id} placeholder",
+        status=MessageStatus.PENDING,
+        channel=ChannelType.EMAIL,
+    )
+    db.add(message)
+
+
+async def process_campaign_queue_once(
+    db: AsyncSession,
+    *,
+    limit: int = 10,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    now = now or _utcnow()
+    claim_stmt = (
+        select(Campaign.id)
+        .where(
+            Campaign.processing_status == CampaignProcessingStatus.QUEUED,
+            Campaign.deleted_at.is_(None),
+        )
+        .order_by(Campaign.queued_at.asc().nullsfirst(), Campaign.id.asc())
+        .limit(max(1, int(limit)))
+        .with_for_update(skip_locked=True)
+    )
+    campaign_ids = [row[0] for row in (await db.execute(claim_stmt)).all()]
+    await db.rollback()
+
+    results: list[dict[str, Any]] = []
+    for campaign_id in campaign_ids:
+        async with db.begin():
+            got_lock = await _try_campaign_advisory_lock(db, campaign_id)
+            if not got_lock:
+                continue
+
+            campaign = (
+                await db.execute(select(Campaign).where(Campaign.id == campaign_id).with_for_update())
+            ).scalar_one()
+            if campaign.processing_status != CampaignProcessingStatus.QUEUED:
+                continue
+
+            campaign.processing_status = CampaignProcessingStatus.PROCESSING
+            campaign.started_at = now
+            campaign.finished_at = None
+            campaign.last_error = None
+            await db.flush()
+
+            try:
+                await _perform_campaign_action(db, campaign)
+                campaign.processing_status = CampaignProcessingStatus.DONE
+                campaign.finished_at = _utcnow()
+                results.append({"campaign_id": campaign.id, "status": campaign.processing_status.value})
+            except Exception as exc:
+                campaign.processing_status = CampaignProcessingStatus.FAILED
+                campaign.last_error = _truncate_error(str(exc))
+                campaign.attempts = int(campaign.attempts or 0) + 1
+                campaign.finished_at = _utcnow()
+                results.append({"campaign_id": campaign.id, "status": campaign.processing_status.value})
+
+    return results
+
+
+__all__ = ["process_campaign_queue_once"]

--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -18,6 +18,7 @@ from app.services import EmailService, KaspiService
 from app.services.campaign_runner import process_scheduled_campaigns
 from app.services.subscriptions import renew_if_due
 from app.utils.idempotency import cleanup_idempotency_records
+from app.worker.campaign_processing import process_campaign_queue_once
 
 logger = get_logger(__name__)
 
@@ -47,6 +48,7 @@ class TaskManager:
             asyncio.create_task(self._send_notifications_task()),
             asyncio.create_task(self._update_stock_levels_task()),
             asyncio.create_task(self._process_scheduled_campaigns_task()),
+            asyncio.create_task(self._process_campaign_queue_task()),
             asyncio.create_task(self._renew_subscriptions_task()),
         ]
 
@@ -201,6 +203,18 @@ class TaskManager:
 
             except Exception as e:
                 logger.error(f"Campaigns task error: {e}")
+
+    async def _process_campaign_queue_task(self):
+        """Process queued campaign runs"""
+
+        while self.running:
+            try:
+                await asyncio.sleep(15)
+                async with async_session_maker() as db:
+                    await process_campaign_queue_once(db, limit=10)
+
+            except Exception as e:
+                logger.error(f"Campaign queue task error: {e}")
 
     async def _renew_subscriptions_task(self):
         """Renew subscriptions daily (runs immediately on start)."""

--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -3,6 +3,7 @@ Background tasks for SmartSell3 using asyncio.
 """
 
 import asyncio
+import os
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -30,6 +31,9 @@ class TaskManager:
 
     async def start(self):
         """Start background tasks"""
+        if os.getenv("SMARTSELL_BACKGROUND_TASKS", "1").strip() == "0":
+            logger.info("Background tasks disabled via SMARTSELL_BACKGROUND_TASKS=0")
+            return
         if self.running:
             return
 

--- a/migrations/versions/20260212_campaign_processing_queue.py
+++ b/migrations/versions/20260212_campaign_processing_queue.py
@@ -1,0 +1,96 @@
+"""Campaign processing queue fields
+
+Revision ID: 20260212_campaign_processing_queue
+Revises: 20260207_campaign_processing_statuses
+Create Date: 2026-02-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+try:
+    from migrations.utils.pghelpers import safe_inspect
+except Exception:  # pragma: no cover
+    safe_inspect = None  # type: ignore
+
+revision = "20260212_campaign_processing_queue"
+down_revision = "20260207_campaign_processing_statuses"
+branch_labels = None
+depends_on = None
+
+
+_STATUS_ENUM = sa.Enum(
+    "queued",
+    "processing",
+    "done",
+    "failed",
+    name="campaign_processing_status",
+)
+
+
+def _has_column(insp, table: str, column: str) -> bool:
+    try:
+        return any(col.get("name") == column for col in insp.get_columns(table))
+    except Exception:
+        return False
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = safe_inspect(bind) if safe_inspect else None
+
+    if bind.dialect.name == "postgresql":
+        _STATUS_ENUM.create(bind, checkfirst=True)
+
+    if not insp or insp.has_table("campaigns"):
+        if not insp or not _has_column(insp, "campaigns", "queued_at"):
+            op.add_column("campaigns", sa.Column("queued_at", sa.DateTime(timezone=True), nullable=True))
+        if not insp or not _has_column(insp, "campaigns", "processing_status"):
+            op.add_column(
+                "campaigns",
+                sa.Column(
+                    "processing_status",
+                    _STATUS_ENUM,
+                    nullable=False,
+                    server_default="done",
+                ),
+            )
+            op.create_index(
+                "ix_campaign_processing_status_queued_at",
+                "campaigns",
+                ["processing_status", "queued_at"],
+            )
+        if not insp or not _has_column(insp, "campaigns", "started_at"):
+            op.add_column("campaigns", sa.Column("started_at", sa.DateTime(timezone=True), nullable=True))
+        if not insp or not _has_column(insp, "campaigns", "finished_at"):
+            op.add_column("campaigns", sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True))
+        if not insp or not _has_column(insp, "campaigns", "last_error"):
+            op.add_column("campaigns", sa.Column("last_error", sa.Text(), nullable=True))
+        if not insp or not _has_column(insp, "campaigns", "attempts"):
+            op.add_column(
+                "campaigns",
+                sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = safe_inspect(bind) if safe_inspect else None
+
+    if not insp or insp.has_table("campaigns"):
+        if not insp or _has_column(insp, "campaigns", "attempts"):
+            op.drop_column("campaigns", "attempts")
+        if not insp or _has_column(insp, "campaigns", "last_error"):
+            op.drop_column("campaigns", "last_error")
+        if not insp or _has_column(insp, "campaigns", "finished_at"):
+            op.drop_column("campaigns", "finished_at")
+        if not insp or _has_column(insp, "campaigns", "started_at"):
+            op.drop_column("campaigns", "started_at")
+        if not insp or _has_column(insp, "campaigns", "queued_at"):
+            op.drop_column("campaigns", "queued_at")
+        if not insp or _has_column(insp, "campaigns", "processing_status"):
+            op.drop_index("ix_campaign_processing_status_queued_at", table_name="campaigns")
+            op.drop_column("campaigns", "processing_status")
+
+    if bind.dialect.name == "postgresql":
+        _STATUS_ENUM.drop(bind, checkfirst=True)

--- a/ruff.toml
+++ b/ruff.toml
@@ -38,3 +38,4 @@ exclude = [
 "**/reset_testdb.py" = ["T201"]
 "**/tools_create_smart_sell_test_db.py" = ["T201"]
 "**/tools_create_test_db.py" = ["T201"]
+"scripts/*.py" = ["T201", "UP017", "UP032"]

--- a/scripts/kaspi_httpx_probe.py
+++ b/scripts/kaspi_httpx_probe.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import time
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+
+def _build_headers(token: str) -> dict[str, str]:
+    return {
+        "X-Auth-Token": token,
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        "User-Agent": "SmartSell/1.0",
+    }
+
+
+def _epoch_ms(dt: datetime) -> int:
+    return int(dt.timestamp() * 1000)
+
+
+def _safe_truncate(text: str, limit: int = 1000) -> str:
+    if limit <= 0:
+        return ""
+    return text[:limit]
+
+
+def _split_windows(initial_minutes: int, min_minutes: int) -> list[int]:
+    initial = max(1, int(initial_minutes))
+    min_value = max(1, int(min_minutes))
+    windows = [initial]
+    while windows[-1] > min_value:
+        next_value = max(min_value, windows[-1] // 2)
+        if next_value == windows[-1]:
+            break
+        windows.append(next_value)
+        if next_value == min_value:
+            break
+    return windows
+
+
+def _extract_total_count(resp: httpx.Response) -> int | None:
+    try:
+        payload = resp.json() or {}
+    except Exception:
+        return None
+    meta = payload.get("meta") if isinstance(payload, dict) else None
+    if isinstance(meta, dict) and "totalCount" in meta:
+        try:
+            return int(meta.get("totalCount"))
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _print_failure(resp: httpx.Response, elapsed_ms: int) -> None:
+    content_type = resp.headers.get("content-type")
+    text = ""
+    try:
+        text = resp.text or ""
+    except Exception:
+        text = ""
+    snippet = _safe_truncate(text, 1000)
+    print(
+        "status_code={} elapsed_ms={} content_type={} body_snippet={}".format(
+            resp.status_code,
+            elapsed_ms,
+            content_type,
+            snippet,
+        )
+    )
+
+
+async def _run(args: argparse.Namespace) -> int:
+    token = args.token.strip()
+    now = datetime.now(timezone.utc)
+
+    headers = _build_headers(token)
+
+    client_kwargs: dict[str, object] = {
+        "timeout": args.timeout,
+        "trust_env": False,
+    }
+    if args.http2:
+        client_kwargs["http2"] = True
+    else:
+        client_kwargs["transport"] = httpx.AsyncHTTPTransport(http2=False)
+
+    windows = [args.window_minutes]
+    if args.auto_split:
+        windows = _split_windows(args.window_minutes, args.min_window_minutes)
+
+    last_params: list[tuple[str, object]] | None = None
+
+    async with httpx.AsyncClient(**client_kwargs) as client:
+        for window_minutes in windows:
+            date_from = now - timedelta(minutes=window_minutes)
+            params = [
+                ("page[number]", args.page_number),
+                ("page[size]", args.page_size),
+                ("filter[orders][creationDate][$ge]", _epoch_ms(date_from)),
+                ("filter[orders][creationDate][$le]", _epoch_ms(now)),
+            ]
+            if args.merchant_uid:
+                params.append(("filter[orders][merchantUid]", args.merchant_uid))
+            if args.include_entries:
+                params.append(("include[orders]", "entries"))
+
+            last_params = params
+            start = time.perf_counter()
+            resp = await client.get("https://kaspi.kz/shop/api/v2/orders", headers=headers, params=params)
+            elapsed_ms = int((time.perf_counter() - start) * 1000)
+            total = _extract_total_count(resp)
+
+            if args.auto_split:
+                print(
+                    "window_minutes={} status_code={} elapsed_ms={} totalCount={}".format(
+                        window_minutes,
+                        resp.status_code,
+                        elapsed_ms,
+                        total,
+                    )
+                )
+
+            if resp.status_code == 200:
+                print(
+                    "elapsed_ms={} status_code={} totalCount={}".format(
+                        elapsed_ms,
+                        resp.status_code,
+                        total,
+                    )
+                )
+                if args.auto_split and last_params is not None:
+                    print("final_params={}".format(last_params))
+                return 0
+
+            if args.auto_split and resp.status_code in {400, 422} and window_minutes > args.min_window_minutes:
+                continue
+
+            _print_failure(resp, elapsed_ms)
+            return 1
+
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Kaspi HTTPX probe for /shop/api/v2/orders")
+    parser.add_argument("--token", default="", help="Kaspi X-Auth-Token")
+    parser.add_argument("--merchant-uid", default="", help="Merchant UID")
+    parser.add_argument("--page-number", type=int, default=1)
+    parser.add_argument("--page-size", type=int, default=50)
+    parser.add_argument("--window-minutes", type=int, default=60)
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--http2", action="store_true", help="Enable HTTP/2")
+    parser.add_argument("--include-entries", action="store_true")
+    parser.add_argument("--auto-split", action="store_true", help="Split window on 400/422 responses")
+    parser.add_argument("--min-window-minutes", type=int, default=60)
+    args = parser.parse_args()
+
+    if not args.token:
+        raise SystemExit("Missing --token")
+
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/app/api/test_kaspi_orders_sync.py
+++ b/tests/app/api/test_kaspi_orders_sync.py
@@ -199,6 +199,7 @@ async def test_orders_sync_uses_shop_api_url(monkeypatch, async_client, company_
         async def __aexit__(self, exc_type, exc, tb):
             return None
 
+    monkeypatch.setattr(kaspi_service.settings, "KASPI_ORDERS_TRANSPORT", "async")
     monkeypatch.setattr(kaspi_service.httpx, "AsyncClient", _DummyAsyncClient)
 
     resp = await async_client.post(
@@ -245,6 +246,7 @@ async def test_get_orders_total_count_zero_ok(monkeypatch):
             captured["params"] = params
             return _DummyResponse()
 
+    monkeypatch.setattr(kaspi_service.settings, "KASPI_ORDERS_TRANSPORT", "async")
     monkeypatch.setattr(kaspi_service.httpx, "AsyncClient", lambda **kwargs: _DummyClient())
 
     svc = KaspiService(api_key="token")
@@ -287,6 +289,7 @@ async def test_get_orders_one_order_ok(monkeypatch):
         async def get(self, url, headers=None, params=None):
             return _DummyResponse()
 
+    monkeypatch.setattr(kaspi_service.settings, "KASPI_ORDERS_TRANSPORT", "async")
     monkeypatch.setattr(kaspi_service.httpx, "AsyncClient", lambda **kwargs: _DummyClient())
 
     svc = KaspiService(api_key="token")

--- a/tests/app/api/test_kaspi_orders_sync.py
+++ b/tests/app/api/test_kaspi_orders_sync.py
@@ -125,6 +125,44 @@ async def test_sync_uses_query_merchant_uid(monkeypatch, async_client, company_a
 
 
 @pytest.mark.asyncio
+async def test_sync_passes_backfill_days(monkeypatch, async_client, company_a_admin_headers):
+    captured: dict[str, int | None] = {"backfill_days": None}
+
+    async def fake_sync_orders(self, *, backfill_days=None, **kwargs):  # noqa: ANN001, ARG001
+        captured["backfill_days"] = backfill_days
+        return {"ok": True, "status": "success", "fetched": 0, "inserted": 0, "updated": 0}
+
+    monkeypatch.setattr(KaspiService, "sync_orders", fake_sync_orders)
+
+    resp = await async_client.post(
+        "/api/v1/kaspi/orders/sync?merchantUid=17319385&backfill_days=7",
+        headers=company_a_admin_headers,
+    )
+    assert resp.status_code == 200
+    assert captured["backfill_days"] == 7
+
+
+@pytest.mark.asyncio
+async def test_sync_backfill_rejected_in_production(monkeypatch, async_client, company_a_admin_headers):
+    from app.api.v1 import kaspi as kaspi_module
+    from app.core.config import settings
+
+    async def fake_sync_orders(*args, **kwargs):  # noqa: ANN001, ARG001
+        raise AssertionError("sync_orders should not be called when backfill is blocked")
+
+    monkeypatch.setattr(KaspiService, "sync_orders", fake_sync_orders)
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production", raising=False)
+    monkeypatch.setattr(kaspi_module.settings, "ENVIRONMENT", "production", raising=False)
+
+    resp = await async_client.post(
+        "/api/v1/kaspi/orders/sync?merchantUid=17319385&backfill_days=7",
+        headers=company_a_admin_headers,
+    )
+    assert resp.status_code == 400
+    assert resp.json().get("detail") == "backfill_days_allowed_only_in_development"
+
+
+@pytest.mark.asyncio
 async def test_sync_missing_merchant_uid_returns_422(async_client, async_db_session, company_a_admin_headers):
     from app.models.company import Company
 
@@ -199,6 +237,7 @@ async def test_orders_sync_uses_shop_api_url(monkeypatch, async_client, company_
         async def __aexit__(self, exc_type, exc, tb):
             return None
 
+    monkeypatch.setattr(kaspi_service.settings, "KASPI_ORDERS_TRANSPORT", "async")
     monkeypatch.setattr(kaspi_service.httpx, "AsyncClient", _DummyAsyncClient)
 
     resp = await async_client.post(
@@ -245,6 +284,7 @@ async def test_get_orders_total_count_zero_ok(monkeypatch):
             captured["params"] = params
             return _DummyResponse()
 
+    monkeypatch.setattr(kaspi_service.settings, "KASPI_ORDERS_TRANSPORT", "async")
     monkeypatch.setattr(kaspi_service.httpx, "AsyncClient", lambda **kwargs: _DummyClient())
 
     svc = KaspiService(api_key="token")
@@ -287,6 +327,7 @@ async def test_get_orders_one_order_ok(monkeypatch):
         async def get(self, url, headers=None, params=None):
             return _DummyResponse()
 
+    monkeypatch.setattr(kaspi_service.settings, "KASPI_ORDERS_TRANSPORT", "async")
     monkeypatch.setattr(kaspi_service.httpx, "AsyncClient", lambda **kwargs: _DummyClient())
 
     svc = KaspiService(api_key="token")

--- a/tests/app/test_campaign_processing_worker.py
+++ b/tests/app/test_campaign_processing_worker.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.models.campaign import Campaign, CampaignProcessingStatus, CampaignStatus
+from app.models.company import Company
+from app.worker import campaign_processing
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_campaign(
+    async_db_session,
+    *,
+    company_id: int,
+    processing_status: CampaignProcessingStatus,
+) -> Campaign:
+    company = await async_db_session.get(Company, company_id)
+    if not company:
+        company = Company(id=company_id, name=f"Company {company_id}")
+        async_db_session.add(company)
+        await async_db_session.flush()
+
+    campaign = Campaign(
+        title=f"Processing {company_id}-{processing_status.value}",
+        description="test",
+        status=CampaignStatus.DRAFT,
+        scheduled_at=None,
+        company_id=company_id,
+        processing_status=processing_status,
+        queued_at=datetime.now(UTC) if processing_status == CampaignProcessingStatus.QUEUED else None,
+    )
+    async_db_session.add(campaign)
+    await async_db_session.commit()
+    await async_db_session.refresh(campaign)
+    return campaign
+
+
+async def test_campaign_run_endpoint_idempotent(async_client, async_db_session, auth_headers):
+    campaign = await _seed_campaign(
+        async_db_session,
+        company_id=91010,
+        processing_status=CampaignProcessingStatus.DONE,
+    )
+
+    first = await async_client.post(
+        f"/api/v1/admin/campaigns/{campaign.id}/run",
+        headers=auth_headers,
+    )
+    assert first.status_code == 200, first.text
+    payload_first = first.json()
+    assert payload_first.get("status") == CampaignProcessingStatus.QUEUED.value
+    queued_at = payload_first.get("queued_at")
+    assert queued_at
+
+    second = await async_client.post(
+        f"/api/v1/admin/campaigns/{campaign.id}/run",
+        headers=auth_headers,
+    )
+    assert second.status_code == 200, second.text
+    payload_second = second.json()
+    assert payload_second.get("status") == CampaignProcessingStatus.QUEUED.value
+    assert payload_second.get("queued_at") == queued_at
+
+
+async def test_campaign_worker_transitions_to_done(async_db_session):
+    campaign = await _seed_campaign(
+        async_db_session,
+        company_id=91020,
+        processing_status=CampaignProcessingStatus.QUEUED,
+    )
+
+    results = await campaign_processing.process_campaign_queue_once(async_db_session, limit=5)
+    assert results
+
+    await async_db_session.refresh(campaign)
+    assert campaign.processing_status == CampaignProcessingStatus.DONE
+    assert campaign.started_at is not None
+    assert campaign.finished_at is not None
+
+
+async def test_campaign_worker_failure_sets_error(async_db_session, monkeypatch):
+    campaign = await _seed_campaign(
+        async_db_session,
+        company_id=91030,
+        processing_status=CampaignProcessingStatus.QUEUED,
+    )
+
+    async def _boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(campaign_processing, "_perform_campaign_action", _boom)
+
+    await campaign_processing.process_campaign_queue_once(async_db_session, limit=5)
+    await async_db_session.refresh(campaign)
+
+    assert campaign.processing_status == CampaignProcessingStatus.FAILED
+    assert campaign.last_error
+    assert "boom" in campaign.last_error
+    assert campaign.attempts == 1
+
+
+async def test_campaign_worker_lock_prevents_processing(async_db_session, monkeypatch):
+    campaign = await _seed_campaign(
+        async_db_session,
+        company_id=91040,
+        processing_status=CampaignProcessingStatus.QUEUED,
+    )
+
+    async def _deny_lock(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr(campaign_processing, "_try_campaign_advisory_lock", _deny_lock)
+
+    results = await campaign_processing.process_campaign_queue_once(async_db_session, limit=5)
+    assert results == []
+
+    await async_db_session.refresh(campaign)
+    assert campaign.processing_status == CampaignProcessingStatus.QUEUED

--- a/tests/app/test_campaign_run_endpoint.py
+++ b/tests/app/test_campaign_run_endpoint.py
@@ -117,3 +117,37 @@ async def test_campaign_run_claims_once(async_client, test_db):
     assert second.status_code == 200, second.text
     payload_second = second.json()
     assert payload_second.get("processed") == 0
+
+
+async def test_campaign_run_company_id_from_body(async_client, test_db):
+    _ = test_db
+    headers = _platform_admin_headers_without_company()
+    campaign_id = _seed_due_campaign(company_id=9103, title_suffix="body")
+
+    resp = await async_client.post(
+        "/api/v1/admin/tasks/campaigns/run",
+        headers=headers,
+        json={"companyId": 9103},
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload.get("processed") == 1
+
+    SessionLocal = sessionmaker(bind=base_conftest.sync_engine, expire_on_commit=False, autoflush=False)
+    with SessionLocal() as s:
+        campaign = s.query(Campaign).filter(Campaign.id == campaign_id).first()
+        assert campaign is not None
+        assert campaign.status == CampaignStatus.SUCCESS
+
+
+async def test_campaign_run_missing_company_id_returns_400(async_client, test_db):
+    _ = test_db
+    headers = _platform_admin_headers_without_company()
+
+    resp = await async_client.post(
+        "/api/v1/admin/tasks/campaigns/run",
+        headers=headers,
+    )
+    assert resp.status_code == 400, resp.text
+    payload = resp.json()
+    assert payload.get("code") == "company_id_required"

--- a/tests/app/test_campaign_run_endpoint.py
+++ b/tests/app/test_campaign_run_endpoint.py
@@ -151,3 +151,31 @@ async def test_campaign_run_missing_company_id_returns_400(async_client, test_db
     assert resp.status_code == 400, resp.text
     payload = resp.json()
     assert payload.get("code") == "company_id_required"
+
+
+async def test_campaign_seed_and_run(async_client, test_db):
+    _ = test_db
+    headers = _platform_admin_headers_without_company()
+
+    seed = await async_client.post(
+        "/api/v1/admin/dev/seed/campaign_due?company_id=9201",
+        headers=headers,
+    )
+    assert seed.status_code == 200, seed.text
+    seed_payload = seed.json()
+    campaign_id = seed_payload.get("campaign_id")
+    assert campaign_id
+
+    run = await async_client.post(
+        "/api/v1/admin/tasks/campaigns/run?company_id=9201",
+        headers=headers,
+    )
+    assert run.status_code == 200, run.text
+    run_payload = run.json()
+    assert run_payload.get("processed") == 1
+
+    SessionLocal = sessionmaker(bind=base_conftest.sync_engine, expire_on_commit=False, autoflush=False)
+    with SessionLocal() as s:
+        campaign = s.query(Campaign).filter(Campaign.id == campaign_id).first()
+        assert campaign is not None
+        assert campaign.status == CampaignStatus.SUCCESS

--- a/tests/app/test_campaign_run_endpoint.py
+++ b/tests/app/test_campaign_run_endpoint.py
@@ -83,14 +83,12 @@ async def test_campaign_run_ok(async_client, test_db):
     campaign_id = _seed_due_campaign(company_id=9101, title_suffix="ok")
 
     resp = await async_client.post(
-        "/api/v1/admin/tasks/campaigns/run",
+        "/api/v1/admin/tasks/campaigns/run?company_id=9101",
         headers=headers,
     )
     assert resp.status_code == 200, resp.text
     payload = resp.json()
-    assert payload.get("ok") is True
-    assert payload.get("started") == 1
-    assert payload.get("found") >= 1
+    assert payload.get("processed") == 1
 
     SessionLocal = sessionmaker(bind=base_conftest.sync_engine, expire_on_commit=False, autoflush=False)
     with SessionLocal() as s:
@@ -105,17 +103,17 @@ async def test_campaign_run_claims_once(async_client, test_db):
     _seed_due_campaign(company_id=9102, title_suffix=datetime.now(UTC).isoformat())
 
     first = await async_client.post(
-        "/api/v1/admin/tasks/campaigns/run",
+        "/api/v1/admin/tasks/campaigns/run?company_id=9102",
         headers=headers,
     )
     assert first.status_code == 200, first.text
     payload_first = first.json()
-    assert payload_first.get("started") == 1
+    assert payload_first.get("processed") == 1
 
     second = await async_client.post(
-        "/api/v1/admin/tasks/campaigns/run",
+        "/api/v1/admin/tasks/campaigns/run?company_id=9102",
         headers=headers,
     )
     assert second.status_code == 200, second.text
     payload_second = second.json()
-    assert payload_second.get("started") == 0
+    assert payload_second.get("processed") == 0

--- a/tests/app/test_campaign_runner.py
+++ b/tests/app/test_campaign_runner.py
@@ -8,7 +8,7 @@ from app.core.config import settings
 from app.core.provider_registry import ProviderRegistry
 from app.models.campaign import Campaign, CampaignStatus, ChannelType, Message, MessageStatus
 from app.models.company import Company
-from app.services.campaign_runner import run_campaigns
+from app.services.campaign_runner import run_campaigns, run_due_campaigns
 
 
 async def _seed_campaign(async_db_session, *, company_id: int, status: CampaignStatus, scheduled_at=None):
@@ -82,6 +82,48 @@ async def test_campaign_tenant_isolation(async_db_session, monkeypatch):
     await async_db_session.refresh(campaign_a)
     await async_db_session.refresh(campaign_b)
 
+    assert campaign_a.status == CampaignStatus.SUCCESS
+    assert campaign_b.status == CampaignStatus.READY
+
+
+async def test_run_due_campaigns_processes_ready(async_db_session, monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development", raising=False)
+    ProviderRegistry.invalidate()
+
+    campaign = await _seed_campaign(async_db_session, company_id=3001, status=CampaignStatus.READY)
+    processed = await run_due_campaigns(async_db_session, company_id=3001, limit=10)
+
+    assert processed == 1
+    await async_db_session.refresh(campaign)
+    assert campaign.status == CampaignStatus.SUCCESS
+
+
+async def test_run_due_campaigns_idempotent(async_db_session, monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development", raising=False)
+    ProviderRegistry.invalidate()
+
+    campaign = await _seed_campaign(async_db_session, company_id=3002, status=CampaignStatus.READY)
+    first = await run_due_campaigns(async_db_session, company_id=3002, limit=10)
+    second = await run_due_campaigns(async_db_session, company_id=3002, limit=10)
+
+    assert first == 1
+    assert second == 0
+    await async_db_session.refresh(campaign)
+    assert campaign.status == CampaignStatus.SUCCESS
+
+
+async def test_run_due_campaigns_tenant_scoped(async_db_session, monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development", raising=False)
+    ProviderRegistry.invalidate()
+
+    campaign_a = await _seed_campaign(async_db_session, company_id=3003, status=CampaignStatus.READY)
+    campaign_b = await _seed_campaign(async_db_session, company_id=3004, status=CampaignStatus.READY)
+
+    processed = await run_due_campaigns(async_db_session, company_id=3003, limit=10)
+
+    assert processed == 1
+    await async_db_session.refresh(campaign_a)
+    await async_db_session.refresh(campaign_b)
     assert campaign_a.status == CampaignStatus.SUCCESS
     assert campaign_b.status == CampaignStatus.READY
 

--- a/tests/app/test_kaspi_service_timeouts.py
+++ b/tests/app/test_kaspi_service_timeouts.py
@@ -54,6 +54,7 @@ async def test_kaspi_list_orders_uses_computed_timeout(monkeypatch):
         captured["trust_env"] = trust_env
         return _DummyClient(timeout=timeout, transport=transport, http2=http2)
 
+    monkeypatch.setattr(kaspi_service.settings, "KASPI_ORDERS_TRANSPORT", "async")
     monkeypatch.setattr(kaspi_service.httpx, "AsyncClient", _client_factory)
 
     await svc.list_orders(
@@ -116,6 +117,7 @@ async def test_kaspi_get_orders_uses_shop_api_url_and_jsonapi_pagination(monkeyp
             captured["headers"] = headers
             return _DummyResponse()
 
+    monkeypatch.setattr(kaspi_service.settings, "KASPI_ORDERS_TRANSPORT", "async")
     monkeypatch.setattr(kaspi_service.httpx, "AsyncClient", _DummyClient)
 
     await svc.get_orders(page=0, page_size=0)

--- a/tests/app/test_kaspi_service_timeouts.py
+++ b/tests/app/test_kaspi_service_timeouts.py
@@ -54,6 +54,7 @@ async def test_kaspi_list_orders_uses_computed_timeout(monkeypatch):
         captured["trust_env"] = trust_env
         return _DummyClient(timeout=timeout, transport=transport, http2=http2)
 
+    monkeypatch.setattr(kaspi_service.settings, "KASPI_ORDERS_TRANSPORT", "async")
     monkeypatch.setattr(kaspi_service.httpx, "AsyncClient", _client_factory)
 
     await svc.list_orders(
@@ -116,6 +117,7 @@ async def test_kaspi_get_orders_uses_shop_api_url_and_jsonapi_pagination(monkeyp
             captured["headers"] = headers
             return _DummyResponse()
 
+    monkeypatch.setattr(kaspi_service.settings, "KASPI_ORDERS_TRANSPORT", "async")
     monkeypatch.setattr(kaspi_service.httpx, "AsyncClient", _DummyClient)
 
     await svc.get_orders(page=0, page_size=0)
@@ -172,7 +174,7 @@ async def test_kaspi_get_orders_sync_transport_uses_threadpool(monkeypatch):
             captured["headers"] = headers
             return _DummyResponse()
 
-    async def _run_sync(func, *args, cancellable=True, **kwargs):
+    async def _run_sync(func, *args, abandon_on_cancel=True, **kwargs):
         captured["run_sync"] = True
         return func(*args, **kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,7 @@ os.environ.setdefault("FORCE_INMEMORY_BACKENDS", "1")
 os.environ.setdefault("TEST_REDIS_DISABLED", "1")
 os.environ.setdefault("CSRF_SECRET", "test-csrf-secret-32-chars-minimum")
 os.environ["KASPI_STUB"] = "0"
+os.environ.setdefault("SMARTSELL_BACKGROUND_TASKS", "0")
 
 # РЇРІРЅРѕ СѓРєР°Р¶РµРј "СЃРѕРІСЂРµРјРµРЅРЅС‹Р№" strict-СЂРµР¶РёРј asyncio, РµСЃР»Рё РїР»Р°РіРёРЅ РЅРµ РґРµР»Р°РµС‚ СЌС‚РѕРіРѕ СЃР°Рј.
 os.environ.setdefault("PYTEST_ASYNCIO_MODE", "strict")

--- a/tests/scripts/test_kaspi_httpx_probe.py
+++ b/tests/scripts/test_kaspi_httpx_probe.py
@@ -1,4 +1,3 @@
-feat/workers-campaigns-iteration3
 import httpx
 
 from scripts.kaspi_httpx_probe import _extract_total_count, _safe_truncate, _split_windows
@@ -14,7 +13,6 @@ def test_split_windows_stops_at_min():
     assert _split_windows(75, 60) == [75, 60]
 
 
-feat/workers-campaigns-iteration3
 def test_safe_truncate_respects_limit():
     assert _safe_truncate("abc", 2) == "ab"
     assert _safe_truncate("abc", 0) == ""

--- a/tests/scripts/test_kaspi_httpx_probe.py
+++ b/tests/scripts/test_kaspi_httpx_probe.py
@@ -4,8 +4,6 @@ from scripts.kaspi_httpx_probe import _extract_total_count, _safe_truncate, _spl
 
 
 def test_split_windows_halves_to_min():
-
-
     assert _split_windows(480, 60) == [480, 240, 120, 60]
 
 
@@ -26,4 +24,3 @@ def test_extract_total_count_from_meta():
 def test_extract_total_count_missing_meta():
     resp = httpx.Response(200, json={"data": []})
     assert _extract_total_count(resp) is None
-

--- a/tests/scripts/test_kaspi_httpx_probe.py
+++ b/tests/scripts/test_kaspi_httpx_probe.py
@@ -1,0 +1,13 @@
+from scripts.kaspi_httpx_probe import _split_windows
+
+
+def test_split_windows_exact_halves():
+    assert _split_windows(480, 60) == [480, 240, 120, 60]
+
+
+def test_split_windows_stops_at_min():
+    assert _split_windows(75, 60) == [75, 60]
+
+
+def test_split_windows_below_min_single_attempt():
+    assert _split_windows(30, 60) == [30]

--- a/tests/scripts/test_kaspi_httpx_probe.py
+++ b/tests/scripts/test_kaspi_httpx_probe.py
@@ -1,0 +1,26 @@
+import httpx
+
+from scripts.kaspi_httpx_probe import _extract_total_count, _safe_truncate, _split_windows
+
+
+def test_split_windows_halves_to_min():
+    assert _split_windows(480, 60) == [480, 240, 120, 60]
+
+
+def test_split_windows_stops_at_min():
+    assert _split_windows(75, 60) == [75, 60]
+
+
+def test_safe_truncate_respects_limit():
+    assert _safe_truncate("abc", 2) == "ab"
+    assert _safe_truncate("abc", 0) == ""
+
+
+def test_extract_total_count_from_meta():
+    resp = httpx.Response(200, json={"meta": {"totalCount": 3}})
+    assert _extract_total_count(resp) == 3
+
+
+def test_extract_total_count_missing_meta():
+    resp = httpx.Response(200, json={"data": []})
+    assert _extract_total_count(resp) is None

--- a/tests/test_db_password_pgpass.py
+++ b/tests/test_db_password_pgpass.py
@@ -92,3 +92,33 @@ def test_sync_url_injects_password_from_db_password(monkeypatch):
     parsed = urlparse(url)
 
     assert parsed.password
+
+
+def test_sync_engine_falls_back_from_masked_url(monkeypatch):
+    import app.core.db as db
+    from sqlalchemy import create_engine as sa_create_engine
+
+    db._SYNC_ENGINE = None
+    db._SYNC_SESSION_MAKER = None
+    db._SYNC_REPLICA_ENGINE = None
+
+    calls = {"count": 0, "url": None}
+    masked = "postgresql+psycopg2://user:***@localhost:5432/dbname"
+    unmasked = "postgresql+psycopg2://user:realpass@localhost:5432/dbname"
+
+    def fake_resolve_sync_pg_url():
+        calls["count"] += 1
+        return masked if calls["count"] == 1 else unmasked
+
+    def fake_create_engine(url, **kwargs):
+        calls["url"] = url
+        return sa_create_engine("sqlite:///:memory:")
+
+    monkeypatch.setattr(db, "_resolve_sync_pg_url", fake_resolve_sync_pg_url)
+    monkeypatch.setattr(db, "create_engine", fake_create_engine)
+
+    engine = db._get_sync_engine()
+
+    assert calls["url"] == unmasked
+    assert calls["count"] >= 2
+    assert engine is not None

--- a/tests/test_db_password_pgpass.py
+++ b/tests/test_db_password_pgpass.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlparse
 
-from app.core.config import Settings, resolve_database_url
+from app.core.config import Settings, resolve_async_database_url, resolve_database_url
 
 
 def _clear_db_env(monkeypatch):
@@ -84,6 +84,17 @@ def test_masked_password_is_stripped_without_env_password(monkeypatch):
     assert source
 
 
+def test_async_resolution_strips_masked_password(monkeypatch):
+    _clear_db_env(monkeypatch)
+    monkeypatch.setenv("ENVIRONMENT", "testing")
+    monkeypatch.setenv("TEST_ASYNC_DATABASE_URL", "postgresql+asyncpg://user:***@localhost:5432/dbname")
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "config::async-masked")
+
+    url, _, _ = resolve_async_database_url(Settings())
+
+    assert ":***@" not in url
+
+
 def test_sync_url_injects_password_from_db_password(monkeypatch):
     import os
 
@@ -135,18 +146,12 @@ def test_resolve_sync_pg_url_skips_masked_candidate(monkeypatch):
 
     _clear_db_env(monkeypatch)
     monkeypatch.setenv("ENVIRONMENT", "testing")
-    monkeypatch.setenv("TEST_ASYNC_DATABASE_URL", "postgresql+asyncpg://user:real@localhost:5432/dbname")
+    monkeypatch.setenv("TEST_ASYNC_DATABASE_URL", "postgresql+asyncpg://user:***@localhost:5432/dbname")
+    monkeypatch.setenv("TEST_DATABASE_URL", "postgresql+asyncpg://user:***@localhost:5432/dbname")
     monkeypatch.setenv("PYTEST_CURRENT_TEST", "db::resolve")
 
     new_settings = SettingsCls()
     monkeypatch.setattr(db, "settings", new_settings, raising=False)
-    masked = "postgresql://user:***@localhost:5432/dbname"
-    monkeypatch.setattr(SettingsCls, "sqlalchemy_sync_url", property(lambda _self: masked))
-    monkeypatch.setattr(
-        SettingsCls,
-        "sqlalchemy_urls",
-        property(lambda _self: {"sync": masked, "async": masked, "driver": "postgresql"}),
-    )
 
     resolved = db._resolve_sync_pg_url()
 

--- a/tests/test_db_password_pgpass.py
+++ b/tests/test_db_password_pgpass.py
@@ -20,6 +20,7 @@ def test_pgpassword_injected_when_url_missing_password(monkeypatch):
     # Simulate local/pytest context with PGPASSWORD provided and URL lacking password
     monkeypatch.setenv("ENVIRONMENT", "local")
     _clear_db_env(monkeypatch)
+    monkeypatch.setenv("TEST_DATABASE_URL", "postgresql+psycopg2://user:real@localhost:5432/dbname")
 
     url_without_password = "postgresql+asyncpg://postgres@localhost:5432/smartsell_test"
     # testing flag keeps resolution predictable; provide test URL without password
@@ -94,9 +95,56 @@ def test_sync_url_injects_password_from_db_password(monkeypatch):
     assert parsed.password
 
 
-def test_sync_engine_falls_back_from_masked_url(monkeypatch):
+def test_resolved_url_and_sqlalchemy_urls_unmasked(monkeypatch):
+    from app.core.config import get_settings
+
+    _clear_db_env(monkeypatch)
+    monkeypatch.setenv("ENVIRONMENT", "testing")
+    monkeypatch.setenv("TEST_DATABASE_URL", "postgresql://user:realpass@localhost:5432/dbname")
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "config::unmasked")
+
+    get_settings.cache_clear()
+    url, _, _ = resolve_database_url(Settings())
+    parsed = urlparse(url)
+
+    assert parsed.password
+    assert parsed.password != "***"
+
+    settings = get_settings()
+    assert settings.sqlalchemy_urls["sync"]
+    assert ":***@" not in settings.sqlalchemy_urls["sync"]
+    get_settings.cache_clear()
+
+
+def test_resolve_sync_pg_url_skips_masked_candidate(monkeypatch):
     import app.core.db as db
+    from app.core.config import Settings as SettingsCls
+
+    _clear_db_env(monkeypatch)
+    monkeypatch.setenv("ENVIRONMENT", "testing")
+    monkeypatch.setenv("TEST_ASYNC_DATABASE_URL", "postgresql+asyncpg://user:real@localhost:5432/dbname")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:real@localhost:5432/dbname")
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "db::resolve")
+
+    new_settings = SettingsCls()
+    monkeypatch.setattr(db, "settings", new_settings, raising=False)
+    monkeypatch.setattr(SettingsCls, "sqlalchemy_sync_url", property(lambda _self: ""))
+    monkeypatch.setattr(SettingsCls, "sqlalchemy_urls", property(lambda _self: {}))
+    monkeypatch.setattr(
+        db,
+        "resolve_database_url",
+        lambda _settings=None: ("postgresql://user:real@localhost:5432/dbname", "TEST_DATABASE_URL", ""),
+    )
+
+    resolved = db._resolve_sync_pg_url()
+
+    assert ":***@" not in resolved
+
+
+def test_sync_engine_falls_back_from_masked_url(monkeypatch):
     from sqlalchemy import create_engine as sa_create_engine
+
+    import app.core.db as db
 
     db._SYNC_ENGINE = None
     db._SYNC_SESSION_MAKER = None

--- a/tests/test_db_password_pgpass.py
+++ b/tests/test_db_password_pgpass.py
@@ -20,7 +20,6 @@ def test_pgpassword_injected_when_url_missing_password(monkeypatch):
     # Simulate local/pytest context with PGPASSWORD provided and URL lacking password
     monkeypatch.setenv("ENVIRONMENT", "local")
     _clear_db_env(monkeypatch)
-    monkeypatch.setenv("TEST_DATABASE_URL", "postgresql+psycopg2://user:real@localhost:5432/dbname")
 
     url_without_password = "postgresql+asyncpg://postgres@localhost:5432/smartsell_test"
     # testing flag keeps resolution predictable; provide test URL without password
@@ -68,6 +67,20 @@ def test_masked_password_is_replaced_by_db_password(monkeypatch):
 
     assert "secret123" in url
     assert ":***@" not in url
+    assert source
+
+
+def test_masked_password_is_stripped_without_env_password(monkeypatch):
+    _clear_db_env(monkeypatch)
+    monkeypatch.setenv("ENVIRONMENT", "testing")
+    monkeypatch.setenv("TEST_DATABASE_URL", "postgresql+asyncpg://user:***@localhost:5432/dbname")
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "config::masked-no-env")
+
+    url, source, _ = resolve_database_url(Settings())
+    parsed = urlparse(url)
+
+    assert ":***@" not in url
+    assert parsed.password in {None, ""}
     assert source
 
 
@@ -123,17 +136,16 @@ def test_resolve_sync_pg_url_skips_masked_candidate(monkeypatch):
     _clear_db_env(monkeypatch)
     monkeypatch.setenv("ENVIRONMENT", "testing")
     monkeypatch.setenv("TEST_ASYNC_DATABASE_URL", "postgresql+asyncpg://user:real@localhost:5432/dbname")
-    monkeypatch.setenv("DATABASE_URL", "postgresql://user:real@localhost:5432/dbname")
     monkeypatch.setenv("PYTEST_CURRENT_TEST", "db::resolve")
 
     new_settings = SettingsCls()
     monkeypatch.setattr(db, "settings", new_settings, raising=False)
-    monkeypatch.setattr(SettingsCls, "sqlalchemy_sync_url", property(lambda _self: ""))
-    monkeypatch.setattr(SettingsCls, "sqlalchemy_urls", property(lambda _self: {}))
+    masked = "postgresql://user:***@localhost:5432/dbname"
+    monkeypatch.setattr(SettingsCls, "sqlalchemy_sync_url", property(lambda _self: masked))
     monkeypatch.setattr(
-        db,
-        "resolve_database_url",
-        lambda _settings=None: ("postgresql://user:real@localhost:5432/dbname", "TEST_DATABASE_URL", ""),
+        SettingsCls,
+        "sqlalchemy_urls",
+        property(lambda _self: {"sync": masked, "async": masked, "driver": "postgresql"}),
     )
 
     resolved = db._resolve_sync_pg_url()


### PR DESCRIPTION
Adds campaign processing queue: admin run endpoint (idempotent), background queue processor, Alembic migration for processing_status fields/index, and tests. Also ensures enum values are persisted as lowercase.