### PR TITLE
Dev

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -62,6 +62,7 @@ from app.core.security import (
     denylist_key_for_token,
     get_password_hash,
     get_refresh_from_cookie,
+    mark_access_token_revoked,
     resolve_tenant_company_id,
     revoke_token,
     validate_csrf_token,
@@ -725,6 +726,7 @@ async def logout(
             token = header_val.split(" ", 1)[1].strip()
     if not token:
         token = request.cookies.get("access_token")
+    mark_access_token_revoked(token or "")
     client_info = get_client_info(request)
     payload = None
     user_id = 0
@@ -743,14 +745,17 @@ async def logout(
 
             key = denylist_key_for_token(token, payload)
             exp = payload.get("exp")
+            ttl_seconds = None
+            if exp is not None:
+                try:
+                    ttl_seconds = max(1, int(float(exp) - time.time()))
+                except Exception:
+                    ttl_seconds = None
             if key:
-                ttl_seconds = None
-                if exp is not None:
-                    try:
-                        ttl_seconds = max(1, int(float(exp) - time.time()))
-                    except Exception:
-                        ttl_seconds = None
                 revoke_token(key, ttl_seconds=ttl_seconds)
+            token_hash_key = denylist_key_for_token(token, None)
+            if token_hash_key and token_hash_key != key:
+                revoke_token(token_hash_key, ttl_seconds=ttl_seconds)
         except Exception:
             token_invalid = True
             token = None

--- a/app/api/v1/campaigns.py
+++ b/app/api/v1/campaigns.py
@@ -334,6 +334,38 @@ class _StorageProxy:
 
 storage: Any = _StorageProxy()
 
+CAMPAIGNS_ORM_GUARD_STATUS = status.HTTP_409_CONFLICT
+CAMPAIGNS_ORM_GUARD_DETAIL = "campaigns_orm_mode_not_supported_for_this_endpoint"
+
+
+def ensure_campaigns_mode_is_storage(
+    *,
+    request: Request | None = None,
+    user: User | None = None,
+    endpoint: str | None = None,
+) -> None:
+    backend = _get_campaigns_storage_backend()
+    if backend != "orm":
+        return
+    if request is None:
+        request = _campaign_request_ctx.get(None)
+    if user is None:
+        user = _campaign_user_ctx.get(None)
+    endpoint_value = endpoint or (request.url.path if request else "unknown")
+    user_id = getattr(user, "id", None) if user else None
+    company_id = getattr(user, "company_id", None) if user else None
+    logger.warning(
+        "campaigns storage guard: endpoint=%s user_id=%s company_id=%s mode=%s",
+        endpoint_value,
+        user_id,
+        company_id,
+        backend,
+    )
+    raise HTTPException(
+        status_code=CAMPAIGNS_ORM_GUARD_STATUS,
+        detail=CAMPAIGNS_ORM_GUARD_DETAIL,
+    )
+
 
 # ------------------------------------------------------------------------------
 # ВСПОМОГАТЕЛЬНЫЙ СЕЙВЕР ДЛЯ СООБЩЕНИЙ С ГАРАНТИЕЙ campaign_id
@@ -345,6 +377,7 @@ def _save_message_with_cid(mid: int, payload: dict[str, Any], campaign_id: int) 
     - совместимо с InMemoryStorage (проглотит поле);
     - совместимо с SQL-стораджем (поле NOT NULL).
     """
+    ensure_campaigns_mode_is_storage()
     data = dict(payload)
     data["campaign_id"] = int(campaign_id)
     try:
@@ -385,10 +418,12 @@ class RateLimiter:
 
 rate_limiter = RateLimiter()
 _campaign_user_ctx: ContextVar[User | None] = ContextVar("campaign_user_ctx", default=None)
+_campaign_request_ctx: ContextVar[Request | None] = ContextVar("campaign_request_ctx", default=None)
 
 
-async def _auth_user(current_user: User = Depends(get_current_user)) -> User:
+async def _auth_user(request: Request, current_user: User = Depends(get_current_user)) -> User:
     _campaign_user_ctx.set(current_user)
+    _campaign_request_ctx.set(request)
     return current_user
 
 
@@ -730,6 +765,7 @@ class BulkUpsertMessageRequest(BaseModel):
 # ХЕЛПЕРЫ ДЛЯ КАМПАНИЙ / СООБЩЕНИЙ
 # ------------------------------------------------------------------------------
 def _get_campaign_or_404(campaign_id: int, user: User | None = None) -> Campaign:
+    ensure_campaigns_mode_is_storage()
     user = user or _campaign_user_ctx.get(None)
     data = storage.get_campaign(campaign_id)
     if not data:
@@ -744,6 +780,7 @@ def _get_campaign_or_404(campaign_id: int, user: User | None = None) -> Campaign
 
 
 def _save_campaign(c: Campaign) -> None:
+    ensure_campaigns_mode_is_storage()
     storage.save_campaign(c.model_dump())
 
 
@@ -921,8 +958,6 @@ async def create_campaign(
     backend = _get_campaigns_storage_backend()
     # owner, учитываем при уникальности
     owner = (campaign.owner or user.username or "").strip()
-    if _title_exists(campaign.title, owner=owner, company_id=getattr(user, "company_id", None)):
-        raise ConflictError("Campaign with this title already exists", "DUPLICATE_TITLE", http_status=409)
 
     if backend == "orm":
         company_id = getattr(user, "company_id", None)
@@ -1000,6 +1035,9 @@ async def create_campaign(
         payload["tags"] = _normalize_tags(campaign.tags)
         payload["owner"] = owner
         return Campaign(**payload)
+
+    if _title_exists(campaign.title, owner=owner, company_id=getattr(user, "company_id", None)):
+        raise ConflictError("Campaign with this title already exists", "DUPLICATE_TITLE", http_status=409)
 
     new_id = storage.next_id("campaigns")
 
@@ -1320,6 +1358,7 @@ async def search_campaigns(
     order: Literal["asc", "desc"] = Query("desc"),
     user: User = Depends(_auth_user),
 ):
+    ensure_campaigns_mode_is_storage()
     try:
         raw_campaigns = storage.list_campaigns(company_id=getattr(user, "company_id", None))
     except TypeError:
@@ -1349,6 +1388,7 @@ async def search_campaigns(
 
 @read_router.get("/recipients", response_model=list[str])
 async def list_all_recipients(user: User = Depends(_auth_user)):
+    ensure_campaigns_mode_is_storage()
     recs = set()
     try:
         raw_campaigns = storage.list_campaigns(company_id=getattr(user, "company_id", None))
@@ -1367,6 +1407,7 @@ async def list_all_recipients(user: User = Depends(_auth_user)):
 
 @read_router.get("/search_tags", response_model=list[str])
 async def search_tags(q: str = Query("", min_length=0), user: User = Depends(_auth_user)):
+    ensure_campaigns_mode_is_storage()
     found = set()
     qs = (q or "").strip().lower()
     try:
@@ -1408,6 +1449,7 @@ async def validate_campaign(campaign: Campaign = Body(...)):
 
 @read_router.get("/export", response_model=list[Campaign])
 async def export_campaigns(user: User = Depends(_auth_user)):
+    ensure_campaigns_mode_is_storage()
     try:
         raw_campaigns = storage.list_campaigns(company_id=getattr(user, "company_id", None))
     except TypeError:
@@ -1422,6 +1464,7 @@ async def get_export_formats():
 
 @read_router.get("/export/{fmt}", response_model=Any)
 async def export_campaigns_fmt(fmt: CampaignExportFormat = Path(...), user: User = Depends(_auth_user)):
+    ensure_campaigns_mode_is_storage()
     try:
         raw_campaigns = storage.list_campaigns(company_id=getattr(user, "company_id", None))
     except TypeError:
@@ -1466,6 +1509,7 @@ async def export_campaigns_fmt(fmt: CampaignExportFormat = Path(...), user: User
     ],
 )
 async def import_campaigns_bulk(payload: list[Campaign] = Body(...), user: User = Depends(_auth_user)):
+    ensure_campaigns_mode_is_storage()
     imported = 0
     errors: list[dict[str, Any]] = []
     for idx, campaign in enumerate(payload):
@@ -1531,6 +1575,7 @@ async def import_campaigns_bulk(payload: list[Campaign] = Body(...), user: User 
     dependencies=[Depends(require_store_admin_company)],
 )
 async def save_campaign_draft(campaign: Campaign = Body(...), user: User = Depends(_auth_user)):
+    ensure_campaigns_mode_is_storage()
     owner = (campaign.owner or user.username or "").strip()
     if _title_exists(campaign.title, owner=owner, company_id=getattr(user, "company_id", None)):
         raise ConflictError("Campaign with this title already exists", "DUPLICATE_TITLE", http_status=409)
@@ -1575,6 +1620,7 @@ async def list_campaign_drafts(
     order: Literal["asc", "desc"] = Query("desc"),
     user: User = Depends(_auth_user),
 ):
+    ensure_campaigns_mode_is_storage()
     try:
         raw_campaigns = storage.list_campaigns(company_id=getattr(user, "company_id", None))
     except TypeError:
@@ -1594,6 +1640,7 @@ async def list_campaign_drafts(
 
 @read_router.get("/drafts/{campaign_id}", response_model=Campaign)
 async def get_campaign_draft(campaign_id: int = Path(..., ge=1), user: User = Depends(_auth_user)):
+    ensure_campaigns_mode_is_storage()
     data = storage.get_campaign(campaign_id)
     if not data or data.get("active", True):
         raise HTTPException(status_code=404, detail="Draft not found")
@@ -1630,6 +1677,7 @@ async def get_campaign(
     dependencies=[Depends(require_store_admin_company)],
 )
 async def update_campaign(campaign_id: int, campaign: Campaign = Body(...), user: User = Depends(_auth_user)):
+    ensure_campaigns_mode_is_storage()
     current = storage.get_campaign(campaign_id)
     if (not current) or (
         current.get("company_id") is not None and current.get("company_id") != getattr(user, "company_id", None)
@@ -1689,6 +1737,7 @@ async def update_campaign(campaign_id: int, campaign: Campaign = Body(...), user
     dependencies=[Depends(require_store_admin_company)],
 )
 async def delete_campaign(campaign_id: int, user: User = Depends(_auth_user)):
+    ensure_campaigns_mode_is_storage()
     data = storage.get_campaign(campaign_id)
     if (not data) or (
         data.get("company_id") is not None and data.get("company_id") != getattr(user, "company_id", None)
@@ -2290,6 +2339,7 @@ async def set_tags_for_campaign(campaign_id: int, req: SetTagsRequest, user: Use
     dependencies=[Depends(require_store_admin_company)],
 )
 async def archive_campaign(campaign_id: int, req: ArchiveRequest = Body(None), user: User = Depends(_auth_user)):
+    ensure_campaigns_mode_is_storage()
     data = storage.get_campaign(campaign_id)
     if not data:
         raise HTTPException(status_code=404, detail="Campaign not found")
@@ -2305,6 +2355,7 @@ async def archive_campaign(campaign_id: int, req: ArchiveRequest = Body(None), u
     dependencies=[Depends(require_store_admin_company)],
 )
 async def restore_campaign(campaign_id: int, req: RestoreRequest = Body(None), user: User = Depends(_auth_user)):
+    ensure_campaigns_mode_is_storage()
     data = storage.get_campaign(campaign_id)
     if not data:
         raise HTTPException(status_code=404, detail="Campaign not found")
@@ -2321,6 +2372,7 @@ async def restore_campaign(campaign_id: int, req: RestoreRequest = Body(None), u
     dependencies=[Depends(require_store_admin_company)],
 )
 async def bulk_archive_campaigns(req: BulkDeleteRequest, user: User = Depends(_auth_user)):
+    ensure_campaigns_mode_is_storage()
     archived = 0
     for cid in req.ids:
         data = storage.get_campaign(cid)
@@ -2341,6 +2393,7 @@ async def bulk_archive_campaigns(req: BulkDeleteRequest, user: User = Depends(_a
     dependencies=[Depends(require_store_admin_company)],
 )
 async def bulk_restore_campaigns(req: BulkDeleteRequest, user: User = Depends(_auth_user)):
+    ensure_campaigns_mode_is_storage()
     restored = 0
     for cid in req.ids:
         data = storage.get_campaign(cid)
@@ -2361,6 +2414,7 @@ async def bulk_restore_campaigns(req: BulkDeleteRequest, user: User = Depends(_a
     dependencies=[Depends(require_store_admin_company)],
 )
 async def bulk_delete_campaigns(req: BulkDeleteRequest, user: User = Depends(_auth_user)):
+    ensure_campaigns_mode_is_storage()
     deleted = 0
     for cid in req.ids:
         data = storage.get_campaign(cid)

--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -220,15 +220,26 @@ async def _get_auth_db():
 # Security helpers (advanced -> legacy)
 # ------------------------------------------------------------------------------
 _HAS_ADV_SECURITY = False
+_legacy_verify_token = None  # type: ignore
+denylist_key_for_token = None  # type: ignore[assignment]
+is_token_revoked = None  # type: ignore[assignment]
+is_access_token_revoked = None  # type: ignore[assignment]
 try:
     from app.core.security import (  # type: ignore; noqa: F401 (may be unused here); -> dict payload {sub, scp, role, jti, exp, kid, ...}
         decode_and_validate,
         denylist_key_for_token,
         is_token_revoked,
+        is_access_token_revoked,
     )
 
     _HAS_ADV_SECURITY = True
 except Exception:  # pragma: no cover
+    try:
+        from app.core.security import denylist_key_for_token, is_token_revoked, is_access_token_revoked  # type: ignore
+    except Exception:
+        denylist_key_for_token = None  # type: ignore[assignment]
+        is_token_revoked = None  # type: ignore[assignment]
+        is_access_token_revoked = None  # type: ignore[assignment]
     try:
         from app.core.security import verify_token as _legacy_verify_token  # type: ignore
     except Exception:
@@ -302,6 +313,22 @@ def _decode_token_soft(token: str) -> dict | None:
     return None
 
 
+def _is_token_revoked_for_payload(token: str, payload: dict | None) -> bool:
+    if not payload or not token:
+        return False
+    if callable(is_access_token_revoked) and is_access_token_revoked(token):
+        return True
+    if not callable(denylist_key_for_token) or not callable(is_token_revoked):
+        return False
+    key = denylist_key_for_token(token, payload)
+    if key and is_token_revoked(key):
+        return True
+    token_hash_key = denylist_key_for_token(token, None)
+    if token_hash_key and token_hash_key != key and is_token_revoked(token_hash_key):
+        return True
+    return False
+
+
 def _auth_context_from_payload(token: str, payload: dict) -> AuthContext:
     sub = str(payload.get("sub", ""))
     scopes = set(payload.get("scp") or [])
@@ -352,8 +379,13 @@ async def get_current_user_optional(
         token = request.cookies.get("access_token")
     if not token:
         return None
+    if callable(is_access_token_revoked) and is_access_token_revoked(token):
+        return None
+
     payload = _decode_token_soft(token)
     if not payload:
+        return None
+    if _is_token_revoked_for_payload(token, payload):
         return None
     ctx = _auth_context_from_payload(token, payload)
     if ctx.user_id <= 0:
@@ -374,12 +406,14 @@ async def get_current_user(
     if not token:
         raise AuthenticationError("Authentication required", "AUTH_REQUIRED")
 
+    if callable(is_access_token_revoked) and is_access_token_revoked(token):
+        raise AuthenticationError("Invalid or expired token", "INVALID_TOKEN")
+
     payload = None
     if _HAS_ADV_SECURITY:
         try:
             payload = decode_and_validate(token, expected_type="access")  # type: ignore
-            key = denylist_key_for_token(token, payload)
-            if key and is_token_revoked(key):
+            if _is_token_revoked_for_payload(token, payload):
                 raise AuthenticationError("Invalid or expired token", "INVALID_TOKEN")
         except ValueError as exc:
             if str(exc) == "Token expired":
@@ -396,6 +430,9 @@ async def get_current_user(
             audit_logger.log_auth_failure(reason="invalid_token", **info)
         except Exception:
             pass
+        raise AuthenticationError("Invalid or expired token", "INVALID_TOKEN")
+
+    if _is_token_revoked_for_payload(token, payload):
         raise AuthenticationError("Invalid or expired token", "INVALID_TOKEN")
 
     ctx = _auth_context_from_payload(token, payload)

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -681,6 +681,20 @@ def _build_denylist_backend() -> DenylistBackend:
 
 _DENYLIST: DenylistBackend = _build_denylist_backend()
 
+# --- In-memory access token revoke fallback ---
+REVOKED_ACCESS_TOKENS: set[str] = set()
+
+
+def mark_access_token_revoked(token: str) -> None:
+    """Mark a raw access token string as revoked (in-memory fallback)."""
+    if token:
+        REVOKED_ACCESS_TOKENS.add(token)
+
+
+def is_access_token_revoked(token: str) -> bool:
+    """Check if a raw access token string has been revoked (in-memory fallback)."""
+    return bool(token) and token in REVOKED_ACCESS_TOKENS
+
 
 def is_token_revoked(jti: str) -> bool:
     try:

--- a/app/services/inventory_reservations.py
+++ b/app/services/inventory_reservations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -42,17 +43,20 @@ async def _get_warehouse(db: AsyncSession, *, tenant_id: int, warehouse_id: int)
 
 
 async def _get_default_warehouse(db: AsyncSession, *, tenant_id: int) -> Warehouse:
-    result = await db.execute(
+    base = (
         select(Warehouse)
         .where(
             Warehouse.company_id == tenant_id,
             Warehouse.is_active.is_(True),
             Warehouse.is_archived.is_(False),
-            Warehouse.is_main.is_(True),
         )
         .order_by(Warehouse.id.asc())
     )
+    result = await db.execute(base.where(Warehouse.is_main.is_(True)))
     warehouse = result.scalars().first()
+    if not warehouse:
+        result = await db.execute(base)
+        warehouse = result.scalars().first()
     if not warehouse:
         raise SmartSellValidationError(
             "Warehouse is not configured",
@@ -80,11 +84,10 @@ async def _get_or_create_stock(
     if stock is not None:
         return stock
 
-    base_qty = int(getattr(product, "stock_quantity", 0) or 0)
     stock = ProductStock(
         product_id=product.id,
         warehouse_id=warehouse.id,
-        quantity=base_qty,
+        quantity=0,
         reserved_quantity=0,
     )
     db.add(stock)
@@ -130,6 +133,142 @@ def _build_result(stock: ProductStock) -> dict[str, int]:
         "reserved": int(stock.reserved_quantity),
         "available": int(stock.available_quantity),
     }
+
+
+class ReservationResult(BaseModel):
+    ok: bool
+    error_code: str | None = None
+    product_id: int | None = None
+    warehouse_id: int | None = None
+    on_hand: int | None = None
+    reserved: int | None = None
+    available: int | None = None
+
+
+async def _resolve_preorder_warehouse_id(
+    db: AsyncSession,
+    *,
+    tenant_id: int,
+    preorder_id: int,
+    product_id: int,
+) -> int | None:
+    result = await db.execute(
+        select(ProductStock.warehouse_id)
+        .join(StockMovement, StockMovement.stock_id == ProductStock.id)
+        .join(Warehouse, Warehouse.id == ProductStock.warehouse_id)
+        .where(
+            StockMovement.reference_type == "preorder",
+            StockMovement.reference_id == preorder_id,
+            StockMovement.product_id == product_id,
+            StockMovement.movement_type == MovementType.RESERVE.value,
+            Warehouse.company_id == tenant_id,
+        )
+        .order_by(StockMovement.id.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def reserve_stock_for_preorder(
+    *,
+    db: AsyncSession,
+    company_id: int,
+    product_id: int,
+    quantity: int,
+    preorder_id: int,
+    user_id: int | None = None,
+) -> ReservationResult:
+    try:
+        result = await reserve_and_log(
+            db,
+            tenant_id=company_id,
+            product_id=product_id,
+            qty=int(quantity),
+            reference_type="preorder",
+            reference_id=preorder_id,
+        )
+    except SmartSellValidationError as exc:
+        if exc.code in {"WAREHOUSE_NOT_CONFIGURED", "INSUFFICIENT_STOCK"}:
+            return ReservationResult(ok=False, error_code=exc.code)
+        raise
+
+    return ReservationResult(
+        ok=True,
+        product_id=result.get("product_id"),
+        warehouse_id=result.get("warehouse_id"),
+        on_hand=result.get("on_hand"),
+        reserved=result.get("reserved"),
+        available=result.get("available"),
+    )
+
+
+async def release_stock_for_preorder(
+    *,
+    db: AsyncSession,
+    company_id: int,
+    product_id: int,
+    quantity: int,
+    preorder_id: int,
+    user_id: int | None = None,
+) -> None:
+    warehouse_id = await _resolve_preorder_warehouse_id(
+        db,
+        tenant_id=company_id,
+        preorder_id=preorder_id,
+        product_id=product_id,
+    )
+    if warehouse_id is None:
+        return
+
+    result = await db.execute(
+        select(ProductStock)
+        .where(ProductStock.product_id == product_id)
+        .where(ProductStock.warehouse_id == warehouse_id)
+        .with_for_update()
+    )
+    stock = result.scalar_one_or_none()
+    if stock is None:
+        return
+
+    release_qty = min(int(quantity), int(stock.reserved_quantity or 0))
+    if release_qty <= 0:
+        return
+
+    await release_and_log(
+        db,
+        tenant_id=company_id,
+        product_id=product_id,
+        qty=release_qty,
+        reference_type="preorder",
+        reference_id=preorder_id,
+        warehouse_id=warehouse_id,
+    )
+
+
+async def fulfill_preorder_reservation(
+    *,
+    db: AsyncSession,
+    company_id: int,
+    product_id: int,
+    quantity: int,
+    preorder_id: int,
+    user_id: int | None = None,
+) -> None:
+    warehouse_id = await _resolve_preorder_warehouse_id(
+        db,
+        tenant_id=company_id,
+        preorder_id=preorder_id,
+        product_id=product_id,
+    )
+    await fulfill_reservation(
+        db,
+        tenant_id=company_id,
+        product_id=product_id,
+        qty=int(quantity),
+        reference_type="preorder",
+        reference_id=preorder_id,
+        warehouse_id=warehouse_id,
+    )
 
 
 async def reserve_and_log(

--- a/app/services/preorders.py
+++ b/app/services/preorders.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from uuid import uuid4
 
-from sqlalchemy import case, func, or_, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -16,7 +16,12 @@ from app.models.preorder import Preorder, PreorderItem, PreorderStatus
 from app.models.product import Product
 from app.models.warehouse import MovementType, ProductStock, StockMovement, Warehouse
 from app.schemas.preorders import PreorderCreateIn, PreorderListFilters, PreorderUpdateIn
-from app.services.inventory_reservations import fulfill_reservation, release_and_log, reserve_and_log
+from app.services.inventory_reservations import (
+    ReservationResult,
+    fulfill_preorder_reservation,
+    release_stock_for_preorder,
+    reserve_stock_for_preorder,
+)
 
 
 def _parse_dt(value: str | None, field: str) -> datetime | None:
@@ -172,6 +177,18 @@ def _transition(preorder: Preorder, target: PreorderStatus) -> None:
     raise SmartSellValidationError("Invalid preorder status transition", "INVALID_PREORDER_STATUS", http_status=409)
 
 
+def _raise_reservation_error(result: ReservationResult) -> None:
+    if result.error_code == "WAREHOUSE_NOT_CONFIGURED":
+        raise SmartSellValidationError(
+            "Warehouse is not configured",
+            "WAREHOUSE_NOT_CONFIGURED",
+            http_status=422,
+        )
+    if result.error_code == "INSUFFICIENT_STOCK":
+        raise SmartSellValidationError("Insufficient stock", "INSUFFICIENT_STOCK", http_status=422)
+    raise SmartSellValidationError("Reservation failed", "RESERVATION_FAILED", http_status=422)
+
+
 async def _movement_exists(
     db: AsyncSession,
     *,
@@ -196,30 +213,6 @@ async def _movement_exists(
         .limit(1)
     )
     return result.scalar_one_or_none() is not None
-
-
-async def _resolve_reservation_warehouse_id(
-    db: AsyncSession,
-    *,
-    company_id: int,
-    preorder_id: int,
-    product_id: int,
-) -> int | None:
-    result = await db.execute(
-        select(ProductStock.warehouse_id)
-        .join(StockMovement, StockMovement.stock_id == ProductStock.id)
-        .join(Warehouse, Warehouse.id == ProductStock.warehouse_id)
-        .where(
-            StockMovement.reference_type == "preorder",
-            StockMovement.reference_id == preorder_id,
-            StockMovement.product_id == product_id,
-            StockMovement.movement_type == MovementType.RESERVE.value,
-            Warehouse.company_id == company_id,
-        )
-        .order_by(StockMovement.id.desc())
-        .limit(1)
-    )
-    return result.scalar_one_or_none()
 
 
 async def confirm_preorder(db: AsyncSession, *, company_id: int, preorder_id: int) -> Preorder:
@@ -259,15 +252,15 @@ async def confirm_preorder(db: AsyncSession, *, company_id: int, preorder_id: in
             )
             if exists:
                 continue
-            await reserve_and_log(
-                db,
-                tenant_id=company_id,
+            result = await reserve_stock_for_preorder(
+                db=db,
+                company_id=company_id,
                 product_id=item.product_id,
-                qty=int(item.qty),
-                reference_type="preorder",
-                reference_id=preorder.id,
-                warehouse_id=None,
+                quantity=int(item.qty),
+                preorder_id=preorder.id,
             )
+            if not result.ok:
+                _raise_reservation_error(result)
 
         _transition(preorder, PreorderStatus.CONFIRMED)
 
@@ -297,89 +290,13 @@ async def cancel_preorder(db: AsyncSession, *, company_id: int, preorder_id: int
             for item in preorder.items or []:
                 if not item.product_id:
                     continue
-                reserved_delta = (
-                    await db.execute(
-                        select(
-                            func.coalesce(
-                                func.sum(
-                                    case(
-                                        (
-                                            StockMovement.movement_type == MovementType.RESERVE.value,
-                                            StockMovement.quantity,
-                                        ),
-                                        (
-                                            StockMovement.movement_type == MovementType.RELEASE.value,
-                                            -StockMovement.quantity,
-                                        ),
-                                        (
-                                            StockMovement.movement_type == MovementType.FULFILL.value,
-                                            StockMovement.quantity,
-                                        ),
-                                        else_=0,
-                                    )
-                                ),
-                                0,
-                            )
-                        ).where(
-                            StockMovement.reference_type == "preorder",
-                            StockMovement.reference_id == preorder.id,
-                            StockMovement.product_id == item.product_id,
-                        )
-                    )
-                ).scalar_one()
-                to_release = max(0, int(reserved_delta or 0))
-                if to_release <= 0:
-                    continue
-
-                reserved_total = (
-                    await db.execute(
-                        select(func.coalesce(func.sum(ProductStock.reserved_quantity), 0))
-                        .join(Warehouse, Warehouse.id == ProductStock.warehouse_id)
-                        .where(ProductStock.product_id == item.product_id)
-                        .where(Warehouse.company_id == company_id)
-                    )
-                ).scalar_one()
-                release_target = min(to_release, int(reserved_total or 0))
-                if release_target <= 0:
-                    raise SmartSellValidationError(
-                        "Reservation inconsistent",
-                        "RESERVATION_INCONSISTENT",
-                        http_status=409,
-                    )
-
-                remaining = release_target
-                stocks = (
-                    (
-                        await db.execute(
-                            select(ProductStock)
-                            .join(Warehouse, Warehouse.id == ProductStock.warehouse_id)
-                            .where(ProductStock.product_id == item.product_id)
-                            .where(Warehouse.company_id == company_id)
-                            .where(ProductStock.reserved_quantity > 0)
-                            .with_for_update()
-                            .order_by(ProductStock.reserved_quantity.desc(), ProductStock.id.asc())
-                        )
-                    )
-                    .scalars()
-                    .all()
+                await release_stock_for_preorder(
+                    db=db,
+                    company_id=company_id,
+                    product_id=item.product_id,
+                    quantity=int(item.qty),
+                    preorder_id=preorder.id,
                 )
-                for stock in stocks:
-                    if remaining <= 0:
-                        break
-                    available = int(stock.reserved_quantity or 0)
-                    if available <= 0:
-                        continue
-                    release_qty = min(remaining, available)
-                    await release_and_log(
-                        db,
-                        tenant_id=company_id,
-                        product_id=item.product_id,
-                        qty=release_qty,
-                        reference_type="preorder",
-                        reference_id=preorder.id,
-                        warehouse_id=stock.warehouse_id,
-                    )
-                    remaining -= release_qty
 
         _transition(preorder, PreorderStatus.CANCELLED)
 
@@ -436,12 +353,6 @@ async def fulfill_preorder(
         for item in preorder.items:
             if not item.product_id:
                 continue
-            warehouse_id = await _resolve_reservation_warehouse_id(
-                db,
-                company_id=company_id,
-                preorder_id=preorder.id,
-                product_id=item.product_id,
-            )
             fulfill_exists = await _movement_exists(
                 db,
                 company_id=company_id,
@@ -452,14 +363,12 @@ async def fulfill_preorder(
             )
             if fulfill_exists:
                 continue
-            await fulfill_reservation(
-                db,
-                tenant_id=company_id,
+            await fulfill_preorder_reservation(
+                db=db,
+                company_id=company_id,
                 product_id=item.product_id,
-                qty=int(item.qty),
-                reference_type="preorder",
-                reference_id=preorder.id,
-                warehouse_id=warehouse_id,
+                quantity=int(item.qty),
+                preorder_id=preorder.id,
             )
 
         if existing_order_id is not None:

--- a/scripts/smoke-campaigns-e2e.ps1
+++ b/scripts/smoke-campaigns-e2e.ps1
@@ -238,7 +238,23 @@ $cleanupResp = Invoke-Api -Method "POST" -Url "$BaseUrl/api/v1/admin/tasks/campa
 if ($cleanupResp.StatusCode -eq 403 -or $cleanupResp.StatusCode -eq 404) {
   Write-Host "[WARN] Campaigns cleanup task not available for this token (403/404); deleting campaign"
   $deleteResp = Invoke-Api -Method "DELETE" -Url "$BaseUrl/api/v1/campaigns/$campaignId"
-  if ($deleteResp.StatusCode -ne 204 -and $deleteResp.StatusCode -ne 200 -and $deleteResp.StatusCode -ne 404) {
+  if ($deleteResp.StatusCode -eq 409) {
+    $detail = $null
+    try {
+      if ($deleteResp.Body -is [string]) {
+        $detail = (ConvertFrom-Json $deleteResp.Body).detail
+      } else {
+        $detail = $deleteResp.Body.detail
+      }
+    } catch {
+      $detail = $null
+    }
+    if ($detail -eq "campaigns_orm_mode_not_supported_for_this_endpoint") {
+      Write-Host "[WARN] Campaign delete skipped: ORM guard active"
+    } else {
+      $null = Assert-Ok -Resp $deleteResp -Action "Delete campaign"
+    }
+  } elseif ($deleteResp.StatusCode -ne 204 -and $deleteResp.StatusCode -ne 200 -and $deleteResp.StatusCode -ne 404) {
     $null = Assert-Ok -Resp $deleteResp -Action "Delete campaign"
   }
 } else {

--- a/tests/app/api/test_campaigns_orm_guard.py
+++ b/tests/app/api/test_campaigns_orm_guard.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from sqlalchemy import select
+
+from app.api.v1 import campaigns as campaigns_api
+from app.core.subscriptions.plan_catalog import normalize_plan_id
+from app.models.billing import Subscription
+
+
+def _reset_campaigns_storage() -> None:
+    campaigns_mod = importlib.import_module("app.api.v1.campaigns")
+    campaigns_mod._STORAGE_INSTANCE = None
+    campaigns_mod._STORAGE_BACKEND = None
+
+
+async def _ensure_subscription(async_db_session, *, company_id: int) -> None:
+    subscription = (
+        await async_db_session.execute(
+            select(Subscription)
+            .where(Subscription.company_id == company_id)
+            .where(Subscription.deleted_at.is_(None))
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if subscription:
+        subscription.status = "active"
+        return
+
+    async_db_session.add(
+        Subscription(
+            company_id=company_id,
+            plan=normalize_plan_id("start") or "trial",
+            status="active",
+            billing_cycle="monthly",
+            price=0,
+            currency="KZT",
+        )
+    )
+
+
+GUARDED_ENDPOINTS = [
+    ("get", "/api/v1/campaigns/search", None),
+    ("get", "/api/v1/campaigns/recipients", None),
+    ("get", "/api/v1/campaigns/search_tags?q=sale", None),
+    ("get", "/api/v1/campaigns/export", None),
+    ("get", "/api/v1/campaigns/export/json", None),
+    (
+        "post",
+        "/api/v1/campaigns/import",
+        [
+            {
+                "title": "Import campaign",
+                "messages": [{"recipient": "user@example.com", "content": "Hello"}],
+            }
+        ],
+    ),
+    (
+        "post",
+        "/api/v1/campaigns/draft",
+        {"title": "Draft campaign", "messages": [{"recipient": "user@example.com", "content": "Hello"}]},
+    ),
+    ("get", "/api/v1/campaigns/drafts", None),
+    ("get", "/api/v1/campaigns/drafts/1", None),
+    ("put", "/api/v1/campaigns/1", {"title": "Updated"}),
+    ("delete", "/api/v1/campaigns/1", None),
+    ("post", "/api/v1/campaigns/1/archive", None),
+    ("post", "/api/v1/campaigns/1/restore", None),
+    ("post", "/api/v1/campaigns/bulk_archive", {"ids": [1]}),
+    ("post", "/api/v1/campaigns/bulk_restore", {"ids": [1]}),
+    ("post", "/api/v1/campaigns/bulk_delete", {"ids": [1]}),
+    (
+        "post",
+        "/api/v1/campaigns/1/messages",
+        {"recipient": "user@example.com", "content": "Hello"},
+    ),
+    ("get", "/api/v1/campaigns/1/messages", None),
+    ("get", "/api/v1/campaigns/1/messages/1", None),
+    (
+        "put",
+        "/api/v1/campaigns/1/messages/1",
+        {"recipient": "user@example.com", "content": "Updated"},
+    ),
+    ("delete", "/api/v1/campaigns/1/messages/1", None),
+    (
+        "post",
+        "/api/v1/campaigns/1/messages/upsert_by_recipient",
+        {"recipient": "user@example.com", "content": "Hello"},
+    ),
+    (
+        "post",
+        "/api/v1/campaigns/1/messages/1/status",
+        {"status": "sent"},
+    ),
+    ("post", "/api/v1/campaigns/1/messages/1/reset_to_pending", None),
+    ("post", "/api/v1/campaigns/1/messages/clear_failed", None),
+    ("post", "/api/v1/campaigns/1/messages/mark_all_sent", None),
+    (
+        "post",
+        "/api/v1/campaigns/1/messages/bulk_status_update",
+        {"status": "sent", "ids": [1]},
+    ),
+    ("post", "/api/v1/campaigns/1/messages/bulk_delete", {"ids": [1]}),
+    (
+        "post",
+        "/api/v1/campaigns/1/messages/bulk_add",
+        {"messages": [{"recipient": "user@example.com", "content": "Hello"}]},
+    ),
+    (
+        "post",
+        "/api/v1/campaigns/1/messages/bulk_upsert",
+        {"items": [{"recipient": "user@example.com", "content": "Hello"}]},
+    ),
+    ("get", "/api/v1/campaigns/1/stats", None),
+    ("post", "/api/v1/campaigns/1/send", None),
+    ("post", "/api/v1/campaigns/1/send_async", None),
+    (
+        "post",
+        "/api/v1/campaigns/1/schedule",
+        {"schedule_time": "2099-01-01T00:00:00Z"},
+    ),
+    ("post", "/api/v1/campaigns/1/cancel_schedule", None),
+    ("post", "/api/v1/campaigns/1/preview_send", ["user@example.com"]),
+    ("post", "/api/v1/campaigns/1/resend_failed", None),
+    ("get", "/api/v1/campaigns/1/tags", None),
+    ("post", "/api/v1/campaigns/1/tags", {"tag": "sale"}),
+    ("delete", "/api/v1/campaigns/1/tags/sale", None),
+    ("put", "/api/v1/campaigns/1/tags", {"tags": ["sale"]}),
+    ("get", "/api/v1/campaigns/1/advanced_stats", None),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method,path,payload", GUARDED_ENDPOINTS)
+async def test_campaigns_storage_only_endpoints_guarded_in_orm(
+    async_client,
+    async_db_session,
+    company_a_admin_headers,
+    monkeypatch,
+    method,
+    path,
+    payload,
+):
+    monkeypatch.setenv("SMARTSELL_CAMPAIGNS_STORAGE", "orm")
+    monkeypatch.setenv("FORCE_INMEMORY_BACKENDS", "0")
+    _reset_campaigns_storage()
+
+    await _ensure_subscription(async_db_session, company_id=1001)
+    await async_db_session.commit()
+
+    request = getattr(async_client, method)
+    if payload is None:
+        resp = await request(path, headers=company_a_admin_headers)
+    else:
+        resp = await request(path, headers=company_a_admin_headers, json=payload)
+
+    assert resp.status_code == campaigns_api.CAMPAIGNS_ORM_GUARD_STATUS, resp.text
+    assert resp.json().get("detail") == campaigns_api.CAMPAIGNS_ORM_GUARD_DETAIL

--- a/tests/services/test_inventory_reservation_service.py
+++ b/tests/services/test_inventory_reservation_service.py
@@ -5,7 +5,12 @@ from sqlalchemy import select
 
 from app.core.exceptions import NotFoundError, SmartSellValidationError
 from app.models.warehouse import MovementType, ProductStock, StockMovement, Warehouse
-from app.services.inventory_reservations import fulfill_reservation, release_and_log, reserve_and_log
+from app.services.inventory_reservations import (
+    fulfill_reservation,
+    release_and_log,
+    reserve_and_log,
+    reserve_stock_for_preorder,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -177,3 +182,59 @@ async def test_double_reserve_insufficient(async_db_session, factory):
             reference_id=701,
         )
     assert exc.value.code == "INSUFFICIENT_STOCK"
+
+
+async def test_reserve_stock_for_preorder_happy_path(async_db_session, factory):
+    company = await factory["create_company"]()
+    product = await factory["create_product"](company=company, stock_quantity=5)
+    warehouse = await _create_main_warehouse(async_db_session, company)
+    stock = ProductStock(product_id=product.id, warehouse_id=warehouse.id, quantity=5, reserved_quantity=0)
+    async_db_session.add(stock)
+    await async_db_session.commit()
+
+    result = await reserve_stock_for_preorder(
+        db=async_db_session,
+        company_id=company.id,
+        product_id=product.id,
+        quantity=2,
+        preorder_id=900,
+    )
+    assert result.ok is True
+    assert result.reserved == 2
+    assert result.available == 3
+
+
+async def test_reserve_stock_for_preorder_missing_warehouse(async_db_session, factory):
+    company = await factory["create_company"]()
+    product = await factory["create_product"](company=company, stock_quantity=5)
+
+    result = await reserve_stock_for_preorder(
+        db=async_db_session,
+        company_id=company.id,
+        product_id=product.id,
+        quantity=1,
+        preorder_id=901,
+    )
+    assert result.ok is False
+    assert result.error_code == "WAREHOUSE_NOT_CONFIGURED"
+
+
+async def test_reserve_stock_for_preorder_insufficient(async_db_session, factory):
+    company = await factory["create_company"]()
+    product = await factory["create_product"](company=company, stock_quantity=2)
+    warehouse = await _create_main_warehouse(async_db_session, company)
+    stock = ProductStock(product_id=product.id, warehouse_id=warehouse.id, quantity=1, reserved_quantity=0)
+    async_db_session.add(stock)
+    await async_db_session.commit()
+
+    result = await reserve_stock_for_preorder(
+        db=async_db_session,
+        company_id=company.id,
+        product_id=product.id,
+        quantity=2,
+        preorder_id=902,
+    )
+    assert result.ok is False
+    assert result.error_code == "INSUFFICIENT_STOCK"
+
+


### PR DESCRIPTION
## Summary

This PR brings several backend hardening and MVP-completion changes around campaigns storage, auth logout behaviour, and inventory + preorders integration, and aligns the TZ gap report with the current state.

Key themes:
- Prevent silent divergence between in-memory and ORM campaigns storage.
- Make `/auth/logout` reliably revoke access tokens, with a clear durability model.
- Wire preorders to the warehouse inventory reservation service, instead of using product-level stock fallbacks.
- Keep e2e smoke scripts in sync with the new behaviour.
- Document the closed gaps in `docs/TZ_GAP_REPORT.md`.

## Changes

### 1. Campaigns storage ORM guard

- Added a centralized guard for campaigns storage-only endpoints when `SMARTSELL_CAMPAIGNS_STORAGE=orm`:
  - Returns `409` with `detail="campaigns_orm_mode_not_supported_for_this_endpoint"`.
  - Logs `endpoint`, `user_id`, `company_id`, and backend mode.
- Guard is applied to:
  - Search/export/drafts/import endpoints.
  - Update/delete/archive/bulk archive/restore/delete helpers.
  - Low-level helpers like `_get_campaign_or_404`, `_save_campaign`, `_save_message_with_cid`.
- Adjusted `/campaigns/create` logic:
  - ORM path relies on DB-level uniqueness (tenant+title).
  - In-memory path keeps the existing `_title_exists` check.

**Motivation:** while ORM storage is being rolled out, it’s safer to explicitly block storage-only endpoints than to have partially divergent behaviour between in-memory and ORM.

### 2. Auth: logout access-token revocation

- Fixed `/api/v1/auth/logout` so that access tokens are actually revoked:

  - Logout now revokes both:
    - JTI-based denylist keys; and
    - a token-hash key.
  - Added an **in-memory access-token revoke set** as a fallback to cover non-advanced paths and tests.

- Updated auth dependencies:

  - `get_current_user` / `get_current_user_optional` now unconditionally check, in order:
    - in-memory revoke set; then
    - JTI-based denylist (if configured); then
    - token-hash denylist (if configured).

- Important behaviour note:

  - The **in-memory revoke set is process-local**: it is sufficient for tests and single-process/dev setups.
  - For multi-worker / multi-instance deployments, the **denylist backend (Redis/Postgres)** remains the durable, cross-process revocation path.

- Tests:
  - `TestAuth::test_logout_with_body_revokes_access` – green.
  - `TestAuth::test_logout_without_body_revokes_access` – green.

**Result:** after `/auth/logout`, the previous access token is rejected by `/auth/me`, matching the contract tests and expected production behaviour. In production, durability still depends on the configured denylist backend.

### 3. Inventory + preorders: stock reservations wiring

- Implemented reservation helpers on top of `ProductStock`:

  - Reserve, release, and fulfill operations log `StockMovement` with appropriate reference metadata.
  - Warehouse selection logic:
    - Prefer `Warehouse.is_main == true`.
    - Fallback to the **first active warehouse** if there is no main one.

- Removed `Product.stock_quantity` as a fallback “source of truth” for reservations:

  - Reservations now use the **warehouse-level stock model** only (`ProductStock` + `StockMovement`).
  - No implicit bootstrapping from `Product.stock_quantity` during reservations.

- Integrated preorders workflow with inventory reservations:

  - `confirm_preorder` → creates a reservation via the inventory service.
  - `cancel_preorder` → releases the reservation.
  - `fulfill_preorder` → fulfills the reservation and logs a stock movement.

- Error mapping:

  - Insufficient stock / warehouse misconfiguration are propagated as API-level errors with clear codes
    (e.g. `INSUFFICIENT_STOCK`, warehouse not configured).

- Tests:
  - `tests/services/test_inventory_reservation_service.py` – passes.
  - `tests/app/api/test_preorders_inventory.py` – passes.
  - `pytest -q tests/app -k "preorder and inventory"` – passes.

**Result:** the preorder flow is now wired to the warehouse inventory model (ProductStock + StockMovement) with explicit warehouse selection rules and no product-level stock fallback. This gives us an end-to-end MVP for “preorder → reserve → cancel/fulfill”.

### 4. Smoke: campaigns e2e script

- Updated `scripts/smoke-campaigns-e2e.ps1`:

  - DELETE step now tolerates the ORM guard (409 with `campaigns_orm_mode_not_supported_for_this_endpoint`) and logs a warning instead of failing the whole smoke run.
  - All other non-2xx responses still fail the smoke.

**Result:** campaigns e2e smoke remains valid in both in-memory and ORM storage modes, while reflecting the new guarded behaviour.

### 5. TZ gap report alignment

- Updated `docs/TZ_GAP_REPORT.md` with a **Targeted Gap Updates** section describing:

  - Auth / logout revoke:
    - Logout makes access tokens invalid immediately.
    - Denylist (JTI + hash) + in-memory fallback, and dependencies always checking revoke.
  - Preorders + Inventory:
    - Preorder confirm/cancel/fulfill uses warehouse reservation flow.
    - Reservation helpers are based on `ProductStock` + `StockMovement`, with main→first-active warehouse selection and no `Product.stock_quantity` fallback.
  - Campaigns storage (in-memory vs ORM):
    - Centralized guard for storage-only endpoints in ORM mode.
    - 409 with `campaigns_orm_mode_not_supported_for_this_endpoint`.
    - In-memory as full mode, ORM as limited but explicit mode.
    - Link to updated `scripts/smoke-campaigns-e2e.ps1`.

**Result:** the gap report is synced with the implemented behaviour and can be used as a living map of which auth, inventory, and campaigns gaps are already closed.

## Testing

Local test runs:

```bash
python -m pytest -q