### PR TITLE
docs: operational readiness docs (incident, release, DR)Feat/incident followups

### DIFF
--- a/SMARTSELL_DR_RESTORE_DRILL.md
+++ b/SMARTSELL_DR_RESTORE_DRILL.md
@@ -1,0 +1,60 @@
+# SMARTSELL_DR_RESTORE_DRILL
+
+## 1 Purpose
+Document the first practical disaster recovery restore drill for SmartSell and define how service can be restored after major failure for first-client operations.
+
+## 2 Failure scenarios
+- Primary database unavailable/corrupted.
+- Application deployment failure causing prolonged outage.
+- Infrastructure-level failure requiring rebuild from backups.
+- Misconfiguration causing service startup failure after release.
+
+## 3 Backup sources
+- Database backup source: TBD (latest verified snapshot location).
+- Application artifact/image source: TBD.
+- Environment/config backup source (secrets/config templates): TBD.
+- Timestamp of backup selected for drill: Not yet executed.
+
+## 4 Restore procedure
+1. Declare DR drill start and assign owner.
+2. Freeze writes to affected environment (if applicable).
+3. Provision/prepare restore target environment.
+4. Restore database from selected backup.
+5. Deploy last known good SmartSell artifact.
+6. Apply required runtime configuration/secrets.
+7. Start API, worker, and required dependencies.
+8. Record timestamps for each step.
+
+## 5 Verification steps
+- [ ] API health endpoint returns success.
+- [ ] Authentication/login works for admin account.
+- [ ] One tenant can read/write a core business flow.
+- [ ] Background worker/scheduler is running.
+- [ ] Critical integration path responds (Kaspi sanity check).
+- [ ] No critical startup/migration errors in logs.
+
+Status: Not yet executed.
+
+## 6 RPO target
+- Target RPO: **15 minutes** (initial operating target).
+- Achieved in this drill: Pending evidence.
+
+## 7 RTO target
+- Target RTO: **60 minutes** (initial operating target).
+- Achieved in this drill: Pending evidence.
+
+## 8 Evidence required
+- Drill date/time and incident owner.
+- Backup identifier used (snapshot/file/version).
+- Restore command outputs/log excerpts.
+- Service health verification outputs.
+- Measured restore duration (start → service healthy).
+- Measured data gap against backup timestamp.
+
+Current evidence status: **Not yet executed / Pending evidence**.
+
+## 9 Follow-up improvements
+1. Automate restore steps into a runnable script/checklist.
+2. Add periodic backup integrity validation.
+3. Re-run drill and compare achieved RPO/RTO vs targets.
+4. Capture known bottlenecks and remove manual steps.

--- a/SMARTSELL_EXECUTION_BOARD.md
+++ b/SMARTSELL_EXECUTION_BOARD.md
@@ -6,7 +6,7 @@
 | Tenant diagnostics summary | P0 | Partial | Founder/Backend | 3-5 days | SMARTSELL_TENANT_DIAGNOSTICS_SUMMARY.md<br>GET /api/v1/admin/tenants/{company_id}/diagnostics<br>tests/app/api/test_admin_tenant_diagnostics.py | Tenant support surface shows sync/error/request/integration health | Data scattered |
 | Billing state machine | P0 | Partial | Founder/Product+Backend | 2-3 days |  | Subscription states and transitions defined | Policy decisions pending |
 | Billing failure/grace/suspension policy | P0 | Partial | Founder/Product+Backend | 2-3 days |  | Subscription state machine written and supportable | Policy decisions pending |
-| DR baseline and restore drill | P0 | Partial | Founder/Ops | 2-4 days |  | Restore drill completed; RPO/RTO documented | No completed drill evidence |
+| DR baseline and restore drill | P0 | Partial | Founder/Ops | 2-4 days | SMARTSELL_DR_RESTORE_DRILL.md | Restore drill completed; RPO/RTO documented | No completed drill evidence |
 | Incident process | P0 | Partial | Founder/Ops | 1-2 days | SMARTSELL_INCIDENT_PROCESS.md | Severity rubric, owner rule, templates exist | No process |
 | Kaspi support visibility | P0 | Partial | Founder/Backend | 3-5 days |  | Last success/failure visible; errors understandable | Integration complexity |
 | Release checklist and smoke gate | P0 | Partial | Founder/Ops | 1-2 days | SMARTSELL_RELEASE_CHECKLIST.md<br>SMARTSELL_RELEASE_DRY_RUN_EVIDENCE.md | Release checklist documented and used | No single enforced gate |

--- a/app/services/tenant_diagnostics.py
+++ b/app/services/tenant_diagnostics.py
@@ -25,7 +25,6 @@ from app.schemas.tenant_diagnostics import (
     TenantDiagnosticsSupport,
 )
 
-
 _BILLING_STATE_MAP = {
     "trial": "trial",
     "active": "active",
@@ -94,9 +93,7 @@ async def get_tenant_diagnostics_summary(
         payment = (await db.execute(stmt)).scalar_one_or_none()
 
     sync_state = (
-        await db.execute(
-            select(KaspiOrderSyncState).where(KaspiOrderSyncState.company_id == company_id).limit(1)
-        )
+        await db.execute(select(KaspiOrderSyncState).where(KaspiOrderSyncState.company_id == company_id).limit(1))
     ).scalar_one_or_none()
 
     kaspi_session_exists = (


### PR DESCRIPTION
Adds operational readiness documentation:

- SMARTSELL_INCIDENT_PROCESS.md
- SMARTSELL_RELEASE_CHECKLIST.md
- SMARTSELL_RELEASE_DRY_RUN_EVIDENCE.md
- SMARTSELL_DR_RESTORE_DRILL.md

Execution board updated with evidence references.

Purpose: prepare SmartSell for onboarding first production tenants.