### PR TITLE
Phase 1 Safe Refactor: campaigns/reports/admin helpers + v1 route registry cleanup

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -158,58 +158,43 @@ def _router_or_none(mod: Any) -> APIRouter | None:
 
 
 V1_ROUTERS: list[tuple[str, APIRouter, bool]] = []
-if auth_mod and _router_or_none(auth_mod):
-    V1_ROUTERS.append(("auth", auth_mod.router, False))
-if users_mod and _router_or_none(users_mod):
-    V1_ROUTERS.append(("users", users_mod.router, False))
-if products_mod and _router_or_none(products_mod):
-    V1_ROUTERS.append(("products", products_mod.router, False))
-if pricing_mod and _router_or_none(pricing_mod):
-    V1_ROUTERS.append(("pricing", pricing_mod.router, False))
-if repricing_mod and _router_or_none(repricing_mod):
-    V1_ROUTERS.append(("repricing", repricing_mod.router, False))
-if preorders_mod and _router_or_none(preorders_mod):
-    V1_ROUTERS.append(("preorders", preorders_mod.router, False))
-if warehouses_mod and _router_or_none(warehouses_mod):
-    V1_ROUTERS.append(("warehouses", warehouses_mod.router, False))
-if inventory_mod and _router_or_none(inventory_mod):
-    V1_ROUTERS.append(("inventory", inventory_mod.router, False))
-if orders_mod and _router_or_none(orders_mod):
-    V1_ROUTERS.append(("orders", orders_mod.router, False))
-if campaigns_mod and _router_or_none(campaigns_mod):
-    # в этом модуле prefix уже абсолютный '/api/v1/campaigns'
-    V1_ROUTERS.append(("campaigns", campaigns_mod.router, True))
-if analytics_mod and _router_or_none(analytics_mod):
-    V1_ROUTERS.append(("analytics", analytics_mod.router, False))
-if exports_mod and _router_or_none(exports_mod):
-    V1_ROUTERS.append(("exports", exports_mod.router, False))
-if reports_mod and _router_or_none(reports_mod):
-    V1_ROUTERS.append(("reports", reports_mod.router, False))
+
+
+def _append_router_if_present(name: str, mod: Any, is_absolute: bool = False) -> bool:
+    router = _router_or_none(mod) if mod else None
+    if not router:
+        return False
+    V1_ROUTERS.append((name, router, is_absolute))
+    return True
+
+
+_append_router_if_present("auth", auth_mod, False)
+_append_router_if_present("users", users_mod, False)
+_append_router_if_present("products", products_mod, False)
+_append_router_if_present("pricing", pricing_mod, False)
+_append_router_if_present("repricing", repricing_mod, False)
+_append_router_if_present("preorders", preorders_mod, False)
+_append_router_if_present("warehouses", warehouses_mod, False)
+_append_router_if_present("inventory", inventory_mod, False)
+_append_router_if_present("orders", orders_mod, False)
+_append_router_if_present("campaigns", campaigns_mod, True)
+_append_router_if_present("analytics", analytics_mod, False)
+_append_router_if_present("exports", exports_mod, False)
+_append_router_if_present("reports", reports_mod, False)
 
 # Поддержка кошелька и платежей, если модули присутствуют
-if wallet and _router_or_none(wallet):
-    # в wallet.py объявлен prefix '/api/v1/wallet'
-    V1_ROUTERS.append(("wallet", wallet.router, True))
-if payments and _router_or_none(payments):
-    # ожидаемый prefix '/api/v1/payments'
-    V1_ROUTERS.append(("payments", payments.router, True))
-if invoices and _router_or_none(invoices):
-    # ожидаемый prefix '/api/v1/invoices'
-    V1_ROUTERS.append(("invoices", invoices.router, True))
+_append_router_if_present("wallet", wallet, True)
+_append_router_if_present("payments", payments, True)
+_append_router_if_present("invoices", invoices, True)
 
 # ⬇⬇⬇ ДОБАВЛЕНО: регистрация Kaspi
-if kaspi_mod and _router_or_none(kaspi_mod):
-    # в kaspi.py объявлен prefix '/api/v1/kaspi' → абсолютный
-    V1_ROUTERS.append(("kaspi", kaspi_mod.router, True))
+if _append_router_if_present("kaspi", kaspi_mod, True):
     public_router = getattr(kaspi_mod, "public_router", None)
     if isinstance(public_router, APIRouter):
         V1_ROUTERS.append(("kaspi_public", public_router, True))
-if integrations_mod and _router_or_none(integrations_mod):
-    V1_ROUTERS.append(("integrations", integrations_mod.router, True))
-if debug_db_mod and _router_or_none(debug_db_mod):
-    V1_ROUTERS.append(("debug_db", debug_db_mod.router, True))
-if admin_mod and _router_or_none(admin_mod):
-    V1_ROUTERS.append(("admin", admin_mod.router, True))
+_append_router_if_present("integrations", integrations_mod, True)
+_append_router_if_present("debug_db", debug_db_mod, True)
+_append_router_if_present("admin", admin_mod, True)
 
 
 def register_v1_router(name: str, router: APIRouter, is_absolute: bool = False) -> None:

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -14,6 +14,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.admin.integrations import router as integrations_router
+from app.api.v1.admin_api_helpers import (
+    build_campaign_processing_payload,
+    build_campaign_queue_item_payload,
+    build_campaign_transition_audit_meta,
+)
 from app.api.v1.admin_plans import router as plans_router
 from app.core.config import settings
 from app.core.db import get_async_db
@@ -265,21 +270,7 @@ class CampaignRunIn(BaseModel):
 
 
 def _campaign_queue_payload(campaign: Campaign) -> dict:
-    return {
-        "id": campaign.id,
-        "company_id": campaign.company_id,
-        "title": campaign.title,
-        "processing_status": campaign.processing_status.value,
-        "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
-        "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
-        "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
-        "failed_at": campaign.failed_at.isoformat() if campaign.failed_at else None,
-        "next_attempt_at": campaign.next_attempt_at.isoformat() if campaign.next_attempt_at else None,
-        "attempts": campaign.attempts,
-        "last_error": campaign.last_error,
-        "request_id": campaign.request_id,
-        "requested_by_user_id": campaign.requested_by_user_id,
-    }
+    return build_campaign_queue_item_payload(campaign)
 
 
 def _resolve_campaign_run_params(
@@ -470,18 +461,7 @@ async def queue_campaign_run(
         CampaignProcessingStatus.QUEUED,
         CampaignProcessingStatus.PROCESSING,
     ) and not should_force_requeue(campaign):
-        return {
-            "campaign_id": campaign.id,
-            "status": campaign.processing_status.value,
-            "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
-            "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
-            "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
-            "failed_at": campaign.failed_at.isoformat() if campaign.failed_at else None,
-            "next_attempt_at": campaign.next_attempt_at.isoformat() if campaign.next_attempt_at else None,
-            "last_error": campaign.last_error,
-            "attempts": campaign.attempts,
-            "request_id": campaign.request_id or request_id,
-        }
+        return build_campaign_processing_payload(campaign, campaign.request_id or request_id)
 
     campaign = await queue_campaign_run_service(
         db,
@@ -491,18 +471,7 @@ async def queue_campaign_run(
         now=datetime.now(UTC),
     )
 
-    return {
-        "campaign_id": campaign.id,
-        "status": campaign.processing_status.value,
-        "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
-        "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
-        "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
-        "failed_at": campaign.failed_at.isoformat() if campaign.failed_at else None,
-        "next_attempt_at": campaign.next_attempt_at.isoformat() if campaign.next_attempt_at else None,
-        "last_error": campaign.last_error,
-        "attempts": campaign.attempts,
-        "request_id": request_id,
-    }
+    return build_campaign_processing_payload(campaign, request_id)
 
 
 @router.get(
@@ -579,18 +548,7 @@ async def requeue_campaign(
         force=force,
     )
 
-    payload = {
-        "campaign_id": campaign.id,
-        "status": campaign.processing_status.value,
-        "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
-        "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
-        "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
-        "failed_at": campaign.failed_at.isoformat() if campaign.failed_at else None,
-        "next_attempt_at": campaign.next_attempt_at.isoformat() if campaign.next_attempt_at else None,
-        "last_error": campaign.last_error,
-        "attempts": campaign.attempts,
-        "request_id": campaign.request_id or request_id,
-    }
+    payload = build_campaign_processing_payload(campaign, campaign.request_id or request_id)
     if force:
         payload["warning"] = "requeued_while_processing"
 
@@ -598,19 +556,16 @@ async def requeue_campaign(
         level="info",
         event="campaign_requeue",
         message="Campaign requeued by admin",
-        meta={
-            "action": "campaign_requeue",
-            "campaign_id": campaign.id,
-            "admin_user_id": getattr(admin, "id", None),
-            "request_id": request_id,
-            "force": bool(force),
-            "prev_processing_status": prev_status,
-            "prev_attempts": prev_attempts,
-            "prev_last_error": prev_last_error,
-            "new_processing_status": campaign.processing_status.value,
-            "new_attempts": campaign.attempts,
-            "new_last_error": campaign.last_error,
-        },
+        meta=build_campaign_transition_audit_meta(
+            action="campaign_requeue",
+            campaign=campaign,
+            admin_user_id=getattr(admin, "id", None),
+            request_id=request_id,
+            force=force,
+            prev_processing_status=prev_status,
+            prev_attempts=prev_attempts,
+            prev_last_error=prev_last_error,
+        ),
     )
     return payload
 
@@ -642,32 +597,18 @@ async def cancel_campaign(
             level="info",
             event="campaign_cancel",
             message="Campaign cancel requested (noop)",
-            meta={
-                "action": "campaign_cancel",
-                "campaign_id": campaign.id,
-                "admin_user_id": getattr(admin, "id", None),
-                "request_id": request_id,
-                "force": False,
-                "prev_processing_status": campaign.processing_status.value,
-                "prev_attempts": campaign.attempts,
-                "prev_last_error": campaign.last_error,
-                "new_processing_status": campaign.processing_status.value,
-                "new_attempts": campaign.attempts,
-                "new_last_error": campaign.last_error,
-            },
+            meta=build_campaign_transition_audit_meta(
+                action="campaign_cancel",
+                campaign=campaign,
+                admin_user_id=getattr(admin, "id", None),
+                request_id=request_id,
+                force=False,
+                prev_processing_status=campaign.processing_status.value,
+                prev_attempts=campaign.attempts,
+                prev_last_error=campaign.last_error,
+            ),
         )
-        return {
-            "campaign_id": campaign.id,
-            "status": campaign.processing_status.value,
-            "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
-            "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
-            "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
-            "failed_at": campaign.failed_at.isoformat() if campaign.failed_at else None,
-            "next_attempt_at": campaign.next_attempt_at.isoformat() if campaign.next_attempt_at else None,
-            "last_error": campaign.last_error,
-            "attempts": campaign.attempts,
-            "request_id": campaign.request_id,
-        }
+        return build_campaign_processing_payload(campaign, campaign.request_id)
 
     prev_status = campaign.processing_status.value
     prev_attempts = campaign.attempts
@@ -685,33 +626,19 @@ async def cancel_campaign(
         level="info",
         event="campaign_cancel",
         message="Campaign cancelled by admin",
-        meta={
-            "action": "campaign_cancel",
-            "campaign_id": campaign.id,
-            "admin_user_id": getattr(admin, "id", None),
-            "request_id": request_id,
-            "force": False,
-            "prev_processing_status": prev_status,
-            "prev_attempts": prev_attempts,
-            "prev_last_error": prev_last_error,
-            "new_processing_status": campaign.processing_status.value,
-            "new_attempts": campaign.attempts,
-            "new_last_error": campaign.last_error,
-        },
+        meta=build_campaign_transition_audit_meta(
+            action="campaign_cancel",
+            campaign=campaign,
+            admin_user_id=getattr(admin, "id", None),
+            request_id=request_id,
+            force=False,
+            prev_processing_status=prev_status,
+            prev_attempts=prev_attempts,
+            prev_last_error=prev_last_error,
+        ),
     )
 
-    return {
-        "campaign_id": campaign.id,
-        "status": campaign.processing_status.value,
-        "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
-        "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
-        "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
-        "failed_at": campaign.failed_at.isoformat() if campaign.failed_at else None,
-        "next_attempt_at": campaign.next_attempt_at.isoformat() if campaign.next_attempt_at else None,
-        "last_error": campaign.last_error,
-        "attempts": campaign.attempts,
-        "request_id": campaign.request_id or request_id,
-    }
+    return build_campaign_processing_payload(campaign, campaign.request_id or request_id)
 
 
 @router.get(

--- a/app/api/v1/admin_api_helpers.py
+++ b/app/api/v1/admin_api_helpers.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.models.campaign import Campaign
+
+
+def build_campaign_queue_item_payload(campaign: Campaign) -> dict[str, Any]:
+    return {
+        "id": campaign.id,
+        "company_id": campaign.company_id,
+        "title": campaign.title,
+        "processing_status": campaign.processing_status.value,
+        "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
+        "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
+        "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
+        "failed_at": campaign.failed_at.isoformat() if campaign.failed_at else None,
+        "next_attempt_at": campaign.next_attempt_at.isoformat() if campaign.next_attempt_at else None,
+        "attempts": campaign.attempts,
+        "last_error": campaign.last_error,
+        "request_id": campaign.request_id,
+        "requested_by_user_id": campaign.requested_by_user_id,
+    }
+
+
+def build_campaign_processing_payload(campaign: Campaign, request_id: str | None) -> dict[str, Any]:
+    return {
+        "campaign_id": campaign.id,
+        "status": campaign.processing_status.value,
+        "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
+        "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
+        "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
+        "failed_at": campaign.failed_at.isoformat() if campaign.failed_at else None,
+        "next_attempt_at": campaign.next_attempt_at.isoformat() if campaign.next_attempt_at else None,
+        "last_error": campaign.last_error,
+        "attempts": campaign.attempts,
+        "request_id": request_id,
+    }
+
+
+def build_campaign_transition_audit_meta(
+    *,
+    action: str,
+    campaign: Campaign,
+    admin_user_id: int | None,
+    request_id: str,
+    force: bool,
+    prev_processing_status: str,
+    prev_attempts: int,
+    prev_last_error: str | None,
+) -> dict[str, Any]:
+    return {
+        "action": action,
+        "campaign_id": campaign.id,
+        "admin_user_id": admin_user_id,
+        "request_id": request_id,
+        "force": bool(force),
+        "prev_processing_status": prev_processing_status,
+        "prev_attempts": prev_attempts,
+        "prev_last_error": prev_last_error,
+        "new_processing_status": campaign.processing_status.value,
+        "new_attempts": campaign.attempts,
+        "new_last_error": campaign.last_error,
+    }

--- a/app/api/v1/campaigns.py
+++ b/app/api/v1/campaigns.py
@@ -17,6 +17,16 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.api.v1.campaigns_api_helpers import (
+    ORM_ACTIVE_STATUSES,
+    build_campaign_queue_response,
+    normalize_campaigns_db_url,
+    orm_campaign_to_payload,
+    orm_message_to_payload,
+    orm_status_is_active,
+    resolve_campaigns_storage_backend,
+    sync_storage_campaign_processing,
+)
 from app.api.v1.campaigns_helpers import _normalize_tags, _now_iso, _parse_dt
 from app.api.v1.campaigns_schemas import (
     AddTagRequest,
@@ -89,38 +99,12 @@ _STORAGE_BACKEND: str | None = None
 _STORAGE_INSTANCE: Any | None = None
 
 
-def _truthy_env(name: str) -> bool:
-    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
-
-
 def _resolve_campaigns_storage_backend() -> str:
-    if _truthy_env("FORCE_INMEMORY_BACKENDS"):
-        return "memory"
-
-    raw = (os.getenv("SMARTSELL_CAMPAIGNS_STORAGE") or "").strip().lower()
-    if raw in {"orm", "memory", "legacy_sql"}:
-        return raw
-    if raw == "sql":
-        return "legacy_sql"
-
-    # Backward compatibility
-    if _truthy_env("SMARTSELL_USE_SQL"):
-        return "legacy_sql"
-
-    # Default: ORM (never legacy_sql by default)
-    return "orm"
+    return resolve_campaigns_storage_backend()
 
 
 def _normalize_campaigns_db_url() -> str | None:
-    raw = os.getenv("DATABASE_URL") or os.getenv("DB_URL") or ""
-    url = raw.strip()
-    if not url:
-        return None
-    if url.startswith("postgresql+asyncpg://"):
-        return url.replace("postgresql+asyncpg://", "postgresql+psycopg2://", 1)
-    if url.startswith("postgresql+psycopg://"):
-        return url.replace("postgresql+psycopg://", "postgresql+psycopg2://", 1)
-    return url
+    return normalize_campaigns_db_url()
 
 
 def _init_campaigns_storage() -> Any:
@@ -389,60 +373,19 @@ def _save_campaign(c: Campaign) -> None:
     storage.save_campaign(c.model_dump())
 
 
-_ORM_ACTIVE_STATUSES = [
-    DbCampaignStatus.ACTIVE,
-    DbCampaignStatus.READY,
-    DbCampaignStatus.SCHEDULED,
-    DbCampaignStatus.RUNNING,
-    DbCampaignStatus.SUCCESS,
-]
+_ORM_ACTIVE_STATUSES = ORM_ACTIVE_STATUSES
 
 
 def _orm_status_is_active(status: DbCampaignStatus | None) -> bool:
-    if status is None:
-        return False
-    return status in _ORM_ACTIVE_STATUSES
+    return orm_status_is_active(status)
 
 
 def _orm_message_to_payload(message: DbMessage) -> dict[str, Any]:
-    return {
-        "id": message.id,
-        "recipient": message.recipient,
-        "content": message.content,
-        "status": message.status.value,
-        "channel": message.channel.value,
-        "scheduled_for": None,
-        "error": message.error_message,
-    }
+    return orm_message_to_payload(message)
 
 
 def _orm_campaign_to_payload(campaign: DbCampaign, messages: list[DbMessage]) -> dict[str, Any]:
-    processing_status = campaign.processing_status
-    if processing_status is None:
-        processing_status = DbCampaignProcessingStatus.DONE
-    return {
-        "id": campaign.id,
-        "title": campaign.title,
-        "description": campaign.description,
-        "active": _orm_status_is_active(campaign.status),
-        "archived": campaign.deleted_at is not None,
-        "company_id": campaign.company_id,
-        "tags": [],
-        "messages": [_orm_message_to_payload(message) for message in messages],
-        "created_at": campaign.created_at.isoformat() if campaign.created_at else None,
-        "updated_at": campaign.updated_at.isoformat() if campaign.updated_at else None,
-        "schedule": campaign.scheduled_at.isoformat() if campaign.scheduled_at else None,
-        "owner": None,
-        "processing_status": processing_status.value,
-        "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
-        "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
-        "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
-        "failed_at": campaign.failed_at.isoformat() if campaign.failed_at else None,
-        "next_attempt_at": campaign.next_attempt_at.isoformat() if campaign.next_attempt_at else None,
-        "last_error": campaign.last_error,
-        "attempts": int(campaign.attempts or 0),
-        "request_id": campaign.request_id,
-    }
+    return orm_campaign_to_payload(campaign, messages)
 
 
 def _title_exists(
@@ -839,17 +782,7 @@ async def queue_campaign_run_store(
         DbCampaignProcessingStatus.QUEUED,
         DbCampaignProcessingStatus.PROCESSING,
     ) and not should_force_requeue(campaign):
-        return {
-            "campaign_id": campaign.id,
-            "status": campaign.processing_status.value,
-            "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
-            "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
-            "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
-            "failed_at": campaign.failed_at.isoformat() if campaign.failed_at else None,
-            "last_error": campaign.last_error,
-            "attempts": campaign.attempts,
-            "request_id": campaign.request_id or request_id,
-        }
+        return build_campaign_queue_response(campaign, campaign.request_id or request_id)
 
     campaign = await queue_campaign_run(
         db,
@@ -861,31 +794,14 @@ async def queue_campaign_run_store(
 
     backend = _get_campaigns_storage_backend()
     if backend != "orm":
-        stored = storage.get_campaign(campaign_id)
-        if stored:
-            stored["processing_status"] = campaign.processing_status.value
-            stored["queued_at"] = campaign.queued_at.isoformat() if campaign.queued_at else None
-            stored["started_at"] = campaign.started_at.isoformat() if campaign.started_at else None
-            stored["finished_at"] = campaign.finished_at.isoformat() if campaign.finished_at else None
-            stored["failed_at"] = campaign.failed_at.isoformat() if campaign.failed_at else None
-            stored["next_attempt_at"] = campaign.next_attempt_at.isoformat() if campaign.next_attempt_at else None
-            stored["last_error"] = campaign.last_error
-            stored["attempts"] = int(campaign.attempts or 0)
-            stored["request_id"] = campaign.request_id
-            stored["updated_at"] = _now_iso()
-            storage.save_campaign(stored)
+        sync_storage_campaign_processing(
+            storage=storage,
+            campaign_id=campaign_id,
+            campaign=campaign,
+            now_iso=_now_iso(),
+        )
 
-    return {
-        "campaign_id": campaign.id,
-        "status": campaign.processing_status.value,
-        "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
-        "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
-        "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
-        "failed_at": campaign.failed_at.isoformat() if campaign.failed_at else None,
-        "last_error": campaign.last_error,
-        "attempts": campaign.attempts,
-        "request_id": request_id,
-    }
+    return build_campaign_queue_response(campaign, request_id)
 
 
 # ---- Diagnostics / Search / Export / Import / Drafts (статические пути) ------

--- a/app/api/v1/campaigns_api_helpers.py
+++ b/app/api/v1/campaigns_api_helpers.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from app.api.v1.campaigns_storage import InMemoryStorage
+from app.models.campaign import Campaign as DbCampaign
+from app.models.campaign import CampaignProcessingStatus as DbCampaignProcessingStatus
+from app.models.campaign import CampaignStatus as DbCampaignStatus
+from app.models.campaign import Message as DbMessage
+
+logger = logging.getLogger(__name__)
+
+_STORAGE_BACKEND: str | None = None
+_STORAGE_INSTANCE: Any | None = None
+
+
+def truthy_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def resolve_campaigns_storage_backend() -> str:
+    if truthy_env("FORCE_INMEMORY_BACKENDS"):
+        return "memory"
+
+    raw = (os.getenv("SMARTSELL_CAMPAIGNS_STORAGE") or "").strip().lower()
+    if raw in {"orm", "memory", "legacy_sql"}:
+        return raw
+    if raw == "sql":
+        return "legacy_sql"
+
+    if truthy_env("SMARTSELL_USE_SQL"):
+        return "legacy_sql"
+
+    return "orm"
+
+
+def normalize_campaigns_db_url() -> str | None:
+    raw = os.getenv("DATABASE_URL") or os.getenv("DB_URL") or ""
+    url = raw.strip()
+    if not url:
+        return None
+    if url.startswith("postgresql+asyncpg://"):
+        return url.replace("postgresql+asyncpg://", "postgresql+psycopg2://", 1)
+    if url.startswith("postgresql+psycopg://"):
+        return url.replace("postgresql+psycopg://", "postgresql+psycopg2://", 1)
+    return url
+
+
+def init_campaigns_storage() -> Any:
+    global _STORAGE_BACKEND, _STORAGE_INSTANCE
+    if _STORAGE_INSTANCE is not None:
+        return _STORAGE_INSTANCE
+
+    backend = resolve_campaigns_storage_backend()
+    if backend == "legacy_sql":
+        try:
+            from app.storage.campaigns_sql import CampaignsStorageSQL  # type: ignore
+
+            _STORAGE_INSTANCE = CampaignsStorageSQL(db_url=normalize_campaigns_db_url())
+            _STORAGE_BACKEND = "legacy_sql"
+            return _STORAGE_INSTANCE
+        except Exception as exc:
+            logger.warning("Campaigns SQL storage unavailable; falling back to memory: %s", exc)
+
+    _STORAGE_INSTANCE = InMemoryStorage()
+    _STORAGE_BACKEND = backend if backend in {"orm", "memory"} else "memory"
+    return _STORAGE_INSTANCE
+
+
+def get_campaigns_storage() -> Any:
+    return init_campaigns_storage()
+
+
+def get_campaigns_storage_backend() -> str:
+    if _STORAGE_BACKEND is not None:
+        return _STORAGE_BACKEND
+    return resolve_campaigns_storage_backend()
+
+
+ORM_ACTIVE_STATUSES = [
+    DbCampaignStatus.ACTIVE,
+    DbCampaignStatus.READY,
+    DbCampaignStatus.SCHEDULED,
+    DbCampaignStatus.RUNNING,
+    DbCampaignStatus.SUCCESS,
+]
+
+
+def orm_status_is_active(status: DbCampaignStatus | None) -> bool:
+    if status is None:
+        return False
+    return status in ORM_ACTIVE_STATUSES
+
+
+def orm_message_to_payload(message: DbMessage) -> dict[str, Any]:
+    return {
+        "id": message.id,
+        "recipient": message.recipient,
+        "content": message.content,
+        "status": message.status.value,
+        "channel": message.channel.value,
+        "scheduled_for": None,
+        "error": message.error_message,
+    }
+
+
+def orm_campaign_to_payload(campaign: DbCampaign, messages: list[DbMessage]) -> dict[str, Any]:
+    processing_status = campaign.processing_status
+    if processing_status is None:
+        processing_status = DbCampaignProcessingStatus.DONE
+    return {
+        "id": campaign.id,
+        "title": campaign.title,
+        "description": campaign.description,
+        "active": orm_status_is_active(campaign.status),
+        "archived": campaign.deleted_at is not None,
+        "company_id": campaign.company_id,
+        "tags": [],
+        "messages": [orm_message_to_payload(message) for message in messages],
+        "created_at": campaign.created_at.isoformat() if campaign.created_at else None,
+        "updated_at": campaign.updated_at.isoformat() if campaign.updated_at else None,
+        "schedule": campaign.scheduled_at.isoformat() if campaign.scheduled_at else None,
+        "owner": None,
+        "processing_status": processing_status.value,
+        "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
+        "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
+        "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
+        "failed_at": campaign.failed_at.isoformat() if campaign.failed_at else None,
+        "next_attempt_at": campaign.next_attempt_at.isoformat() if campaign.next_attempt_at else None,
+        "last_error": campaign.last_error,
+        "attempts": int(campaign.attempts or 0),
+        "request_id": campaign.request_id,
+    }
+
+
+def build_campaign_queue_response(campaign: DbCampaign, request_id: str | None) -> dict[str, Any]:
+    return {
+        "campaign_id": campaign.id,
+        "status": campaign.processing_status.value,
+        "queued_at": campaign.queued_at.isoformat() if campaign.queued_at else None,
+        "started_at": campaign.started_at.isoformat() if campaign.started_at else None,
+        "finished_at": campaign.finished_at.isoformat() if campaign.finished_at else None,
+        "failed_at": campaign.failed_at.isoformat() if campaign.failed_at else None,
+        "last_error": campaign.last_error,
+        "attempts": campaign.attempts,
+        "request_id": request_id,
+    }
+
+
+def sync_storage_campaign_processing(
+    *,
+    storage: Any,
+    campaign_id: int,
+    campaign: DbCampaign,
+    now_iso: str,
+) -> None:
+    stored = storage.get_campaign(campaign_id)
+    if not stored:
+        return
+    stored["processing_status"] = campaign.processing_status.value
+    stored["queued_at"] = campaign.queued_at.isoformat() if campaign.queued_at else None
+    stored["started_at"] = campaign.started_at.isoformat() if campaign.started_at else None
+    stored["finished_at"] = campaign.finished_at.isoformat() if campaign.finished_at else None
+    stored["failed_at"] = campaign.failed_at.isoformat() if campaign.failed_at else None
+    stored["next_attempt_at"] = campaign.next_attempt_at.isoformat() if campaign.next_attempt_at else None
+    stored["last_error"] = campaign.last_error
+    stored["attempts"] = int(campaign.attempts or 0)
+    stored["request_id"] = campaign.request_id
+    stored["updated_at"] = now_iso
+    storage.save_campaign(stored)
+
+
+__all__ = [
+    "ORM_ACTIVE_STATUSES",
+    "build_campaign_queue_response",
+    "get_campaigns_storage",
+    "get_campaigns_storage_backend",
+    "init_campaigns_storage",
+    "normalize_campaigns_db_url",
+    "orm_campaign_to_payload",
+    "orm_message_to_payload",
+    "orm_status_is_active",
+    "resolve_campaigns_storage_backend",
+    "sync_storage_campaign_processing",
+    "truthy_env",
+]

--- a/app/api/v1/reports.py
+++ b/app/api/v1/reports.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-import csv
-import json
 import os
 import re
-from datetime import UTC, date, datetime, time
+from datetime import date, datetime
 from decimal import Decimal
-from io import BytesIO, StringIO
+from io import BytesIO
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi import APIRouter, Depends, Query, Request, Response
 from fastapi.responses import StreamingResponse
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4
@@ -19,6 +17,39 @@ from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, Tabl
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.v1.reports_api_helpers import (
+    _date_bounds as helpers_date_bounds,
+)
+from app.api.v1.reports_api_helpers import (
+    _extract_kaspi_attrs as helpers_extract_kaspi_attrs,
+)
+from app.api.v1.reports_api_helpers import (
+    _log_report_event as helpers_log_report_event,
+)
+from app.api.v1.reports_api_helpers import (
+    _log_report_pdf_event as helpers_log_report_pdf_event,
+)
+from app.api.v1.reports_api_helpers import (
+    _parse_date as helpers_parse_date,
+)
+from app.api.v1.reports_api_helpers import (
+    _parse_dt as helpers_parse_dt,
+)
+from app.api.v1.reports_api_helpers import (
+    _resolve_company_id_param as helpers_resolve_company_id_param,
+)
+from app.api.v1.reports_api_helpers import (
+    _resolve_wallet_report_company_id as helpers_resolve_wallet_report_company_id,
+)
+from app.api.v1.reports_api_helpers import (
+    _safe_reference as helpers_safe_reference,
+)
+from app.api.v1.reports_api_helpers import (
+    _to_optional_str as helpers_to_optional_str,
+)
+from app.api.v1.reports_api_helpers import (
+    build_csv_streaming_response as helpers_build_csv_streaming_response,
+)
 from app.core.db import get_async_db
 from app.core.dependencies import (
     get_current_verified_user,
@@ -26,9 +57,7 @@ from app.core.dependencies import (
     require_company_access,
     require_store_admin_company,
 )
-from app.core.exceptions import AuthorizationError, NotFoundError, _ensure_request_id
-from app.core.logging import audit_logger
-from app.core.rbac import is_platform_admin, is_store_admin, is_store_manager
+from app.core.rbac import is_platform_admin
 from app.core.security import resolve_tenant_company_id
 from app.core.subscriptions import FEATURE_PREORDERS, FEATURE_REPRICING, require_feature
 from app.models.billing import BillingInvoice, WalletBalance, WalletTransaction
@@ -62,110 +91,38 @@ router = APIRouter(
 
 
 def _parse_dt(value: str | None, field: str) -> datetime | None:
-    if not value:
-        return None
-    v = value.strip()
-    if v.endswith("Z"):
-        v = v[:-1] + "+00:00"
-    try:
-        dt = datetime.fromisoformat(v)
-    except Exception as exc:
-        raise HTTPException(status_code=422, detail=f"{field} must be ISO 8601") from exc
-    if dt.tzinfo is not None:
-        dt = dt.astimezone(UTC).replace(tzinfo=None)
-    return dt
+    return helpers_parse_dt(value, field)
 
 
 def _parse_date(value: str | None, field: str) -> date | None:
-    if not value:
-        return None
-    try:
-        return date.fromisoformat(value.strip())
-    except Exception as exc:
-        raise HTTPException(status_code=422, detail=f"{field} must be YYYY-MM-DD") from exc
+    return helpers_parse_date(value, field)
 
 
 def _date_bounds(date_from: date | None, date_to: date | None) -> tuple[datetime | None, datetime | None]:
-    start_dt = datetime.combine(date_from, time.min) if date_from else None
-    end_dt = datetime.combine(date_to, time.max) if date_to else None
-    return start_dt, end_dt
+    return helpers_date_bounds(date_from, date_to)
 
 
 def _resolve_wallet_report_company_id(
     current_user: User,
     company_id: int | None,
 ) -> int:
-    if is_platform_admin(current_user):
-        if company_id is not None:
-            return int(company_id)
-        return resolve_tenant_company_id(current_user, not_found_detail="Company not set")
-    if not (is_store_admin(current_user) or is_store_manager(current_user)):
-        raise AuthorizationError("Admin role required", "ADMIN_REQUIRED")
-    resolved_company_id = resolve_tenant_company_id(current_user, not_found_detail="Company not set")
-    if company_id is not None and int(company_id) != int(resolved_company_id):
-        raise NotFoundError("company_not_found", code="company_not_found", http_status=404)
-    return int(resolved_company_id)
+    return helpers_resolve_wallet_report_company_id(current_user, company_id)
 
 
 def _safe_reference(reference_type: str | None, reference_id: int | None) -> str:
-    ref = (reference_type or "").strip()
-    if not ref:
-        return ""
-    if reference_id is None:
-        return ref
-    return f"{ref}:{reference_id}"
+    return helpers_safe_reference(reference_type, reference_id)
 
 
 def _extract_kaspi_attrs(internal_notes: Any) -> dict[str, Any]:
-    if internal_notes is None:
-        return {}
-    if isinstance(internal_notes, dict):
-        data = internal_notes
-    elif isinstance(internal_notes, str):
-        try:
-            data = json.loads(internal_notes) if internal_notes.strip() else {}
-        except json.JSONDecodeError:
-            return {}
-    else:
-        return {}
-    if not isinstance(data, dict):
-        return {}
-    kaspi = data.get("kaspi")
-    return kaspi if isinstance(kaspi, dict) else {}
+    return helpers_extract_kaspi_attrs(internal_notes)
 
 
 def _to_optional_str(value: Any) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        return value
-    return str(value)
+    return helpers_to_optional_str(value)
 
 
 def _resolve_company_id_param(request: Request, company_id: int | None) -> int | None:
-    if company_id is not None:
-        return int(company_id)
-    raw = request.query_params.get("company_id")
-    if raw is None:
-        return None
-    try:
-        return int(raw)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail="company_id must be integer") from exc
-
-
-def _csv_stream(rows: list[dict[str, str]], headers: list[str]) -> Any:
-    buffer = StringIO()
-    writer = csv.writer(buffer, lineterminator="\n")
-    writer.writerow(headers)
-    yield buffer.getvalue().encode("utf-8")
-    buffer.seek(0)
-    buffer.truncate(0)
-    for row in rows:
-        writer.writerow([row.get(col, "") for col in headers])
-        yield buffer.getvalue().encode("utf-8")
-        buffer.seek(0)
-        buffer.truncate(0)
+    return helpers_resolve_company_id_param(request, company_id)
 
 
 def _log_report_event(
@@ -178,19 +135,14 @@ def _log_report_event(
     limit: int,
     rows_count: int,
 ) -> None:
-    request_id = _ensure_request_id(request)
-    audit_logger.log_system_event(
-        level="info",
+    helpers_log_report_event(
+        request=request,
         event=event,
-        message="CSV report generated",
-        meta={
-            "request_id": request_id,
-            "company_id": resolved_company_id,
-            "date_from": date_from,
-            "date_to": date_to,
-            "limit": limit,
-            "rows_count": rows_count,
-        },
+        resolved_company_id=resolved_company_id,
+        date_from=date_from,
+        date_to=date_to,
+        limit=limit,
+        rows_count=rows_count,
     )
 
 
@@ -205,23 +157,15 @@ def _log_report_pdf_event(
     rows_count: int | None = None,
     extra_meta: dict[str, Any] | None = None,
 ) -> None:
-    request_id = _ensure_request_id(request)
-    meta: dict[str, Any] = {
-        "request_id": request_id,
-        "company_id": resolved_company_id,
-        "date_from": date_from,
-        "date_to": date_to,
-        "limit": limit,
-    }
-    if rows_count is not None:
-        meta["rows_count"] = rows_count
-    if extra_meta:
-        meta.update(extra_meta)
-    audit_logger.log_system_event(
-        level="info",
+    helpers_log_report_pdf_event(
+        request=request,
         event=event,
-        message="PDF report generated",
-        meta=meta,
+        resolved_company_id=resolved_company_id,
+        date_from=date_from,
+        date_to=date_to,
+        limit=limit,
+        rows_count=rows_count,
+        extra_meta=extra_meta,
     )
 
 
@@ -698,10 +642,10 @@ async def report_wallet_transactions_csv(
         "balance_after",
     ]
 
-    return StreamingResponse(
-        _csv_stream(rows, headers),
-        media_type="text/csv; charset=utf-8",
-        headers={"Content-Disposition": "attachment; filename=wallet-transactions.csv"},
+    return helpers_build_csv_streaming_response(
+        rows=rows,
+        headers=headers,
+        filename="wallet-transactions.csv",
     )
 
 
@@ -761,10 +705,10 @@ async def report_orders_csv(
         "kaspi_reservation_date",
     ]
 
-    return StreamingResponse(
-        _csv_stream(rows, headers),
-        media_type="text/csv; charset=utf-8",
-        headers={"Content-Disposition": "attachment; filename=orders.csv"},
+    return helpers_build_csv_streaming_response(
+        rows=rows,
+        headers=headers,
+        filename="orders.csv",
     )
 
 
@@ -826,10 +770,10 @@ async def report_order_items_csv(
         "created_at",
     ]
 
-    return StreamingResponse(
-        _csv_stream(rows, headers),
-        media_type="text/csv; charset=utf-8",
-        headers={"Content-Disposition": "attachment; filename=order-items.csv"},
+    return helpers_build_csv_streaming_response(
+        rows=rows,
+        headers=headers,
+        filename="order-items.csv",
     )
 
 
@@ -892,10 +836,10 @@ async def report_preorders_csv(
         "fulfilled_at",
     ]
 
-    return StreamingResponse(
-        _csv_stream(rows, headers),
-        media_type="text/csv; charset=utf-8",
-        headers={"Content-Disposition": "attachment; filename=preorders.csv"},
+    return helpers_build_csv_streaming_response(
+        rows=rows,
+        headers=headers,
+        filename="preorders.csv",
     )
 
 
@@ -950,10 +894,10 @@ async def report_inventory_csv(
         "updated_at",
     ]
 
-    return StreamingResponse(
-        _csv_stream(rows, headers),
-        media_type="text/csv; charset=utf-8",
-        headers={"Content-Disposition": "attachment; filename=inventory.csv"},
+    return helpers_build_csv_streaming_response(
+        rows=rows,
+        headers=headers,
+        filename="inventory.csv",
     )
 
 
@@ -1018,10 +962,10 @@ async def report_repricing_runs_csv(
         "request_id",
     ]
 
-    return StreamingResponse(
-        _csv_stream(rows, headers),
-        media_type="text/csv; charset=utf-8",
-        headers={"Content-Disposition": "attachment; filename=repricing-runs.csv"},
+    return helpers_build_csv_streaming_response(
+        rows=rows,
+        headers=headers,
+        filename="repricing-runs.csv",
     )
 
 

--- a/app/api/v1/reports_api_helpers.py
+++ b/app/api/v1/reports_api_helpers.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import csv
+import json
+from datetime import UTC, date, datetime, time
+from io import StringIO
+from typing import Any
+
+from fastapi import HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from app.core.exceptions import AuthorizationError, NotFoundError, _ensure_request_id
+from app.core.logging import audit_logger
+from app.core.rbac import is_platform_admin, is_store_admin, is_store_manager
+from app.core.security import resolve_tenant_company_id
+from app.models.user import User
+
+
+def _parse_dt(value: str | None, field: str) -> datetime | None:
+    if not value:
+        return None
+    v = value.strip()
+    if v.endswith("Z"):
+        v = v[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(v)
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail=f"{field} must be ISO 8601") from exc
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(UTC).replace(tzinfo=None)
+    return dt
+
+
+def _parse_date(value: str | None, field: str) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value.strip())
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail=f"{field} must be YYYY-MM-DD") from exc
+
+
+def _date_bounds(date_from: date | None, date_to: date | None) -> tuple[datetime | None, datetime | None]:
+    start_dt = datetime.combine(date_from, time.min) if date_from else None
+    end_dt = datetime.combine(date_to, time.max) if date_to else None
+    return start_dt, end_dt
+
+
+def _resolve_wallet_report_company_id(
+    current_user: User,
+    company_id: int | None,
+) -> int:
+    if is_platform_admin(current_user):
+        if company_id is not None:
+            return int(company_id)
+        return resolve_tenant_company_id(current_user, not_found_detail="Company not set")
+    if not (is_store_admin(current_user) or is_store_manager(current_user)):
+        raise AuthorizationError("Admin role required", "ADMIN_REQUIRED")
+    resolved_company_id = resolve_tenant_company_id(current_user, not_found_detail="Company not set")
+    if company_id is not None and int(company_id) != int(resolved_company_id):
+        raise NotFoundError("company_not_found", code="company_not_found", http_status=404)
+    return int(resolved_company_id)
+
+
+def _safe_reference(reference_type: str | None, reference_id: int | None) -> str:
+    ref = (reference_type or "").strip()
+    if not ref:
+        return ""
+    if reference_id is None:
+        return ref
+    return f"{ref}:{reference_id}"
+
+
+def _extract_kaspi_attrs(internal_notes: Any) -> dict[str, Any]:
+    if internal_notes is None:
+        return {}
+    if isinstance(internal_notes, dict):
+        data = internal_notes
+    elif isinstance(internal_notes, str):
+        try:
+            data = json.loads(internal_notes) if internal_notes.strip() else {}
+        except json.JSONDecodeError:
+            return {}
+    else:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    kaspi = data.get("kaspi")
+    return kaspi if isinstance(kaspi, dict) else {}
+
+
+def _to_optional_str(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _resolve_company_id_param(request: Request, company_id: int | None) -> int | None:
+    if company_id is not None:
+        return int(company_id)
+    raw = request.query_params.get("company_id")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="company_id must be integer") from exc
+
+
+def _csv_stream(rows: list[dict[str, str]], headers: list[str]) -> Any:
+    buffer = StringIO()
+    writer = csv.writer(buffer, lineterminator="\n")
+    writer.writerow(headers)
+    yield buffer.getvalue().encode("utf-8")
+    buffer.seek(0)
+    buffer.truncate(0)
+    for row in rows:
+        writer.writerow([row.get(col, "") for col in headers])
+        yield buffer.getvalue().encode("utf-8")
+        buffer.seek(0)
+        buffer.truncate(0)
+
+
+def build_csv_streaming_response(
+    *,
+    rows: list[dict[str, str]],
+    headers: list[str],
+    filename: str,
+) -> StreamingResponse:
+    return StreamingResponse(
+        _csv_stream(rows, headers),
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+
+def _log_report_event(
+    *,
+    request: Request,
+    event: str,
+    resolved_company_id: int,
+    date_from: str | None,
+    date_to: str | None,
+    limit: int,
+    rows_count: int,
+) -> None:
+    request_id = _ensure_request_id(request)
+    audit_logger.log_system_event(
+        level="info",
+        event=event,
+        message="CSV report generated",
+        meta={
+            "request_id": request_id,
+            "company_id": resolved_company_id,
+            "date_from": date_from,
+            "date_to": date_to,
+            "limit": limit,
+            "rows_count": rows_count,
+        },
+    )
+
+
+def _log_report_pdf_event(
+    *,
+    request: Request,
+    event: str,
+    resolved_company_id: int,
+    date_from: str | None,
+    date_to: str | None,
+    limit: int,
+    rows_count: int | None = None,
+    extra_meta: dict[str, Any] | None = None,
+) -> None:
+    request_id = _ensure_request_id(request)
+    meta: dict[str, Any] = {
+        "request_id": request_id,
+        "company_id": resolved_company_id,
+        "date_from": date_from,
+        "date_to": date_to,
+        "limit": limit,
+    }
+    if rows_count is not None:
+        meta["rows_count"] = rows_count
+    if extra_meta:
+        meta.update(extra_meta)
+    audit_logger.log_system_event(
+        level="info",
+        event=event,
+        message="PDF report generated",
+        meta=meta,
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -1584,9 +1584,7 @@ def _create_app() -> FastAPI:
             return item
 
         @fallback.put("/{cid}")
-        async def update_campaign(
-            cid: int = Path(..., ge=1), payload: dict[str, Any] = Body(...)
-        ) -> dict[str, Any]:
+        async def update_campaign(cid: int = Path(..., ge=1), payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
             item = _find_campaign(cid)
             if not item:
                 raise HTTPException(status_code=404, detail="not_found")

--- a/app/main_helpers.py
+++ b/app/main_helpers.py
@@ -139,7 +139,11 @@ async def run_lifespan_startup(
         logger.warning("startup side effects failed: %s", e)
     try:
         env_val = str(getattr(settings, "ENVIRONMENT", "") or "").lower()
-        if not core_config._under_pytest() and env_val != "local" and getattr(settings, "DB_URL_SOURCE", "") == "DEFAULT":
+        if (
+            not core_config._under_pytest()
+            and env_val != "local"
+            and getattr(settings, "DB_URL_SOURCE", "") == "DEFAULT"
+        ):
             raise RuntimeError("DATABASE_URL is required for non-local environments")
     except Exception as e:
         if isinstance(e, RuntimeError):
@@ -188,7 +192,9 @@ async def run_lifespan_startup(
 
     try:
         role = getattr(settings, "PROCESS_ROLE", os.getenv("PROCESS_ROLE", "web")) or "web"
-        enable_scheduler = env_truthy(os.getenv("ENABLE_SCHEDULER", "0")) or getattr(settings, "ENABLE_SCHEDULER", False)
+        enable_scheduler = env_truthy(os.getenv("ENABLE_SCHEDULER", "0")) or getattr(
+            settings, "ENABLE_SCHEDULER", False
+        )
         background_tasks_enabled = env_truthy(os.getenv("SMARTSELL_BACKGROUND_TASKS", "1"), True)
         allowed_roles = {"web", "worker", "scheduler"}
         if role not in allowed_roles:


### PR DESCRIPTION
## Summary

This PR closes out Phase 1 of the SmartSell safe-refactor roadmap.

Scope completed:
- safe refactor of `app/api/v1/campaigns.py`
- safe refactor of `app/api/v1/reports.py`
- registration cleanup in `app/api/routes/__init__.py`
- helper extraction from `app/api/v1/admin.py`

## What changed

### New helper modules
- `app/api/v1/campaigns_api_helpers.py`
- `app/api/v1/reports_api_helpers.py`
- `app/api/v1/admin_api_helpers.py`

### Updated modules
- `app/api/v1/campaigns.py`
- `app/api/v1/reports.py`
- `app/api/v1/admin.py`
- `app/api/routes/__init__.py`

## Intent

This was a strict safe-refactor wave.

Goals:
- reduce overload in large API modules
- extract repeated pure/internal helper logic
- preserve route contracts and runtime behavior
- keep patches reviewable and low risk

## Non-goals

This PR does **not**:
- change API contracts
- change route paths
- change request/response schemas
- change RBAC/auth behavior
- change tenant scope behavior
- introduce new features
- redesign business logic

## Validation

Passed:
- `ruff check .`
- `ruff format .`
- `python -m pytest -q tests/app/api/test_openapi_legacy_contract.py`
- `python -c "import app.main"`
- focused regression sweep across touched areas:
  - campaigns
  - reports
  - admin campaign queue/admin access
  - route registration/debug endpoint

Focused sweep result:
- `66 passed`

## Residual risk

A previous full-suite run showed async teardown/session cleanup instability (`asyncpg` / rollback / teardown path).
This is tracked as a separate environment/test-stability concern and is **not** currently proven to be caused by this refactor wave.

## Outcome

Phase 1 is considered merge-ready based on:
- lint-clean repo state
- OpenAPI contract validation
- import smoke
- focused behavioral regression coverage for all touched areas