### PR TITLE
Phase 3 Safe Refactor: deduplicate wallet route exception mapping

### DIFF
--- a/app/api/v1/wallet.py
+++ b/app/api/v1/wallet.py
@@ -103,6 +103,10 @@ def _pick_http_status(exc: Exception) -> int:
     return status.HTTP_400_BAD_REQUEST
 
 
+def _raise_http_from_exception(exc: Exception) -> None:
+    raise HTTPException(status_code=_pick_http_status(exc), detail=str(exc))
+
+
 def _safe_bool(v: Any, default: bool = False) -> bool:
     try:
         return bool(v)
@@ -448,7 +452,7 @@ async def list_accounts(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=_pick_http_status(e), detail=str(e))
+        _raise_http_from_exception(e)
 
 
 @read_router.get(
@@ -483,7 +487,7 @@ async def get_account_by_user_currency(
     except NotFoundError:
         raise
     except Exception as e:
-        raise HTTPException(status_code=_pick_http_status(e), detail=str(e))
+        _raise_http_from_exception(e)
 
 
 @read_router.get(
@@ -511,7 +515,7 @@ async def get_account(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=_pick_http_status(e), detail=str(e))
+        _raise_http_from_exception(e)
 
 
 @read_router.get(
@@ -540,7 +544,7 @@ async def get_balance(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=_pick_http_status(e), detail=str(e))
+        _raise_http_from_exception(e)
 
 
 # =============================================================================
@@ -699,7 +703,7 @@ async def ledger(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=_pick_http_status(e), detail=str(e))
+        _raise_http_from_exception(e)
 
 
 # =============================================================================
@@ -743,7 +747,7 @@ async def adjust_balance(
         raise
     except Exception as e:
         await db.rollback()
-        raise HTTPException(status_code=_pick_http_status(e), detail=str(e))
+        _raise_http_from_exception(e)
 
 
 router.include_router(read_router)


### PR DESCRIPTION
## Summary

This PR continues the SmartSell safe-refactor roadmap with a very small cleanup in `app/api/v1/wallet.py`.

## Scope

- adds a tiny private helper for repeated exception-to-HTTPException mapping
- replaces duplicated identical `except Exception` branches with the shared helper
- keeps route decorators, signatures, payloads, and behavior unchanged

## Non-goals

This PR does not:
- change wallet/accounting semantics
- change RBAC/auth
- change tenant isolation
- change API contracts or OpenAPI
- change request/response schemas
- change route paths/prefixes/tags

## Validation

Passed:
- `ruff check .`
- `ruff format .`
- `python -c "import app.main; print('ok')"`
- `pytest -q tests/app/api/test_openapi_legacy_contract.py`
- `pytest -q tests/app/api/test_wallet_rbac.py tests/app/api/test_wallet_payments_tenant.py tests/app/test_wallet_by_user.py`
- `pytest -q tests/app/test_wallet_invariants.py tests/app/test_wallet_idempotency.py tests/app/test_reports_wallet_transactions_csv.py`
- `pytest -q tests/app/test_tenant_isolation_billing.py`

## Outcome

This is a strict behavior-preserving safe refactor limited to route-level exception mapping deduplication in `wallet.py`.