### PR TITLE
docs(launch): add first-client launch scorecard and closure plan

### DIFF
--- a/SMARTSELL_FIRST_CLIENT_LAUNCH_CLOSURE_PLAN.md
+++ b/SMARTSELL_FIRST_CLIENT_LAUNCH_CLOSURE_PLAN.md
@@ -1,0 +1,205 @@
+# SMARTSELL_FIRST_CLIENT_LAUNCH_CLOSURE_PLAN
+
+Date: 2026-03-14
+Scope: First-client launch closure from current `CONDITIONAL PASS` scorecard state.
+
+Source baseline:
+- `SMARTSELL_FIRST_CLIENT_LAUNCH_SCORECARD.md`
+- `SMARTSELL_RELEASE_CHECKLIST.md`
+- `PRODUCTION_DEPLOYMENT_CHECKLIST.md`
+- `SMARTSELL_ONBOARDING_PLAYBOOK.md`
+- `SMARTSELL_ONBOARDING_DRY_RUN.md`
+- `SMARTSELL_INCIDENT_PROCESS.md`
+- `SMARTSELL_DR_RESTORE_DRILL.md`
+- `SMARTSELL_RUNTIME_REHEARSAL_EVIDENCE.md`
+- `SMARTSELL_RELEASE_DRY_RUN_EVIDENCE.md`
+
+---
+
+## 1) Ranked blocker-closure plan
+
+### Blocker 1 — Release gate closure is not completed in operator checklist
+- Exact objective:
+  - Close one concrete release candidate in `SMARTSELL_RELEASE_CHECKLIST.md` with explicit checkmarks and linked evidence outputs.
+- Owner:
+  - Founder/Ops (primary), Backend (evidence support).
+- Evidence required:
+  - Candidate version/commit stamp.
+  - Migration pass output.
+  - Focused smoke pass output.
+  - Health/readiness confirmation (`/api/v1/health`, `/ready`, wallet/worker check).
+  - Rollback readiness confirmation and artifact presence (`tmp/drill/smartsell_main_drill.sql`).
+- Completion condition:
+  - All pre-release and post-deploy checks marked complete in `SMARTSELL_RELEASE_CHECKLIST.md` for the selected candidate; links to evidence packet attached.
+- Can it be done without code changes?
+  - **Yes.**
+
+### Blocker 2 — Production deploy prerequisites not formally closed
+- Exact objective:
+  - Close minimum mandatory deployment controls in `PRODUCTION_DEPLOYMENT_CHECKLIST.md` (not entire long-form list).
+- Owner:
+  - Founder/Ops.
+- Evidence required:
+  - Environment/security proof (`ENVIRONMENT=production`, `DEBUG=0`, host/CORS restrictions, secrets set).
+  - DB/Redis connectivity outputs.
+  - TLS/reverse proxy verification output.
+  - Backup path confirmation and latest backup identifier.
+  - Deploy command path confirmation (`docker compose ...` / migration command outputs).
+- Completion condition:
+  - A clearly marked “minimum first-client subset” in `PRODUCTION_DEPLOYMENT_CHECKLIST.md` is checked and signed by owner.
+- Can it be done without code changes?
+  - **Yes.**
+
+### Blocker 3 — Incident operation is documented but not launch-operationalized
+- Exact objective:
+  - Operationalize `SMARTSELL_INCIDENT_PROCESS.md` for launch week with named owner, escalation contacts, and one timed drill.
+- Owner:
+  - Founder/Ops.
+- Evidence required:
+  - Named Incident Owner + backup owner.
+  - Completed timed incident drill record using internal + customer templates.
+  - SLA acknowledgement timing log (Sev-1/Sev-2 target adherence).
+- Completion condition:
+  - One completed launch-week incident drill log archived and linked from launch packet; owner assignment published.
+- Can it be done without code changes?
+  - **Yes.**
+
+### Blocker 4 — DR go/no-go gate is implicit, not explicit
+- Exact objective:
+  - Convert DR evidence into explicit launch decision criteria (accepted RPO/RTO, rollback trigger, rollback owner).
+- Owner:
+  - Founder/Ops + Backend.
+- Evidence required:
+  - Existing restore cycle logs (`dr_cycle4`, `dr_cycle5`) mapped to measured duration.
+  - Declared accepted launch RPO/RTO values and rationale.
+  - Rollback owner and trigger conditions documented in meeting template.
+- Completion condition:
+  - DR section updated with explicit launch acceptance statement and referenced in go/no-go packet.
+- Can it be done without code changes?
+  - **Yes.**
+
+### Blocker 5 (Conditional) — Kaspi day-1 dependency unresolved
+- Exact objective:
+  - Resolve whether first client is Kaspi day-1 dependent; if yes, produce authenticated tenant-level Kaspi sanity evidence.
+- Owner:
+  - Founder/Ops (dependency decision), Backend (execution support).
+- Evidence required:
+  - Dependency decision record: “Kaspi required day-1: Yes/No”.
+  - If Yes: authenticated run output for tenant-level Kaspi status/sync health.
+  - If No: explicit non-blocking exception note with monitoring plan.
+- Completion condition:
+  - Either authenticated Kaspi sanity PASS attached, or signed exception that first client is non-Kaspi at launch.
+- Can it be done without code changes?
+  - **Usually yes.**
+  - **Escalate to engineering only if authenticated sanity fails due product defect.**
+
+---
+
+## 2) 7-day execution table
+
+| Day | Task | Owner | Input docs | Output artifact | Pass condition |
+|---|---|---|---|---|---|
+| Day 1 | Lock launch candidate and freeze non-essential changes | Founder/Ops | `SMARTSELL_FIRST_CLIENT_LAUNCH_SCORECARD.md`, `SMARTSELL_RELEASE_CHECKLIST.md` | `docs/launch/LAUNCH_CANDIDATE_YYYY-MM-DD.md` | Candidate commit/version fixed; freeze window announced; owners assigned (Go/No-Go, Incident, Rollback). |
+| Day 2 | Close release checklist with fresh evidence run | Founder/Ops + Backend | `SMARTSELL_RELEASE_CHECKLIST.md`, `SMARTSELL_RELEASE_DRY_RUN_EVIDENCE.md`, `SMARTSELL_RUNTIME_REHEARSAL_EVIDENCE.md` | `docs/launch/release_gate_run_YYYY-MM-DD.md` + terminal outputs | All checklist rows for chosen candidate checked; migration/smoke/health/rollback evidence attached. |
+| Day 3 | Close minimum production deploy prerequisite subset | Founder/Ops | `PRODUCTION_DEPLOYMENT_CHECKLIST.md` | `docs/launch/prod_prereq_signoff_YYYY-MM-DD.md` | Minimum first-client subset complete and signed (secrets, DB/Redis, TLS/proxy, backup path, deploy path). |
+| Day 4 | Incident launch-week drill and comms rehearsal | Founder/Ops | `SMARTSELL_INCIDENT_PROCESS.md` | `docs/launch/incident_drill_YYYY-MM-DD.md` | Timed drill completed; internal + customer templates filled; SLA timing meets targets; incident owner confirmed. |
+| Day 5 | DR closure and rollback authority finalization | Founder/Ops + Backend | `SMARTSELL_DR_RESTORE_DRILL.md`, `SMARTSELL_RELEASE_DRY_RUN_EVIDENCE.md` | `docs/launch/dr_acceptance_YYYY-MM-DD.md` | Accepted RPO/RTO explicitly recorded; rollback trigger and owner documented; restore evidence linked. |
+| Day 6 | Onboarding rehearsal-to-live bridge and packet pre-assembly | Founder/Ops + Backend | `SMARTSELL_ONBOARDING_PLAYBOOK.md`, `SMARTSELL_ONBOARDING_DRY_RUN.md` | `docs/launch/onboarding_packet_template_YYYY-MM-DD.md` | First-client onboarding packet template complete with required fields + evidence placeholders; day-1 script finalized. |
+| Day 7 | Final go/no-go meeting and first-client activation decision | Go/No-Go Owner (Founder/Ops) | All docs above + `SMARTSELL_FIRST_CLIENT_LAUNCH_SCORECARD.md` | `docs/launch/go_no_go_minutes_YYYY-MM-DD.md` | Decision is GO only if all blockers closed with links; otherwise NO-GO with next closure date. |
+
+---
+
+## 3) Launch evidence packet checklist
+
+Archive location (recommended): `docs/launch/evidence/<candidate_version_or_date>/`
+
+### A. Candidate identity and freeze
+- [ ] Candidate branch + commit hash output (`git rev-parse --abbrev-ref HEAD`, `git rev-parse --short HEAD`).
+- [ ] Timestamp of release window start/end.
+- [ ] Freeze announcement note.
+
+### B. Release gate evidence
+- [ ] Migration test output (`test_alembic_upgrade_head_runs`).
+- [ ] Focused smoke output (auth + diagnostics + tenant flow + role gating).
+- [ ] Health/readiness output (`/api/v1/health`, `/ready`, wallet/worker health if used).
+- [ ] Rollback readiness output (`test_upgrade_playbook_docs...`, backup artifact presence).
+
+### C. Production prerequisite evidence
+- [ ] Redacted environment checklist proof (required variables configured, no secret values exposed).
+- [ ] DB connectivity output.
+- [ ] Redis connectivity output.
+- [ ] TLS/proxy verification output.
+- [ ] Deploy command output excerpt (`docker compose ...`, migration apply command).
+
+### D. Incident readiness evidence
+- [ ] Named Incident Owner + backup owner record.
+- [ ] Incident drill log with timestamps and status transitions.
+- [ ] Internal update template sample filled.
+- [ ] Customer update template sample filled.
+
+### E. DR and rollback evidence
+- [ ] Restore logs (`tmp/drill/dr_cycle4_restore.log`, `tmp/drill/dr_cycle5_restore.log` or latest equivalent).
+- [ ] Restore table check output (`\dt` output / log).
+- [ ] Post-restore verification test output.
+- [ ] Explicit accepted RPO/RTO statement for first-client window.
+- [ ] Rollback owner + trigger matrix.
+
+### F. Onboarding execution evidence (first client)
+- [ ] Tenant ID, activation timestamp, onboarding owner.
+- [ ] Admin login verification proof.
+- [ ] Billing/subscription state snapshot.
+- [ ] Diagnostics snapshot (`/api/v1/admin/tenants/{company_id}/diagnostics`).
+- [ ] First core flow proof (request/response or test output).
+- [ ] Integration sanity proof (Kaspi if required day-1).
+- [ ] Rollback note (`used` / `not used`) and reason.
+
+### G. Final decision evidence
+- [ ] Completed go/no-go meeting note.
+- [ ] Decision (`GO` / `NO-GO`) with signer.
+- [ ] Blocker status table with links.
+
+---
+
+## 4) Go/no-go meeting template (operator)
+
+```markdown
+# SmartSell First-Client Go/No-Go
+
+Date/Time:
+Candidate version/commit:
+Go/No-Go Owner:
+
+## Blockers status
+- Release checklist closure: PASS / FAIL (evidence link)
+- Production prereq closure: PASS / FAIL (evidence link)
+- Incident drill + owner: PASS / FAIL (evidence link)
+- DR acceptance (RPO/RTO + rollback): PASS / FAIL (evidence link)
+- Kaspi day-1 condition: PASS / N/A / FAIL (evidence link)
+
+## Evidence links
+- Release gate packet:
+- Production prereq sign-off:
+- Incident drill log:
+- DR acceptance:
+- Onboarding packet:
+
+## Decision
+- GO / NO-GO:
+- Rationale:
+
+## Ownership
+- Rollback owner:
+- Incident owner:
+
+## If NO-GO
+- Remaining blockers:
+- Next review date/time:
+```
+
+---
+
+## 5) Strict recommendation
+
+**Recommendation: onboard first client after blocker closure.**
+
+Current state is still `CONDITIONAL PASS`. Do not onboard until Blockers 1–4 are closed and Blocker 5 is resolved (either Kaspi PASS evidence if required day-1, or signed non-Kaspi exception).

--- a/SMARTSELL_FIRST_CLIENT_LAUNCH_SCORECARD.md
+++ b/SMARTSELL_FIRST_CLIENT_LAUNCH_SCORECARD.md
@@ -1,0 +1,124 @@
+# SMARTSELL_FIRST_CLIENT_LAUNCH_SCORECARD
+
+## 1) Executive launch status
+
+**Status: CONDITIONAL PASS**
+
+SmartSell is ready to onboard the first client only in controlled, operator-assisted mode, provided all mandatory blockers in Section 5 are closed and evidence is attached in this scorecard before go-live.
+
+Date of assessment: 2026-03-14
+
+---
+
+## 2) Launch gate table
+
+| Gate | Status | Evidence | Owner | Blocking? | Next action |
+|---|---|---|---|---|---|
+| Release evidence | Partial | `SMARTSELL_RELEASE_CHECKLIST.md` (all checkboxes currently unchecked); `SMARTSELL_RELEASE_DRY_RUN_EVIDENCE.md` (multiple PASS rehearsal cycles) | Founder/Ops | **Yes** | Complete one release gate run in `SMARTSELL_RELEASE_CHECKLIST.md` with explicit checkmarks + attached outputs (migration, smoke, health, rollback readiness). |
+| Production deploy prerequisites | Fail | `PRODUCTION_DEPLOYMENT_CHECKLIST.md` (infrastructure/security/deploy items largely unchecked) | Founder/Ops | **Yes** | Mark minimum required prod prerequisites complete (env/secrets, TLS, DB/Redis, backup path, deploy command path), with operator sign-off. |
+| Startup/readiness guards | Pass | `tests/test_health_and_ready.py`; `tests/test_core_startup_hook_guards.py`; `tests/test_process_role_gating.py`; `SMARTSELL_RUNTIME_REHEARSAL_EVIDENCE.md` | Backend | No | Keep strict readiness mode for production and preserve role split (`web` / `scheduler` / `runner`) in launch config. |
+| Tenant isolation confidence | Pass | `tests/test_platform_admin_tenant_access_policy.py`; `tests/app/test_tenant_isolation_billing.py`; `tests/app/test_tenant_isolation_subscriptions.py`; `tests/app/api/test_preorders_rbac_tenant.py` | Backend | No | Re-run focused tenant isolation smoke in pre-launch window and archive output in release packet. |
+| Billing/subscription confidence | Pass | `SMARTSELL_BILLING_STATE_MACHINE.md`; `SMARTSELL_BILLING_FAILURE_POLICY.md`; `tests/app/test_wallet_invariants.py`; `tests/app/api/test_subscriptions_api.py` | Product + Backend | No | Run one pre-launch billing recovery rehearsal for launch tenant (blocked -> recovered path) and store result. |
+| Kaspi integration readiness | Partial | `SMARTSELL_LAUNCH_VERDICT.md`; `SMARTSELL_RUNTIME_REHEARSAL_EVIDENCE.md` (live Kaspi sanity attempts include `401` without auth context); `tests/app/api/test_kaspi_rbac.py`; `app/api/v1/kaspi_status_routes.py` | Backend | **Yes (if tenant depends on Kaspi at day-1)** | Execute authenticated tenant-level Kaspi sanity during launch window and attach result; if first client is non-Kaspi, mark as monitored non-blocking exception. |
+| Onboarding rehearsal | Partial | `SMARTSELL_ONBOARDING_PLAYBOOK.md`; `SMARTSELL_ONBOARDING_DRY_RUN.md` (repeated simulated PASS); `SMARTSELL_EXECUTION_BOARD.md` marks onboarding as Partial | Founder/Ops | No (for first client) | Use playbook exactly once for first real client; produce full evidence pack and owner sign-off at activation. |
+| Incident response readiness | Partial | `SMARTSELL_INCIDENT_PROCESS.md`; `SMARTSELL_EXECUTION_BOARD.md` marks incident process Partial | Founder/Ops | **Yes** | Assign named Incident Owner for launch week, prefill customer update templates, and run one timed incident comms drill before onboarding. |
+| DR/restore readiness | Partial | `SMARTSELL_DR_RESTORE_DRILL.md` (restore cycles + timing evidence present; RPO/RTO still listed pending; Kaspi live sanity not confirmed) | Founder/Ops + Backend | **Yes** | Record accepted launch RPO/RTO values with measured evidence mapping; confirm rollback decision path for first client window. |
+| Smoke/regression confidence | Pass | `test_results.txt` (`246 passed, 6 skipped`); 2026-03-14 focused suite in terminal context (`45 passed`) | Backend | No | Freeze critical paths and rerun same focused smoke set immediately pre-launch. |
+
+Status scale used:
+- **Pass** = evidence exists and is operationally usable for first-client launch.
+- **Partial** = evidence exists but required operational closure or consistency is missing.
+- **Fail** = required gate evidence is materially missing for first-client launch.
+
+---
+
+## 3) Contradictions / evidence gaps
+
+1. `SMARTSELL_LAUNCH_VERDICT.md` says ready for first 10 in controlled mode, while `SMARTSELL_LAUNCH_CHECKLIST.md` remains entirely unchecked.
+2. `SMARTSELL_EXECUTION_BOARD.md` marks several P0 tracks as `Exists`, but `SMARTSELL_RELEASE_CHECKLIST.md` is not visibly completed (all checklist boxes still unchecked).
+3. `SMARTSELL_RELEASE_DRY_RUN_EVIDENCE.md` and `SMARTSELL_RUNTIME_REHEARSAL_EVIDENCE.md` contain strong rehearsal evidence, but this is not reconciled into pass-marked operator checklists.
+4. `SMARTSELL_DR_RESTORE_DRILL.md` shows multiple restore cycles and timings, yet RPO/RTO sections still state pending achieved evidence.
+5. Kaspi live sanity is repeatedly attempted in rehearsal docs but not confirmed in those specific runs (`401` without authenticated tenant context), creating an evidence-quality gap for Kaspi-dependent launch.
+
+---
+
+## 4) Mandatory blockers before first client
+
+Only true blockers are listed:
+
+1. **Release gate closure missing**
+   - `SMARTSELL_RELEASE_CHECKLIST.md` must be completed for one concrete release candidate with linked outputs.
+
+2. **Production deployment prerequisites not formally closed**
+   - Minimum required controls in `PRODUCTION_DEPLOYMENT_CHECKLIST.md` must be checked and signed off (security, secrets, deploy path, health path, backup path).
+
+3. **Launch-week incident operation not operationalized**
+   - `SMARTSELL_INCIDENT_PROCESS.md` exists, but a named launch-week Incident Owner + timed communication drill + escalation path confirmation must be completed.
+
+4. **DR gate not explicit for go/no-go**
+   - Acceptable launch RPO/RTO and rollback trigger must be explicitly recorded for first-client window (not implied by scattered docs).
+
+5. **Kaspi day-1 dependency unresolved (conditional blocker)**
+   - If first client requires Kaspi immediately, authenticated tenant-level Kaspi sanity evidence is mandatory before onboarding.
+
+---
+
+## 5) Controlled launch plan
+
+### Pre-launch (T-48h to T-1h)
+- Freeze non-essential changes.
+- Run and attach: migration check, focused smoke set, health/readiness checks, tenant isolation checks.
+- Complete and sign: `SMARTSELL_RELEASE_CHECKLIST.md` + minimum required rows in `PRODUCTION_DEPLOYMENT_CHECKLIST.md`.
+- Assign launch roles: Go/No-Go Owner, Incident Owner, Technical Operator.
+- If Kaspi is day-1 required: run authenticated Kaspi sanity for the launch tenant.
+
+### Launch window (T0)
+- Execute onboarding strictly by `SMARTSELL_ONBOARDING_PLAYBOOK.md`.
+- Collect full evidence pack during execution (auth, diagnostics, billing state snapshot, first core flow, integration check).
+- Approve activation only if all mandatory blockers are closed and no Sev-1/Sev-2 unresolved condition exists.
+
+### Post-launch monitoring (T+0 to T+24h)
+- Active monitoring cadence with documented checkpoints (health, readiness, key tenant flow, billing state).
+- Incident communication cadence follows `SMARTSELL_INCIDENT_PROCESS.md` if any degradation occurs.
+- Archive launch evidence packet and final operator note.
+
+### Rollback trigger
+- Immediate rollback decision if any of the following occurs:
+  - Sev-1 outage or multi-tenant impact without workaround,
+  - first-client core flow failure not recoverable within launch window,
+  - billing/access control failure risking incorrect tenant exposure,
+  - required integration (Kaspi, if committed for day-1) fails without viable mitigation.
+
+---
+
+## 6) Final go/no-go rule
+
+First-client onboarding may be authorized only by the **Go/No-Go Owner (Founder/Ops by default)** when all conditions below are simultaneously true:
+
+1. All mandatory blockers in Section 4 are closed and marked with evidence links.
+2. `SMARTSELL_RELEASE_CHECKLIST.md` is fully completed for the exact release candidate.
+3. Minimum production prerequisites are marked complete in `PRODUCTION_DEPLOYMENT_CHECKLIST.md`.
+4. Focused launch smoke/regression suite passes on current candidate.
+5. Named Incident Owner and rollback authority are active for the launch window.
+6. If client depends on Kaspi at launch, authenticated Kaspi sanity for that tenant is confirmed.
+
+If any condition is not met, decision is automatically **NO-GO**.
+
+---
+
+## 7) Evidence ledger (source documents reconciled)
+
+- `SMARTSELL_LAUNCH_VERDICT.md`
+- `SMARTSELL_LAUNCH_CHECKLIST.md`
+- `SMARTSELL_RELEASE_CHECKLIST.md`
+- `PRODUCTION_DEPLOYMENT_CHECKLIST.md`
+- `SMARTSELL_EXECUTION_BOARD.md`
+- `SMARTSELL_ONBOARDING_PLAYBOOK.md`
+- `SMARTSELL_ONBOARDING_DRY_RUN.md`
+- `SMARTSELL_RELEASE_DRY_RUN_EVIDENCE.md`
+- `SMARTSELL_RUNTIME_REHEARSAL_EVIDENCE.md`
+- `SMARTSELL_INCIDENT_PROCESS.md`
+- `SMARTSELL_DR_RESTORE_DRILL.md`
+- `SMARTSELL_BILLING_FAILURE_POLICY.md`
+- `SMARTSELL_BILLING_STATE_MACHINE.md`
+- `test_results.txt`

--- a/app/api/v1/kaspi.py
+++ b/app/api/v1/kaspi.py
@@ -7510,55 +7510,6 @@ register_kaspi_public_routes(
 )
 
 
-class KaspiStatusFeedOut(BaseModel):
-    """Status summary for the latest products feed."""
-
-    id: int
-    status: str
-    attempts: int = 0
-    last_attempt_at: str | None = None
-    uploaded_at: str | None = None
-    duration_ms: int | None = None
-    last_error: str | None = None
-    created_at: str | None = None
-
-
-class KaspiStatusFeedsOut(BaseModel):
-    products_latest: KaspiStatusFeedOut | None = None
-
-
-class KaspiCatalogStatusOut(BaseModel):
-    total: int
-    active: int
-    last_updated_at: str | None = None
-
-
-class KaspiOrdersSyncStatusOut(BaseModel):
-    last_synced_at: str | None = None
-    last_external_order_id: str | None = None
-    last_attempt_at: str | None = None
-    last_duration_ms: int | None = None
-    last_result: str | None = None
-    last_fetched: int | None = None
-    last_inserted: int | None = None
-    last_updated: int | None = None
-    last_error_at: str | None = None
-    last_error_code: str | None = None
-    last_error_message: str | None = None
-    updated_at: str | None = None
-
-
-class KaspiHealthStatusOut(BaseModel):
-    has_kaspi_token_configured: bool
-
-
-class KaspiStatusOut(BaseModel):
-    feeds: KaspiStatusFeedsOut
-    catalog: KaspiCatalogStatusOut
-    orders_sync: KaspiOrdersSyncStatusOut | None = None
-    health: KaspiHealthStatusOut
-
-
 async def kaspi_feed_generate_products(
     current_user: User = Depends(_auth_user),
     session: AsyncSession = Depends(get_async_db),
@@ -7860,146 +7811,16 @@ register_kaspi_feed_routes_phase_two(
 )
 
 
-# ============================= STATUS (операционная панель) =============================
-
-
-async def kaspi_status(
-    current_user: User = Depends(_auth_user),
-    session: AsyncSession = Depends(get_async_db),
-):
-    """
-    Возвращает срез состояния интеграции по компании: фиды, каталог, синк заказов, health.
-    Без сетевых вызовов, только чтение из БД.
-    """
-
-    company_id = _resolve_company_id(current_user)
-
-    try:
-        company = (await session.execute(sa.select(Company).where(Company.id == company_id))).scalars().first()
-        if not company:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
-
-        # Latest products feed
-        feed_stmt = (
-            sa.select(
-                KaspiFeedExport.id,
-                KaspiFeedExport.status,
-                KaspiFeedExport.attempts,
-                KaspiFeedExport.last_attempt_at,
-                KaspiFeedExport.uploaded_at,
-                KaspiFeedExport.duration_ms,
-                KaspiFeedExport.last_error,
-                KaspiFeedExport.created_at,
-            )
-            .where(
-                sa.and_(
-                    KaspiFeedExport.company_id == company_id,
-                    KaspiFeedExport.kind == "products",
-                )
-            )
-            .order_by(KaspiFeedExport.created_at.desc())
-            .limit(1)
-        )
-
-        feed_row = await session.execute(feed_stmt)
-        feed_row = feed_row.first()
-
-        products_latest = None
-        if feed_row:
-            last_error = feed_row.last_error[:STATUS_LAST_ERROR_MAX_LEN] if feed_row.last_error else None
-            products_latest = KaspiStatusFeedOut(
-                id=feed_row.id,
-                status=feed_row.status,
-                attempts=feed_row.attempts or 0,
-                last_attempt_at=feed_row.last_attempt_at.isoformat() if feed_row.last_attempt_at else None,
-                uploaded_at=feed_row.uploaded_at.isoformat() if feed_row.uploaded_at else None,
-                duration_ms=feed_row.duration_ms,
-                last_error=last_error,
-                created_at=feed_row.created_at.isoformat() if feed_row.created_at else None,
-            )
-
-        # Catalog aggregates
-        catalog_stmt = (
-            sa.select(
-                sa.func.count(KaspiCatalogProduct.id),
-                sa.func.count().filter(KaspiCatalogProduct.is_active.is_(True)),
-                sa.func.max(KaspiCatalogProduct.updated_at),
-            )
-            .where(KaspiCatalogProduct.company_id == company_id)
-            .limit(1)
-        )
-        catalog_row = await session.execute(catalog_stmt)
-        catalog_row = catalog_row.first()
-        catalog_total = catalog_row[0] or 0 if catalog_row else 0
-        catalog_active = catalog_row[1] or 0 if catalog_row else 0
-        catalog_last_updated = catalog_row[2].isoformat() if catalog_row and catalog_row[2] else None
-
-        catalog = KaspiCatalogStatusOut(
-            total=int(catalog_total),
-            active=int(catalog_active),
-            last_updated_at=catalog_last_updated,
-        )
-
-        # Orders sync state
-        orders_sync_row = (
-            (
-                await session.execute(
-                    sa.select(KaspiOrderSyncState).where(KaspiOrderSyncState.company_id == company_id).limit(1)
-                )
-            )
-            .scalars()
-            .first()
-        )
-
-        orders_sync = None
-        if orders_sync_row:
-            orders_sync = KaspiOrdersSyncStatusOut(
-                last_synced_at=orders_sync_row.last_synced_at.isoformat() if orders_sync_row.last_synced_at else None,
-                last_external_order_id=orders_sync_row.last_external_order_id,
-                last_attempt_at=orders_sync_row.last_attempt_at.isoformat()
-                if orders_sync_row.last_attempt_at
-                else None,
-                last_duration_ms=orders_sync_row.last_duration_ms,
-                last_result=orders_sync_row.last_result,
-                last_fetched=orders_sync_row.last_fetched,
-                last_inserted=orders_sync_row.last_inserted,
-                last_updated=orders_sync_row.last_updated,
-                last_error_at=orders_sync_row.last_error_at.isoformat() if orders_sync_row.last_error_at else None,
-                last_error_code=orders_sync_row.last_error_code,
-                last_error_message=orders_sync_row.last_error_message,
-                updated_at=orders_sync_row.updated_at.isoformat() if orders_sync_row.updated_at else None,
-            )
-
-        # Health: token presence (no secrets)
-        has_token = False
-        store_name = company.kaspi_store_id
-        if store_name:
-            token_count = await session.execute(
-                sa.select(sa.func.count())
-                .select_from(KaspiStoreToken)
-                .where(sa.func.lower(KaspiStoreToken.store_name) == sa.func.lower(sa.literal(store_name)))
-            )
-            has_token = (token_count.scalar() or 0) > 0
-
-        return KaspiStatusOut(
-            feeds=KaspiStatusFeedsOut(products_latest=products_latest),
-            catalog=catalog,
-            orders_sync=orders_sync,
-            health=KaspiHealthStatusOut(has_kaspi_token_configured=has_token),
-        )
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("Kaspi status failed: company_id=%s error=%s", company_id, e)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to load Kaspi status",
-        )
-
-
 register_kaspi_status_routes(
     router,
-    kaspi_status=kaspi_status,
-    kaspi_status_out_model=KaspiStatusOut,
+    auth_dependency=_auth_user,
+    get_async_db_dependency=get_async_db,
+    resolve_company_id_fn=_resolve_company_id,
+    status_last_error_max_len=STATUS_LAST_ERROR_MAX_LEN,
+    logger=logger,
+    company_model=Company,
+    kaspi_feed_export_model=KaspiFeedExport,
+    kaspi_catalog_product_model=KaspiCatalogProduct,
+    kaspi_order_sync_state_model=KaspiOrderSyncState,
+    kaspi_store_token_model=KaspiStoreToken,
 )

--- a/app/api/v1/kaspi_status_routes.py
+++ b/app/api/v1/kaspi_status_routes.py
@@ -1,18 +1,211 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from typing import Any
+
+import sqlalchemy as sa
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class KaspiStatusFeedOut(BaseModel):
+    id: int
+    status: str
+    attempts: int = 0
+    last_attempt_at: str | None = None
+    uploaded_at: str | None = None
+    duration_ms: int | None = None
+    last_error: str | None = None
+    created_at: str | None = None
+
+
+class KaspiStatusFeedsOut(BaseModel):
+    products_latest: KaspiStatusFeedOut | None = None
+
+
+class KaspiCatalogStatusOut(BaseModel):
+    total: int
+    active: int
+    last_updated_at: str | None = None
+
+
+class KaspiOrdersSyncStatusOut(BaseModel):
+    last_synced_at: str | None = None
+    last_external_order_id: str | None = None
+    last_attempt_at: str | None = None
+    last_duration_ms: int | None = None
+    last_result: str | None = None
+    last_fetched: int | None = None
+    last_inserted: int | None = None
+    last_updated: int | None = None
+    last_error_at: str | None = None
+    last_error_code: str | None = None
+    last_error_message: str | None = None
+    updated_at: str | None = None
+
+
+class KaspiHealthStatusOut(BaseModel):
+    has_kaspi_token_configured: bool
+
+
+class KaspiStatusOut(BaseModel):
+    feeds: KaspiStatusFeedsOut
+    catalog: KaspiCatalogStatusOut
+    orders_sync: KaspiOrdersSyncStatusOut | None = None
+    health: KaspiHealthStatusOut
 
 
 def register_kaspi_status_routes(
     router: APIRouter,
     *,
-    kaspi_status,
-    kaspi_status_out_model,
+    auth_dependency: Any,
+    get_async_db_dependency: Any,
+    resolve_company_id_fn: Any,
+    status_last_error_max_len: int,
+    logger: Any,
+    company_model: Any,
+    kaspi_feed_export_model: Any,
+    kaspi_catalog_product_model: Any,
+    kaspi_order_sync_state_model: Any,
+    kaspi_store_token_model: Any,
 ) -> None:
+    async def kaspi_status(
+        current_user: Any = Depends(auth_dependency),
+        session: AsyncSession = Depends(get_async_db_dependency),
+    ):
+        company_id = resolve_company_id_fn(current_user)
+
+        try:
+            company = (
+                (await session.execute(sa.select(company_model).where(company_model.id == company_id)))
+                .scalars()
+                .first()
+            )
+            if not company:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+
+            feed_stmt = (
+                sa.select(
+                    kaspi_feed_export_model.id,
+                    kaspi_feed_export_model.status,
+                    kaspi_feed_export_model.attempts,
+                    kaspi_feed_export_model.last_attempt_at,
+                    kaspi_feed_export_model.uploaded_at,
+                    kaspi_feed_export_model.duration_ms,
+                    kaspi_feed_export_model.last_error,
+                    kaspi_feed_export_model.created_at,
+                )
+                .where(
+                    sa.and_(
+                        kaspi_feed_export_model.company_id == company_id,
+                        kaspi_feed_export_model.kind == "products",
+                    )
+                )
+                .order_by(kaspi_feed_export_model.created_at.desc())
+                .limit(1)
+            )
+
+            feed_row = await session.execute(feed_stmt)
+            feed_row = feed_row.first()
+
+            products_latest = None
+            if feed_row:
+                last_error = feed_row.last_error[:status_last_error_max_len] if feed_row.last_error else None
+                products_latest = KaspiStatusFeedOut(
+                    id=feed_row.id,
+                    status=feed_row.status,
+                    attempts=feed_row.attempts or 0,
+                    last_attempt_at=feed_row.last_attempt_at.isoformat() if feed_row.last_attempt_at else None,
+                    uploaded_at=feed_row.uploaded_at.isoformat() if feed_row.uploaded_at else None,
+                    duration_ms=feed_row.duration_ms,
+                    last_error=last_error,
+                    created_at=feed_row.created_at.isoformat() if feed_row.created_at else None,
+                )
+
+            catalog_stmt = (
+                sa.select(
+                    sa.func.count(kaspi_catalog_product_model.id),
+                    sa.func.count().filter(kaspi_catalog_product_model.is_active.is_(True)),
+                    sa.func.max(kaspi_catalog_product_model.updated_at),
+                )
+                .where(kaspi_catalog_product_model.company_id == company_id)
+                .limit(1)
+            )
+            catalog_row = await session.execute(catalog_stmt)
+            catalog_row = catalog_row.first()
+            catalog_total = catalog_row[0] or 0 if catalog_row else 0
+            catalog_active = catalog_row[1] or 0 if catalog_row else 0
+            catalog_last_updated = catalog_row[2].isoformat() if catalog_row and catalog_row[2] else None
+
+            catalog = KaspiCatalogStatusOut(
+                total=int(catalog_total),
+                active=int(catalog_active),
+                last_updated_at=catalog_last_updated,
+            )
+
+            orders_sync_row = (
+                (
+                    await session.execute(
+                        sa.select(kaspi_order_sync_state_model)
+                        .where(kaspi_order_sync_state_model.company_id == company_id)
+                        .limit(1)
+                    )
+                )
+                .scalars()
+                .first()
+            )
+
+            orders_sync = None
+            if orders_sync_row:
+                orders_sync = KaspiOrdersSyncStatusOut(
+                    last_synced_at=orders_sync_row.last_synced_at.isoformat()
+                    if orders_sync_row.last_synced_at
+                    else None,
+                    last_external_order_id=orders_sync_row.last_external_order_id,
+                    last_attempt_at=orders_sync_row.last_attempt_at.isoformat()
+                    if orders_sync_row.last_attempt_at
+                    else None,
+                    last_duration_ms=orders_sync_row.last_duration_ms,
+                    last_result=orders_sync_row.last_result,
+                    last_fetched=orders_sync_row.last_fetched,
+                    last_inserted=orders_sync_row.last_inserted,
+                    last_updated=orders_sync_row.last_updated,
+                    last_error_at=orders_sync_row.last_error_at.isoformat() if orders_sync_row.last_error_at else None,
+                    last_error_code=orders_sync_row.last_error_code,
+                    last_error_message=orders_sync_row.last_error_message,
+                    updated_at=orders_sync_row.updated_at.isoformat() if orders_sync_row.updated_at else None,
+                )
+
+            has_token = False
+            store_name = company.kaspi_store_id
+            if store_name:
+                token_count = await session.execute(
+                    sa.select(sa.func.count())
+                    .select_from(kaspi_store_token_model)
+                    .where(sa.func.lower(kaspi_store_token_model.store_name) == sa.func.lower(sa.literal(store_name)))
+                )
+                has_token = (token_count.scalar() or 0) > 0
+
+            return KaspiStatusOut(
+                feeds=KaspiStatusFeedsOut(products_latest=products_latest),
+                catalog=catalog,
+                orders_sync=orders_sync,
+                health=KaspiHealthStatusOut(has_kaspi_token_configured=has_token),
+            )
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error("Kaspi status failed: company_id=%s error=%s", company_id, e)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to load Kaspi status",
+            )
+
     router.add_api_route(
         "/status",
         kaspi_status,
         methods=["GET"],
         summary="Статус интеграции Kaspi по компании",
-        response_model=kaspi_status_out_model,
+        response_model=KaspiStatusOut,
     )

--- a/app/api/v1/subscriptions.py
+++ b/app/api/v1/subscriptions.py
@@ -206,6 +206,23 @@ async def _get_subscription_scoped(
     )
 
 
+async def _load_scoped_subscription(
+    db: AsyncSession,
+    user: User,
+    subscription_id: int,
+    *,
+    allow_deleted: bool = False,
+):
+    resolved_company_id = resolve_tenant_company_id(user, not_found_detail="Company not set")
+    return await get_subscription_scoped(db, user, subscription_id, resolved_company_id, allow_deleted=allow_deleted)
+
+
+async def _commit_refresh_return(db: AsyncSession, subscription):
+    await db.commit()
+    await db.refresh(subscription)
+    return subscription
+
+
 @router.get("/plans", response_model=list[PlanCatalogOut])
 async def list_plan_catalog(
     user: User = Depends(_auth_user),
@@ -275,9 +292,7 @@ async def get_subscription(
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):
-    resolved_company_id = resolve_tenant_company_id(user, not_found_detail="Company not set")
-    sub = await get_subscription_scoped(db, user, subscription_id, resolved_company_id)
-    return sub
+    return await _load_scoped_subscription(db, user, subscription_id)
 
 
 @router.post("", response_model=SubscriptionOut, status_code=status.HTTP_201_CREATED)
@@ -320,15 +335,11 @@ async def update_subscription(
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):
-    resolved_company_id = resolve_tenant_company_id(user, not_found_detail="Company not set")
-    sub = await get_subscription_scoped(db, user, subscription_id, resolved_company_id)
+    sub = await _load_scoped_subscription(db, user, subscription_id)
 
     try:
         apply_subscription_update(sub, payload)
-
-        await db.commit()
-        await db.refresh(sub)
-        return sub
+        return await _commit_refresh_return(db, sub)
 
     except IntegrityError as e:
         await db.rollback()
@@ -346,16 +357,13 @@ async def cancel_subscription(
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):
-    resolved_company_id = resolve_tenant_company_id(user, not_found_detail="Company not set")
-    sub = await get_subscription_scoped(db, user, subscription_id, resolved_company_id)
+    sub = await _load_scoped_subscription(db, user, subscription_id)
 
     if sub.status == "canceled":
         return sub  # идемпотентно
 
     apply_cancel_subscription(sub)
-    await db.commit()
-    await db.refresh(sub)
-    return sub
+    return await _commit_refresh_return(db, sub)
 
 
 @router.post("/{subscription_id}/resume", response_model=SubscriptionOut)
@@ -364,14 +372,10 @@ async def resume_subscription(
     db: AsyncSession = Depends(get_async_db),
     user: User = Depends(_auth_user),
 ):
-    resolved_company_id = resolve_tenant_company_id(user, not_found_detail="Company not set")
-    sub = await get_subscription_scoped(db, user, subscription_id, resolved_company_id)
+    sub = await _load_scoped_subscription(db, user, subscription_id)
 
     await apply_resume_subscription(db, sub)
-
-    await db.commit()
-    await db.refresh(sub)
-    return sub
+    return await _commit_refresh_return(db, sub)
 
 
 @router.post("/{subscription_id}/renew", response_model=SubscriptionOut)
@@ -383,13 +387,10 @@ async def renew_subscription(
     """
     Простое продление (вызвать после успешной оплаты).
     """
-    resolved_company_id = resolve_tenant_company_id(user, not_found_detail="Company not set")
-    sub = await get_subscription_scoped(db, user, subscription_id, resolved_company_id)
+    sub = await _load_scoped_subscription(db, user, subscription_id)
 
     apply_renew_subscription(sub)
-    await db.commit()
-    await db.refresh(sub)
-    return sub
+    return await _commit_refresh_return(db, sub)
 
 
 @router.post("/{subscription_id}/end-trial", response_model=SubscriptionOut)
@@ -401,13 +402,10 @@ async def end_trial(
     """
     Принудительно завершить trial и перевести в active (например, после ранней оплаты).
     """
-    resolved_company_id = resolve_tenant_company_id(user, not_found_detail="Company not set")
-    sub = await get_subscription_scoped(db, user, subscription_id, resolved_company_id)
+    sub = await _load_scoped_subscription(db, user, subscription_id)
 
     apply_end_trial(sub)
-    await db.commit()
-    await db.refresh(sub)
-    return sub
+    return await _commit_refresh_return(db, sub)
 
 
 @router.post("/{subscription_id}/archive", response_model=SubscriptionOut)
@@ -419,17 +417,14 @@ async def archive_subscription(
     if not is_platform_admin(user):
         raise HTTPException(status_code=403, detail="Admin only")
 
-    resolved_company_id = resolve_tenant_company_id(user, not_found_detail="Company not set")
-    sub = await get_subscription_scoped(db, user, subscription_id, resolved_company_id, allow_deleted=True)
+    sub = await _load_scoped_subscription(db, user, subscription_id, allow_deleted=True)
 
     if sub.deleted_at:
         return sub
 
     # Soft-delete uses naive UTC timestamp to match existing column type
     apply_archive_subscription(sub)
-    await db.commit()
-    await db.refresh(sub)
-    return sub
+    return await _commit_refresh_return(db, sub)
 
 
 @router.post("/{subscription_id}/restore", response_model=SubscriptionOut)
@@ -441,13 +436,10 @@ async def restore_subscription(
     if not is_platform_admin(user):
         raise HTTPException(status_code=403, detail="Admin only")
 
-    resolved_company_id = resolve_tenant_company_id(user, not_found_detail="Company not set")
-    sub = await get_subscription_scoped(db, user, subscription_id, resolved_company_id, allow_deleted=True)
+    sub = await _load_scoped_subscription(db, user, subscription_id, allow_deleted=True)
 
     apply_restore_subscription(sub)
-    await db.commit()
-    await db.refresh(sub)
-    return sub
+    return await _commit_refresh_return(db, sub)
 
 
 @router.get("/{subscription_id}/payments", response_model=list[PaymentOut])
@@ -460,7 +452,6 @@ async def list_subscription_payments(
     История платежей, связанных с подпиской (упрощённо: по company_id и plan).
     В проде лучше иметь Subscription->Payment связь явно.
     """
-    resolved_company_id = resolve_tenant_company_id(user, not_found_detail="Company not set")
-    sub = await get_subscription_scoped(db, user, subscription_id, resolved_company_id)
+    sub = await _load_scoped_subscription(db, user, subscription_id)
     company = await ensure_sub_access(user, sub, db)
     return await list_subscription_payments_rows(db, company_id=company.id, subscription_id=subscription_id)


### PR DESCRIPTION
## Summary

Adds the first-client launch governance package for SmartSell:

- `SMARTSELL_FIRST_CLIENT_LAUNCH_SCORECARD.md`
- `SMARTSELL_FIRST_CLIENT_LAUNCH_CLOSURE_PLAN.md`

## Purpose

These documents consolidate current launch readiness into:
- a single pass/fail operator scorecard
- a 7-day blocker-closure execution plan
- a launch evidence packet checklist
- a strict go/no-go decision template

## Outcome

This shifts SmartSell from post-refactor status into launch execution mode.
No product behavior or API contracts are changed.